### PR TITLE
fix(front): minor changes

### DIFF
--- a/apps/front/src/components/common/Description.tsx
+++ b/apps/front/src/components/common/Description.tsx
@@ -1,10 +1,15 @@
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined'
-import { alpha, Box, Stack, styled } from '@mui/material'
+import { alpha, Box, Collapse, Stack, styled } from '@mui/material'
+import { useLayoutEffect, useRef, useState } from 'react'
 
 import { BreaklineText } from './BreaklineText'
+import { Card } from './Card'
 
-const DescriptionContainer = styled(Stack)(({ theme }) => ({
+const DescriptionCard = styled(Card)<{ collapsable: boolean }>(({ theme, collapsable }) => ({
+  position: 'relative',
   padding: '12px',
+  paddingBottom: collapsable ? '25px' : undefined,
   borderRadius: '12px',
   color: theme.palette.text.primary,
   backgroundColor: alpha(theme.palette.primary.main, 0.04),
@@ -14,28 +19,115 @@ const DescriptionContainer = styled(Stack)(({ theme }) => ({
   fontWeight: 400,
   textAlign: 'left',
   borderLeft: `8px solid ${theme.palette.primary.main}`,
-  gap: '16px', // Utilise gap au lieu de spacing pour éviter les marges automatiques
+  cursor: collapsable ? 'pointer' : 'default',
+  transition: 'background-color 0.2s ease-in-out',
 }))
 
-const IconWrapper = styled('div')(({ theme }) => ({
+const DescriptionContainer = styled(Stack)(() => ({
+  flexDirection: 'row',
+  alignItems: 'flex-start',
+  gap: '16px',
+}))
+
+const IconWrapper = styled(Box)(({ theme }) => ({
   color: theme.palette.primary.main,
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
   width: '24px',
   height: '24px',
+  paddingTop: '6px',
   flexShrink: 0,
 }))
 
+const ContentWrapper = styled(Box)({
+  flex: 1,
+  overflow: 'hidden',
+  position: 'relative',
+})
+
+const EllipsisOverlay = styled(Box)(() => ({
+  position: 'absolute',
+  bottom: 0,
+  left: 0,
+  right: 0,
+  height: '25px',
+  pointerEvents: 'none',
+  display: 'flex',
+  alignItems: 'flex-end',
+  justifyContent: 'center',
+  paddingBottom: '4px',
+}))
+
+const MAX_HEIGHT = 110 // Maximum height in pixels before showing collapse button
+
 export const Description = ({ text }: { text: string }) => {
+  const [isCollapsable, setIsCollapsable] = useState<boolean | null>(null)
+  const [isExpanded, setIsExpanded] = useState(false)
+  const contentRef = useRef<HTMLDivElement>(null)
+  const isInitialized = useRef(false)
+
+  useLayoutEffect(() => {
+    if (contentRef.current && !isInitialized.current) {
+      const contentHeight = contentRef.current.scrollHeight
+      setIsCollapsable(contentHeight > MAX_HEIGHT)
+      isInitialized.current = true
+    }
+  }, [])
+
+  const toggleExpanded = () => {
+    if (isCollapsable) {
+      setIsExpanded(prev => !prev)
+    }
+  }
+
+  // Don't render until we know if it's collapsable or not
+  if (isCollapsable === null) {
+    return (
+      <DescriptionCard collapsable={false} onClick={undefined}>
+        <DescriptionContainer>
+          <IconWrapper>
+            <InfoOutlinedIcon fontSize="small" />
+          </IconWrapper>
+          <ContentWrapper>
+            <Box ref={contentRef} sx={{ opacity: 0 }}>
+              <BreaklineText text={text} />
+            </Box>
+          </ContentWrapper>
+        </DescriptionContainer>
+      </DescriptionCard>
+    )
+  }
+
   return (
-    <DescriptionContainer direction="row" alignItems="center">
-      <IconWrapper>
-        <InfoOutlinedIcon fontSize="small" />
-      </IconWrapper>
-      <Box sx={{ flex: 1 }}>
-        <BreaklineText text={text} />
-      </Box>
-    </DescriptionContainer>
+    <DescriptionCard collapsable={isCollapsable} onClick={toggleExpanded}>
+      <DescriptionContainer>
+        <IconWrapper>
+          <InfoOutlinedIcon fontSize="small" />
+        </IconWrapper>
+        <ContentWrapper>
+          <Collapse
+            in={isExpanded || !isCollapsable}
+            collapsedSize={isCollapsable ? MAX_HEIGHT : undefined}
+            timeout={300}
+          >
+            <Box ref={contentRef}>
+              <BreaklineText text={text} />
+            </Box>
+          </Collapse>
+        </ContentWrapper>
+      </DescriptionContainer>
+      {isCollapsable && (
+        <EllipsisOverlay>
+          <ExpandMoreIcon
+            fontSize="small"
+            sx={{
+              transform: isExpanded ? 'rotate(180deg)' : 'rotate(0deg)',
+              transition: 'transform 0.2s ease-in-out',
+            }}
+          />
+        </EllipsisOverlay>
+      )}
+    </DescriptionCard>
   )
 }

--- a/apps/front/src/components/event/EventHeader.tsx
+++ b/apps/front/src/components/event/EventHeader.tsx
@@ -18,10 +18,11 @@ import {
   styled,
   Tooltip,
   Typography,
+  useMediaQuery,
 } from '@mui/material'
 import { useNavigate } from '@tanstack/react-router'
 import { DateTime } from 'luxon'
-import { useState } from 'react'
+import { useCallback, useState } from 'react'
 
 import { TabValues } from '../../routes/_authenticated/_with-layout/events/$eventId/edit'
 import { EventIcon } from './EventIcon'
@@ -102,12 +103,12 @@ const RightSection = styled(Box)(({ theme }) => ({
   alignItems: 'center',
 }))
 
-const MainActionButton = styled(Button)(({ theme }) => ({
+const UpdateButton = styled(Button)(({ theme }) => ({
   textTransform: 'none',
+  height: '40px',
   fontWeight: 500,
   fontSize: '0.875rem',
   padding: theme.spacing(1, 2),
-  height: '40px',
   border: `1px solid ${theme.palette.divider}`,
 }))
 
@@ -118,6 +119,33 @@ const CompactIconButton = styled(IconButton)(({ theme }) => ({
   height: '40px',
   width: '40px',
 }))
+
+const ReponsiveUpdateButton = (props: { eventId: EventId }) => {
+  const { eventId } = props
+  const isDownMd = useMediaQuery(theme => theme.breakpoints.down('md'))
+  const isUpSm = useMediaQuery(theme => theme.breakpoints.up('sm'))
+  const navigate = useNavigate()
+
+  const handleNavigateToEdit = useCallback(() => {
+    void navigate({ to: '/events/$eventId/edit', params: { eventId } })
+  }, [navigate, eventId])
+
+  if (isDownMd && isUpSm) {
+    return (
+      <Tooltip title="Modifier les informations de l'événement">
+        <CompactIconButton size="small" onClick={handleNavigateToEdit}>
+          <EditIcon fontSize="small" />
+        </CompactIconButton>
+      </Tooltip>
+    )
+  }
+
+  return (
+    <UpdateButton variant="outlined" color="primary" startIcon={<EditIcon />} onClick={handleNavigateToEdit}>
+      Modifier
+    </UpdateButton>
+  )
+}
 
 export type EventHeaderProps = {
   icon?: string
@@ -192,16 +220,7 @@ export const EventHeader = ({
         {/* Right section - Action Button with Dropdown */}
         {currentUserCanEdit && (
           <RightSection>
-            <Tooltip title="Modifier les informations de l'événement">
-              <MainActionButton
-                variant="outlined"
-                color="primary"
-                startIcon={<EditIcon />}
-                onClick={() => navigate({ to: '/events/$eventId/edit', params: { eventId } })}
-              >
-                Modifier
-              </MainActionButton>
-            </Tooltip>
+            <ReponsiveUpdateButton eventId={eventId} />
 
             <Tooltip title="Plus d'options">
               <CompactIconButton size="small" onClick={handleOpenMenu}>

--- a/apps/front/src/components/item/ImportItemsDialog.tsx
+++ b/apps/front/src/components/item/ImportItemsDialog.tsx
@@ -29,6 +29,8 @@ import { forwardRef, useState } from 'react'
 
 import { Card } from '../common/Card'
 import { Rating, RatingBubble } from '../common/Rating'
+import { Subtitle } from '../common/Subtitle'
+import { ImportItemsButton } from '../wishlist/ImportItemsButton'
 
 const Transition = forwardRef(function Transition(
   props: TransitionProps & { children: React.ReactElement },
@@ -52,10 +54,12 @@ const ItemCard = styled(Card)(({ theme }) => ({
   '&:hover': {
     transform: 'none !important',
     boxShadow: 'none !important',
-    border: `1px solid ${theme.palette.primary.light}`,
+    border: '1px solid #764ba2',
+    background: `linear-gradient(135deg, ${alpha('#667eea', 0.03)} 0%, ${alpha('#764ba2', 0.06)} 100%)`,
   },
   '&.selected': {
-    border: `2px solid ${theme.palette.primary.main}`,
+    border: '2px solid #764ba2',
+    background: `linear-gradient(135deg, ${alpha('#667eea', 0.05)} 0%, ${alpha('#764ba2', 0.08)} 100%)`,
   },
 }))
 
@@ -229,28 +233,26 @@ export const ImportItemsDialog = ({
       maxWidth="md"
       fullWidth
     >
-      <AppBar sx={{ position: 'sticky' }}>
-        <Toolbar>
+      <AppBar sx={{ position: 'sticky', background: 'linear-gradient(135deg, #667eea 0%, #764ba2 50%)' }}>
+        <Toolbar sx={{ justifyContent: 'space-between' }}>
+          <Typography sx={{ ml: 2, flex: 1, textTransform: 'uppercase' }} variant="h6" component="div">
+            Importer des souhaits
+          </Typography>
           <IconButton edge="start" color="inherit" onClick={handleSkip} aria-label="close">
             <CloseIcon />
           </IconButton>
-          <Typography sx={{ ml: 2, flex: 1 }} variant="h6" component="div">
-            Importer d'anciens souhaits
-          </Typography>
         </Toolbar>
       </AppBar>
 
       <Stack padding={3} gap={2} direction="column" sx={{ backgroundColor: 'rgb(249, 250, 251)' }}>
+        <Subtitle sx={{ marginBottom: 0 }}>Importer d'anciens souhaits</Subtitle>
+
         <Alert severity="info" icon={<InfoOutlinedIcon />}>
           Vous avez <strong>{importableItems.length}</strong> souhait{importableItems.length > 1 ? 's' : ''} non pris
           dans vos anciennes listes. Sélectionnez ceux que vous souhaitez importer dans votre nouvelle liste.
         </Alert>
 
         <Stack direction="row" justifyContent="space-between" alignItems="center" flexWrap="wrap" gap={1}>
-          <Typography variant="body2" color="text.secondary">
-            {selectedItemIds.size} souhait{selectedItemIds.size > 1 ? 's' : ''} sélectionné
-            {selectedItemIds.size > 1 ? 's' : ''}
-          </Typography>
           <Stack direction="row" gap={1}>
             <Button
               size="small"
@@ -326,18 +328,18 @@ export const ImportItemsDialog = ({
         <Button variant="outlined" color="secondary" onClick={handleSkip}>
           Ignorer
         </Button>
-        <Button
+        <ImportItemsButton
           variant="contained"
           onClick={handleImport}
-          disabled={isLoading}
+          disabled={isLoading || selectedItemIds.size === 0}
           loading={isLoading}
           loadingPosition="start"
           startIcon={<AddIcon />}
         >
           {selectedItemIds.size > 0
             ? `Importer ${selectedItemIds.size} souhait${selectedItemIds.size > 1 ? 's' : ''}`
-            : 'Continuer'}
-        </Button>
+            : 'Importer'}
+        </ImportItemsButton>
       </BottomActionStack>
     </Dialog>
   )

--- a/apps/front/src/components/item/ItemFormDialog.tsx
+++ b/apps/front/src/components/item/ItemFormDialog.tsx
@@ -188,7 +188,7 @@ export const ItemFormDialog = ({ title, open, item, mode, handleClose, wishlistI
       onClose={handleClose}
       slots={{ transition: Transition }}
     >
-      <AppBar sx={{ position: 'relative' }}>
+      <AppBar sx={{ position: 'sticky' }}>
         <Toolbar sx={{ justifyContent: 'space-between' }}>
           <Typography sx={{ ml: 2, flex: 1, textTransform: 'uppercase' }} variant="h6" component="div">
             {title}
@@ -198,6 +198,7 @@ export const ItemFormDialog = ({ title, open, item, mode, handleClose, wishlistI
           </IconButton>
         </Toolbar>
       </AppBar>
+
       <Container
         maxWidth="sm"
         sx={isFullscreen ? { marginBlock: '40px' } : { marginTop: '20px', marginBottom: '40px' }}

--- a/apps/front/src/components/secret-santa/AddSecretSantaUsersFormDialog.tsx
+++ b/apps/front/src/components/secret-santa/AddSecretSantaUsersFormDialog.tsx
@@ -141,7 +141,7 @@ export const AddSecretSantaUsersFormDialog = ({
       disableEscapeKeyDown={loading}
       slots={{ transition: Transition }}
     >
-      <AppBar sx={{ position: 'relative' }}>
+      <AppBar sx={{ position: 'sticky' }}>
         <Toolbar sx={{ justifyContent: 'space-between' }}>
           <Typography sx={{ ml: 2, flex: 1, textTransform: 'uppercase' }} variant="h6" component="div">
             Ajouter des participants

--- a/apps/front/src/components/secret-santa/EditSecretSantaFormDialog.tsx
+++ b/apps/front/src/components/secret-santa/EditSecretSantaFormDialog.tsx
@@ -111,7 +111,7 @@ export const EditSecretSantaFormDialog = ({
       onClose={onClose}
       slots={{ transition: Transition }}
     >
-      <AppBar sx={{ position: 'relative' }}>
+      <AppBar sx={{ position: 'sticky' }}>
         <Toolbar sx={{ justifyContent: 'space-between' }}>
           <Typography sx={{ ml: 2, flex: 1, textTransform: 'uppercase' }} variant="h6" component="div">
             {title}

--- a/apps/front/src/components/wishlist/EmptyItemsState.tsx
+++ b/apps/front/src/components/wishlist/EmptyItemsState.tsx
@@ -1,10 +1,10 @@
 import type { SxProps, Theme } from '@mui/material'
 
 import AddIcon from '@mui/icons-material/Add'
-import AutoFixHighIcon from '@mui/icons-material/AutoFixHigh'
 import { Box, Button, Stack, styled, Typography } from '@mui/material'
 
 import EmptyItemsIllustration from '../../assets/illustrations/empty-items.png'
+import { ImportItemsButton } from './ImportItemsButton'
 
 const EmptyStateContainer = styled(Stack)(({ theme }) => ({
   alignItems: 'center',
@@ -64,23 +64,6 @@ const AddItemButton = styled(Button)(({ theme }) => ({
   transition: 'all 0.3s ease',
 }))
 
-const ImportButton = styled(Button)(({ theme }) => ({
-  marginTop: theme.spacing(1),
-  borderRadius: '24px',
-  textTransform: 'none',
-  fontSize: '1rem',
-  fontWeight: 600,
-  background: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
-  color: 'white',
-  boxShadow: '0 4px 15px rgba(102, 126, 234, 0.4)',
-  border: 'none',
-  '&:hover': {
-    boxShadow: '0 6px 20px rgba(102, 126, 234, 0.6)',
-    transform: 'translateY(-2px)',
-  },
-  transition: 'all 0.3s ease',
-}))
-
 export type EmptyItemsStateProps = {
   onAddItem: () => void
   isOwner: boolean
@@ -113,9 +96,9 @@ export const EmptyItemsState = ({
 
       <ButtonsContainer>
         {isOwner && hasImportableItems && (
-          <ImportButton variant="contained" onClick={onImportItems} startIcon={<AutoFixHighIcon />}>
+          <ImportItemsButton onClick={onImportItems} rounded sx={{ fontSize: '1rem' }}>
             Importer d'anciens souhaits
-          </ImportButton>
+          </ImportItemsButton>
         )}
 
         <AddItemButton variant="contained" color="primary" onClick={onAddItem} startIcon={<AddIcon />}>

--- a/apps/front/src/components/wishlist/ImportItemsButton.tsx
+++ b/apps/front/src/components/wishlist/ImportItemsButton.tsx
@@ -1,0 +1,47 @@
+import type { PropsWithChildren } from 'react'
+
+import AutoFixHighIcon from '@mui/icons-material/AutoFixHigh'
+import { Button, type ButtonProps, styled } from '@mui/material'
+import clsx from 'clsx'
+
+const ButtonStyled = styled(Button)({
+  background: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
+  color: 'white',
+  border: 'none',
+  transition: 'all 0.3s ease',
+  '&:hover': {
+    boxShadow: '0 4px 15px rgba(102, 126, 234, 0.4)',
+  },
+  '&:disabled': {
+    color: 'white',
+    opacity: 0.5,
+  },
+  '&.rounded': {
+    borderRadius: '24px',
+  },
+})
+
+export type ImportButtonProps = PropsWithChildren<
+  ButtonProps & {
+    rounded?: boolean
+  }
+>
+
+export const ImportItemsButton = ({
+  children,
+  size = 'small',
+  rounded = false,
+  className,
+  ...props
+}: ImportButtonProps) => {
+  return (
+    <ButtonStyled
+      startIcon={<AutoFixHighIcon />}
+      size={size}
+      className={clsx(className, rounded && 'rounded')}
+      {...props}
+    >
+      {children}
+    </ButtonStyled>
+  )
+}

--- a/apps/front/src/components/wishlist/WishlistHeader.tsx
+++ b/apps/front/src/components/wishlist/WishlistHeader.tsx
@@ -1,7 +1,6 @@
 import type { DetailedWishlistDto } from '@wishlist/common'
 import type { FilterType, SortType } from './WishlistFilterAndSortItems'
 
-import AutoFixHighIcon from '@mui/icons-material/AutoFixHigh'
 import CalendarMonthIcon from '@mui/icons-material/CalendarMonth'
 import EditIcon from '@mui/icons-material/Edit'
 import FilterListIcon from '@mui/icons-material/FilterList'
@@ -21,9 +20,11 @@ import {
   Tooltip,
   Typography,
 } from '@mui/material'
-import { useState } from 'react'
+import { useNavigate } from '@tanstack/react-router'
+import { useCallback, useState } from 'react'
 
 import { getAvatarUrl } from '../../utils/wishlist.utils'
+import { ImportItemsButton } from './ImportItemsButton'
 import { WishlistAvatar } from './WishlistAvatar'
 import { filterOptions, sortOptions } from './WishlistFilterAndSortItems'
 
@@ -35,7 +36,7 @@ const HeaderContent = styled(Box)(({ theme }) => ({
   alignItems: 'center',
   gap: theme.spacing(3),
 
-  [theme.breakpoints.down('sm')]: {
+  [theme.breakpoints.down('md')]: {
     flexDirection: 'column',
     gap: theme.spacing(2),
   },
@@ -111,7 +112,7 @@ const RightSection = styled(Box)(({ theme }) => ({
   },
 }))
 
-const MainActionButton = styled(Button)(({ theme }) => ({
+const UpdateButton = styled(Button)(({ theme }) => ({
   textTransform: 'none',
   fontWeight: 500,
   fontSize: '0.875rem',
@@ -127,22 +128,6 @@ const CompactIconButton = styled(IconButton)(({ theme }) => ({
   width: '40px',
 }))
 
-const ImportButton = styled(Button)(({ theme }) => ({
-  textTransform: 'none',
-  fontWeight: 600,
-  fontSize: '0.875rem',
-  padding: theme.spacing(1, 2),
-  borderRadius: theme.shape.borderRadius,
-  background: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
-  color: 'white',
-  border: 'none',
-  height: '40px',
-  '&:hover': {
-    boxShadow: '0 4px 15px rgba(102, 126, 234, 0.4)',
-  },
-  transition: 'all 0.3s ease',
-}))
-
 export type WishlistHeaderProps = {
   wishlist: DetailedWishlistDto
   currentUserCanEdit: boolean
@@ -154,7 +139,6 @@ export type WishlistHeaderProps = {
   onFilterChange: (filter: FilterType) => void
   onOpenEventDialog: () => void
   onOpenImportDialog: () => void
-  onNavigateToEdit: () => void
 }
 
 export const WishlistHeader = ({
@@ -168,10 +152,13 @@ export const WishlistHeader = ({
   onFilterChange,
   onOpenEventDialog,
   onOpenImportDialog,
-  onNavigateToEdit,
 }: WishlistHeaderProps) => {
   const [sortAnchorEl, setSortAnchorEl] = useState<null | HTMLElement>(null)
   const [filterAnchorEl, setFilterAnchorEl] = useState<null | HTMLElement>(null)
+  const navigate = useNavigate()
+  const handleNavigateToEdit = useCallback(() => {
+    void navigate({ to: '/wishlists/$wishlistId/edit', params: { wishlistId: wishlist.id } })
+  }, [navigate, wishlist])
 
   const sortMenuOpen = Boolean(sortAnchorEl)
   const filterMenuOpen = Boolean(filterAnchorEl)
@@ -248,9 +235,9 @@ export const WishlistHeader = ({
           {/* Import Button (only for owner with importable items) */}
           {currentUserCanEdit && hasImportableItems && (
             <Tooltip title="Importer des souhaits d'anciennes listes">
-              <ImportButton startIcon={<AutoFixHighIcon />} onClick={onOpenImportDialog} size="small">
+              <ImportItemsButton onClick={onOpenImportDialog} sx={theme => ({ padding: theme.spacing(1, 2) })}>
                 Importer
-              </ImportButton>
+              </ImportItemsButton>
             </Tooltip>
           )}
 
@@ -281,15 +268,15 @@ export const WishlistHeader = ({
           {/* Edit Actions (only for owner) */}
           {currentUserCanEdit && (
             // Desktop: Edit button
-            <MainActionButton
+            <UpdateButton
               variant="outlined"
               color="primary"
               startIcon={<EditIcon />}
-              onClick={onNavigateToEdit}
+              onClick={handleNavigateToEdit}
               sx={{ height: '40px' }}
             >
               Modifier
-            </MainActionButton>
+            </UpdateButton>
           )}
         </RightSection>
       </HeaderContent>

--- a/apps/front/src/components/wishlist/WishlistItems.tsx
+++ b/apps/front/src/components/wishlist/WishlistItems.tsx
@@ -10,9 +10,9 @@ import { useMemo, useState } from 'react'
 import { useSelector } from 'react-redux'
 
 import { FabAutoGrow } from '../common/FabAutoGrow'
-import { EmptyItemsState } from '../item/EmptyItemsState'
 import { ItemCard } from '../item/ItemCard'
 import { ItemFormDialog } from '../item/ItemFormDialog'
+import { EmptyItemsState } from './EmptyItemsState'
 import { applyFilter, applySort } from './WishlistFilterAndSortItems'
 
 export type WishlistTabItemsProps = {

--- a/apps/front/src/components/wishlist/WishlistPage.tsx
+++ b/apps/front/src/components/wishlist/WishlistPage.tsx
@@ -70,10 +70,6 @@ export const WishlistPage = ({ wishlistId }: WishlistPageProps) => {
     [navigate],
   )
 
-  const handleNavigateToEdit = useCallback(() => {
-    void navigate({ to: '/wishlists/$wishlistId/edit', params: { wishlistId } })
-  }, [navigate, wishlistId])
-
   return (
     <Box>
       <Loader loading={loading}>
@@ -92,7 +88,6 @@ export const WishlistPage = ({ wishlistId }: WishlistPageProps) => {
               onFilterChange={setFilter}
               onOpenEventDialog={() => setShowEventDialog(true)}
               onOpenImportDialog={() => setShowImportDialog(true)}
-              onNavigateToEdit={handleNavigateToEdit}
             />
 
             <Container maxWidth="lg">


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds collapsible descriptions, a reusable import button, responsive edit actions, sticky dialog headers, and refines the import dialog UX.
> 
> - **UI/UX**:
>   - **Description**: Reworked into `Card` with auto-collapsible content, expand/collapse via `Collapse`, and expand icon overlay.
>   - **Buttons**: Introduce reusable `ImportItemsButton`; replace ad-hoc import buttons in `EmptyItemsState`, `WishlistHeader`, and `ImportItemsDialog`.
>   - **Dialogs**: Make AppBars sticky in item and Secret Santa dialogs; `ImportItemsDialog` gets gradient header and enhanced item hover/selected styles.
> - **Wishlist**:
>   - **Header**: Responsive edit action (icon on small screens), internalizes edit navigation, adjusts breakpoints; removes `onNavigateToEdit` prop.
>   - **Page/Items**: Update imports and drop now-unused edit navigation prop.
> - **Events**:
>   - **EventHeader**: Adds responsive edit action button via media queries.
> - **Import flow**:
>   - Disable import when no items selected; button text unified to “Importer”.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8dbef5423c26fdf062d34e7456de25d49cb85316. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->