### PR TITLE
Fix double tab opening on item card link

### DIFF
--- a/apps/front/src/components/item/ItemCard.tsx
+++ b/apps/front/src/components/item/ItemCard.tsx
@@ -486,7 +486,12 @@ export const ItemCard = ({ item, wishlist, onImageClick }: ItemCardProps) => {
           {/* Title */}
           <ItemTitle>
             {item.url ? (
-              <ClickableTitle href={item.url} target="_blank" rel="noopener noreferrer">
+              <ClickableTitle
+                href={item.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={e => e.stopPropagation()}
+              >
                 {item.name}
               </ClickableTitle>
             ) : (


### PR DESCRIPTION
Fixed bug where clicking directly on the item link would open two tabs because both the Link and its parent container had click handlers. Added stopPropagation to the ClickableTitle to prevent event bubbling.