### PR TITLE
Add user password and picture management mutations

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,7 +86,7 @@ jobs:
     steps:
       - checkout: *checkout
       - attach_workspace: *attach_workspace
-      - run: yarn check --reporter=summary
+      - run: yarn check
 
   typecheck:
       <<: *setup_env_node

--- a/apps/api/schema.graphql
+++ b/apps/api/schema.graphql
@@ -17,6 +17,13 @@ enum AttendeeRole {
   USER
 }
 
+input ChangeUserPasswordInput {
+  newPassword: String!
+  oldPassword: String!
+}
+
+union ChangeUserPasswordResult = ForbiddenRejection | InternalErrorRejection | UnauthorizedRejection | ValidationRejection | VoidOutput
+
 type Event {
   attendeeIds: [AttendeeId!]!
   attendees: [EventAttendee!]! @resolved
@@ -137,11 +144,14 @@ type LoginWithGoogleOutput {
 union LoginWithGoogleResult = InternalErrorRejection | LoginWithGoogleOutput | UnauthorizedRejection | ValidationRejection
 
 type Mutation {
+  changeUserPassword(input: ChangeUserPasswordInput!): ChangeUserPasswordResult!
   linkCurrentUserlWithGoogle(input: LinkUserToGoogleInput!): LinkUserToGoogleResult!
   login(input: LoginInput!): LoginResult!
   loginWithGoogle(input: LoginWithGoogleInput!): LoginWithGoogleResult!
   registerUser(input: RegisterUserInput!): RegisterUserResult!
+  removeUserPicture: RemoveUserPictureResult!
   unlinkCurrentUserSocial(socialId: UserSocialId!): UnlinkCurrentUserSocialResult!
+  updateUserPictureFromSocial(input: UpdateUserPictureFromSocialInput!): UpdateUserPictureFromSocialResult!
   updateUserProfile(input: UpdateUserProfileInput!): UpdateUserProfileResult!
 }
 
@@ -180,11 +190,19 @@ input RegisterUserInput {
 
 union RegisterUserResult = ForbiddenRejection | InternalErrorRejection | UnauthorizedRejection | User | ValidationRejection
 
+union RemoveUserPictureResult = ForbiddenRejection | InternalErrorRejection | UnauthorizedRejection | ValidationRejection | VoidOutput
+
 type UnauthorizedRejection {
   message: String!
 }
 
 union UnlinkCurrentUserSocialResult = ForbiddenRejection | InternalErrorRejection | UnauthorizedRejection | ValidationRejection | VoidOutput
+
+input UpdateUserPictureFromSocialInput {
+  socialId: UserSocialId!
+}
+
+union UpdateUserPictureFromSocialResult = ForbiddenRejection | InternalErrorRejection | UnauthorizedRejection | ValidationRejection | VoidOutput
 
 input UpdateUserProfileInput {
   birthday: String

--- a/apps/api/src/gql/generated-types.ts
+++ b/apps/api/src/gql/generated-types.ts
@@ -31,6 +31,13 @@ export enum AttendeeRole {
   User = 'USER'
 }
 
+export type ChangeUserPasswordInput = {
+  newPassword: Scalars['String']['input'];
+  oldPassword: Scalars['String']['input'];
+};
+
+export type ChangeUserPasswordResult = ForbiddenRejection | InternalErrorRejection | UnauthorizedRejection | ValidationRejection | VoidOutput;
+
 export type Event = {
   __typename: 'Event';
   attendeeIds: Array<Scalars['AttendeeId']['output']>;
@@ -157,12 +164,20 @@ export type LoginWithGoogleResult = InternalErrorRejection | LoginWithGoogleOutp
 
 export type Mutation = {
   __typename: 'Mutation';
+  changeUserPassword: ChangeUserPasswordResult;
   linkCurrentUserlWithGoogle: LinkUserToGoogleResult;
   login: LoginResult;
   loginWithGoogle: LoginWithGoogleResult;
   registerUser: RegisterUserResult;
+  removeUserPicture: RemoveUserPictureResult;
   unlinkCurrentUserSocial: UnlinkCurrentUserSocialResult;
+  updateUserPictureFromSocial: UpdateUserPictureFromSocialResult;
   updateUserProfile: UpdateUserProfileResult;
+};
+
+
+export type MutationChangeUserPasswordArgs = {
+  input: ChangeUserPasswordInput;
 };
 
 
@@ -188,6 +203,11 @@ export type MutationRegisterUserArgs = {
 
 export type MutationUnlinkCurrentUserSocialArgs = {
   socialId: Scalars['UserSocialId']['input'];
+};
+
+
+export type MutationUpdateUserPictureFromSocialArgs = {
+  input: UpdateUserPictureFromSocialInput;
 };
 
 
@@ -253,12 +273,20 @@ export type RegisterUserInput = {
 
 export type RegisterUserResult = ForbiddenRejection | InternalErrorRejection | UnauthorizedRejection | User | ValidationRejection;
 
+export type RemoveUserPictureResult = ForbiddenRejection | InternalErrorRejection | UnauthorizedRejection | ValidationRejection | VoidOutput;
+
 export type UnauthorizedRejection = {
   __typename: 'UnauthorizedRejection';
   message: Scalars['String']['output'];
 };
 
 export type UnlinkCurrentUserSocialResult = ForbiddenRejection | InternalErrorRejection | UnauthorizedRejection | ValidationRejection | VoidOutput;
+
+export type UpdateUserPictureFromSocialInput = {
+  socialId: Scalars['UserSocialId']['input'];
+};
+
+export type UpdateUserPictureFromSocialResult = ForbiddenRejection | InternalErrorRejection | UnauthorizedRejection | ValidationRejection | VoidOutput;
 
 export type UpdateUserProfileInput = {
   birthday?: InputMaybe<Scalars['String']['input']>;

--- a/apps/api/src/user/infrastructure/resolvers/user.resolver.ts
+++ b/apps/api/src/user/infrastructure/resolvers/user.resolver.ts
@@ -5,20 +5,34 @@ import { UserId, UserSocialId } from '@wishlist/common'
 import { RealIP } from 'nestjs-real-ip'
 
 import {
+  ChangeUserPasswordInput,
+  ChangeUserPasswordResult,
   LinkUserToGoogleInput,
   LinkUserToGoogleResult,
   RegisterUserInput,
   RegisterUserResult,
+  RemoveUserPictureResult,
   UnlinkCurrentUserSocialResult,
+  UpdateUserPictureFromSocialInput,
+  UpdateUserPictureFromSocialResult,
   UpdateUserProfileInput,
   UpdateUserProfileResult,
   User,
 } from '../../../gql/generated-types'
 import { CreateUserUseCase } from '../../application/command/create-user.use-case'
 import { LinkUserToGoogleUseCase } from '../../application/command/link-user-to-google.use-case'
+import { RemoveUserPictureUseCase } from '../../application/command/remove-user-picture.use-case'
 import { UnlinkUserSocialUseCase } from '../../application/command/unlink-user-social.use-case'
+import { UpdateUserPasswordUseCase } from '../../application/command/update-user-password.use-case'
+import { UpdateUserPictureFromSocialUseCase } from '../../application/command/update-user-picture-from-social.use-case'
 import { UpdateUserUseCase } from '../../application/command/update-user.use-case'
-import { LinkUserToGoogleInputSchema, RegisterUserInputSchema, UpdateUserProfileInputSchema } from '../user.schema'
+import {
+  ChangeUserPasswordInputSchema,
+  LinkUserToGoogleInputSchema,
+  RegisterUserInputSchema,
+  UpdateUserPictureFromSocialInputSchema,
+  UpdateUserProfileInputSchema,
+} from '../user.schema'
 
 @Resolver()
 export class UserResolver {
@@ -27,6 +41,9 @@ export class UserResolver {
     private readonly linkUserToGoogleUseCase: LinkUserToGoogleUseCase,
     private readonly unlinkUserSocialUseCase: UnlinkUserSocialUseCase,
     private readonly updateUserUseCase: UpdateUserUseCase,
+    private readonly updateUserPasswordUseCase: UpdateUserPasswordUseCase,
+    private readonly updateUserPictureFromSocialUseCase: UpdateUserPictureFromSocialUseCase,
+    private readonly removeUserPictureUseCase: RemoveUserPictureUseCase,
   ) {}
 
   @Query()
@@ -112,5 +129,36 @@ export class UserResolver {
       throw new Error('Failed to load user')
     }
     return loadedUser
+  }
+
+  @Mutation()
+  async changeUserPassword(
+    @Args('input', new ZodPipe(ChangeUserPasswordInputSchema)) input: ChangeUserPasswordInput,
+    @GqlCurrentUser('id') currentUserId: UserId,
+  ): Promise<ChangeUserPasswordResult> {
+    await this.updateUserPasswordUseCase.execute({
+      userId: currentUserId,
+      oldPassword: input.oldPassword,
+      newPassword: input.newPassword,
+    })
+    return { __typename: 'VoidOutput', success: true }
+  }
+
+  @Mutation()
+  async updateUserPictureFromSocial(
+    @Args('input', new ZodPipe(UpdateUserPictureFromSocialInputSchema)) input: UpdateUserPictureFromSocialInput,
+    @GqlCurrentUser('id') currentUserId: UserId,
+  ): Promise<UpdateUserPictureFromSocialResult> {
+    await this.updateUserPictureFromSocialUseCase.execute({
+      userId: currentUserId,
+      socialId: input.socialId,
+    })
+    return { __typename: 'VoidOutput', success: true }
+  }
+
+  @Mutation()
+  async removeUserPicture(@GqlCurrentUser('id') currentUserId: UserId): Promise<RemoveUserPictureResult> {
+    await this.removeUserPictureUseCase.execute({ userId: currentUserId })
+    return { __typename: 'VoidOutput', success: true }
   }
 }

--- a/apps/api/src/user/infrastructure/resolvers/user.resolver.ts
+++ b/apps/api/src/user/infrastructure/resolvers/user.resolver.ts
@@ -23,9 +23,9 @@ import { CreateUserUseCase } from '../../application/command/create-user.use-cas
 import { LinkUserToGoogleUseCase } from '../../application/command/link-user-to-google.use-case'
 import { RemoveUserPictureUseCase } from '../../application/command/remove-user-picture.use-case'
 import { UnlinkUserSocialUseCase } from '../../application/command/unlink-user-social.use-case'
+import { UpdateUserUseCase } from '../../application/command/update-user.use-case'
 import { UpdateUserPasswordUseCase } from '../../application/command/update-user-password.use-case'
 import { UpdateUserPictureFromSocialUseCase } from '../../application/command/update-user-picture-from-social.use-case'
-import { UpdateUserUseCase } from '../../application/command/update-user.use-case'
 import {
   ChangeUserPasswordInputSchema,
   LinkUserToGoogleInputSchema,

--- a/apps/api/src/user/infrastructure/user.graphql
+++ b/apps/api/src/user/infrastructure/user.graphql
@@ -48,6 +48,15 @@ input UpdateUserProfileInput {
   birthday: String
 }
 
+input ChangeUserPasswordInput {
+  oldPassword: String!
+  newPassword: String!
+}
+
+input UpdateUserPictureFromSocialInput {
+  socialId: UserSocialId!
+}
+
 union RegisterUserResult =
   | User
   | ValidationRejection
@@ -76,9 +85,33 @@ union UnlinkCurrentUserSocialResult =
   | ForbiddenRejection
   | InternalErrorRejection
 
+union ChangeUserPasswordResult =
+  | VoidOutput
+  | ValidationRejection
+  | UnauthorizedRejection
+  | ForbiddenRejection
+  | InternalErrorRejection
+
+union UpdateUserPictureFromSocialResult =
+  | VoidOutput
+  | ValidationRejection
+  | UnauthorizedRejection
+  | ForbiddenRejection
+  | InternalErrorRejection
+
+union RemoveUserPictureResult =
+  | VoidOutput
+  | ValidationRejection
+  | UnauthorizedRejection
+  | ForbiddenRejection
+  | InternalErrorRejection
+
 extend type Mutation {
   registerUser(input: RegisterUserInput!): RegisterUserResult!
   linkCurrentUserlWithGoogle(input: LinkUserToGoogleInput!): LinkUserToGoogleResult!
   unlinkCurrentUserSocial(socialId: UserSocialId!): UnlinkCurrentUserSocialResult!
   updateUserProfile(input: UpdateUserProfileInput!): UpdateUserProfileResult!
+  changeUserPassword(input: ChangeUserPasswordInput!): ChangeUserPasswordResult!
+  updateUserPictureFromSocial(input: UpdateUserPictureFromSocialInput!): UpdateUserPictureFromSocialResult!
+  removeUserPicture: RemoveUserPictureResult!
 }

--- a/apps/api/src/user/infrastructure/user.schema.ts
+++ b/apps/api/src/user/infrastructure/user.schema.ts
@@ -33,5 +33,5 @@ export const ChangeUserPasswordInputSchema = z.object({
 }) satisfies z.ZodType<ChangeUserPasswordInput>
 
 export const UpdateUserPictureFromSocialInputSchema = z.object({
-  socialId: z.string().transform((val) => val as UserSocialId),
+  socialId: z.string().transform(val => val as UserSocialId),
 }) satisfies z.ZodType<UpdateUserPictureFromSocialInput>

--- a/apps/api/src/user/infrastructure/user.schema.ts
+++ b/apps/api/src/user/infrastructure/user.schema.ts
@@ -1,6 +1,13 @@
+import { UserSocialId } from '@wishlist/common'
 import z from 'zod'
 
-import { LinkUserToGoogleInput, RegisterUserInput, UpdateUserProfileInput } from '../../gql/generated-types'
+import {
+  ChangeUserPasswordInput,
+  LinkUserToGoogleInput,
+  RegisterUserInput,
+  UpdateUserPictureFromSocialInput,
+  UpdateUserProfileInput,
+} from '../../gql/generated-types'
 
 export const UpdateUserProfileInputSchema = z.object({
   firstname: z.string().nonempty().max(50),
@@ -19,3 +26,12 @@ export const RegisterUserInputSchema = z.object({
 export const LinkUserToGoogleInputSchema = z.object({
   code: z.string(),
 }) satisfies z.ZodType<LinkUserToGoogleInput>
+
+export const ChangeUserPasswordInputSchema = z.object({
+  oldPassword: z.string().min(8).max(50),
+  newPassword: z.string().min(8).max(50),
+}) satisfies z.ZodType<ChangeUserPasswordInput>
+
+export const UpdateUserPictureFromSocialInputSchema = z.object({
+  socialId: z.string().transform((val) => val as UserSocialId),
+}) satisfies z.ZodType<UpdateUserPictureFromSocialInput>

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build": "nx run-many --target=build",
     "test": "nx run-many --target=test --exclude=@wishlist/source",
     "test:int": "nx run-many --target=test:int",
-    "check": "biome check --diagnostic-level=error",
+    "check": "biome check --diagnostic-level=error --reporter=summary",
     "check:fix": "yarn check --write",
     "prepack": "husky",
     "docker:up": "docker compose -f ./docker/docker-compose.yml -f ./docker/docker-compose.local.yml up -d",


### PR DESCRIPTION
## Summary
This PR adds three new GraphQL mutations to enable users to manage their account security and profile pictures: changing passwords, updating profile pictures from social accounts, and removing profile pictures.

## Key Changes
- **New GraphQL Mutations:**
  - `changeUserPassword`: Allows users to change their password with old/new password validation
  - `updateUserPictureFromSocial`: Enables users to update their profile picture from a linked social account
  - `removeUserPicture`: Allows users to remove their profile picture

- **Schema Updates:**
  - Added `ChangeUserPasswordInput` and `ChangeUserPasswordResult` types
  - Added `UpdateUserPictureFromSocialInput` and `UpdateUserPictureFromSocialResult` types
  - Added `RemoveUserPictureResult` union type
  - All result types follow the established error handling pattern with rejection unions

- **Use Case Implementation:**
  - Created `UpdateUserPasswordUseCase` for password change logic
  - Created `UpdateUserPictureFromSocialUseCase` for social picture sync
  - Created `RemoveUserPictureUseCase` for picture removal
  - All mutations are protected with `@GqlCurrentUser` decorator for authentication

- **Input Validation:**
  - Added Zod schemas for all new inputs with password length constraints (8-50 characters)
  - Integrated validation via `ZodPipe` in resolver methods

## Implementation Details
- All mutations return `VoidOutput` on success with standard error rejection types (ValidationRejection, UnauthorizedRejection, ForbiddenRejection, InternalErrorRejection)
- Password change requires both old and new passwords for security
- Social picture update requires a valid `UserSocialId` from linked accounts
- All mutations require authenticated users (enforced by `@GqlCurrentUser` decorator)