### PR TITLE
ci: drop --output-style=stream from nx affected commands

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -92,7 +92,7 @@ jobs:
         uses: ./.github/actions/setup
 
       - name: Run affected typecheck
-        run: yarn nx affected --target=typecheck --base=${{ needs.install.outputs.nx_base }} --head=${{ needs.install.outputs.nx_head }} --exclude=@wishlist/source --parallel=3 --output-style=stream
+        run: yarn nx affected --target=typecheck --base=${{ needs.install.outputs.nx_base }} --head=${{ needs.install.outputs.nx_head }} --exclude=@wishlist/source --parallel=3
 
   test-unit:
     name: Unit Tests
@@ -109,7 +109,7 @@ jobs:
         uses: ./.github/actions/setup
 
       - name: Run affected unit tests
-        run: yarn nx affected --target=test --base=${{ needs.install.outputs.nx_base }} --head=${{ needs.install.outputs.nx_head }} --exclude=@wishlist/source --parallel=3 --output-style=stream
+        run: yarn nx affected --target=test --base=${{ needs.install.outputs.nx_base }} --head=${{ needs.install.outputs.nx_head }} --exclude=@wishlist/source --parallel=3
 
       - name: Upload test reports
         if: always()
@@ -136,7 +136,7 @@ jobs:
       # Testcontainers runs natively against the runner's Docker daemon,
       # so no SSH tunnel / autoforward is required (unlike CircleCI).
       - name: Run affected integration tests
-        run: yarn nx affected --target=test:int --base=${{ needs.install.outputs.nx_base }} --head=${{ needs.install.outputs.nx_head }} --exclude=@wishlist/source --parallel=3 --output-style=stream
+        run: yarn nx affected --target=test:int --base=${{ needs.install.outputs.nx_base }} --head=${{ needs.install.outputs.nx_head }} --exclude=@wishlist/source --parallel=3
 
       - name: Upload test reports
         if: always()


### PR DESCRIPTION
## Summary

Removes `--output-style=stream` from the `nx affected` invocations in `pr-checks.yml` for typecheck, unit tests, and integration tests.

Nx defaults to a sensible output style in CI, and the explicit `stream` flag isn't needed — dropping it lets Nx pick the appropriate dynamic/static terminal output.

## Changes

- `typecheck` job: drop `--output-style=stream`
- `test-unit` job: drop `--output-style=stream`
- `test-int` job: drop `--output-style=stream`

🤖 Generated with [Claude Code](https://claude.com/claude-code)