### PR TITLE
refactor(graphql): rename query fields to noun-style

### DIFF
--- a/apps/api/schema.graphql
+++ b/apps/api/schema.graphql
@@ -162,8 +162,6 @@ union GetPendingEmailChangeResult = ForbiddenRejection | InternalErrorRejection 
 
 union GetSecretSantaForEventResult = ForbiddenRejection | InternalErrorRejection | SecretSanta | UnauthorizedRejection
 
-union GetUserEmailSettingsResult = ForbiddenRejection | InternalErrorRejection | UnauthorizedRejection | UserEmailSettings
-
 union GetWishlistByIdResult = ForbiddenRejection | InternalErrorRejection | NotFoundRejection | UnauthorizedRejection | Wishlist
 
 type GetWishlistsPagedResponse {
@@ -256,7 +254,7 @@ type Mutation {
   deleteSecretSanta(id: SecretSantaId!): DeleteSecretSantaResult!
   deleteSecretSantaUser(id: SecretSantaId!, secretSantaUserId: SecretSantaUserId!): DeleteSecretSantaUserResult!
   importItems(input: ImportItemsInput!): ImportItemsResult!
-  linkCurrentUserlWithGoogle(input: LinkUserToGoogleInput!): LinkUserToGoogleResult!
+  linkCurrentUserWithGoogle(input: LinkUserToGoogleInput!): LinkUserToGoogleResult!
   login(input: LoginInput!): LoginResult!
   loginWithGoogle(input: LoginWithGoogleInput!): LoginWithGoogleResult!
   registerUser(input: RegisterUserInput!): RegisterUserResult!
@@ -298,19 +296,18 @@ type PendingEmailChange {
 }
 
 type Query {
-  adminGetAllUsers(input: AdminGetAllUsersPaginationFilters): AdminGetAllUsersResult!
-  adminGetUserById(userId: UserId!): AdminGetUserByIdResult!
-  getCurrentUser: GetCurrentUserResult!
-  getEventById(id: EventId!): GetEventByIdResult
-  getImportableItems(wishlistId: WishlistId!): GetImportableItemsResult!
-  getMyEvents(filters: EventPaginationFilters!): GetMyEventsResult!
-  getMySecretSantaDraw(eventId: EventId!): GetMySecretSantaDrawResult
-  getMyWishlists(filters: PaginationFilters!): GetMyWishlistsResult!
-  getPendingEmailChange: GetPendingEmailChangeResult
-  getSecretSantaForEvent(eventId: EventId!): GetSecretSantaForEventResult
-  getUserEmailSettings: GetUserEmailSettingsResult!
-  getWishlistById(id: WishlistId!): GetWishlistByIdResult
+  currentUser: GetCurrentUserResult!
+  event(id: EventId!): GetEventByIdResult
+  events(filters: EventPaginationFilters!): GetMyEventsResult!
   health: HealthResult!
+  importableItems(wishlistId: WishlistId!): GetImportableItemsResult!
+  mySecretSantaDraw(eventId: EventId!): GetMySecretSantaDrawResult
+  pendingEmailChange: GetPendingEmailChangeResult
+  secretSanta(eventId: EventId!): GetSecretSantaForEventResult
+  user(userId: UserId!): AdminGetUserByIdResult!
+  users(input: AdminGetAllUsersPaginationFilters): AdminGetAllUsersResult!
+  wishlist(id: WishlistId!): GetWishlistByIdResult
+  wishlists(filters: PaginationFilters!): GetMyWishlistsResult!
 }
 
 input RegisterUserInput {
@@ -445,6 +442,7 @@ type User {
   birthday: String
   createdAt: String!
   email: String!
+  emailSettings: UserEmailSettings @resolved
   firstName: String!
   id: UserId!
   isEnabled: Boolean!

--- a/apps/api/src/event/infrastructure/event.graphql
+++ b/apps/api/src/event/infrastructure/event.graphql
@@ -49,6 +49,6 @@ union GetEventByIdResult =
 union GetMyEventsResult = GetEventsPagedResponse | UnauthorizedRejection | ForbiddenRejection | InternalErrorRejection
 
 extend type Query {
-  getEventById(id: EventId!): GetEventByIdResult
-  getMyEvents(filters: EventPaginationFilters!): GetMyEventsResult!
+  event(id: EventId!): GetEventByIdResult
+  events(filters: EventPaginationFilters!): GetMyEventsResult!
 }

--- a/apps/api/src/event/infrastructure/resolvers/event.resolver.int-spec.ts
+++ b/apps/api/src/event/infrastructure/resolvers/event.resolver.int-spec.ts
@@ -16,10 +16,10 @@ describe('EventResolver (GraphQL)', () => {
     currentUserId = await fixtures.getSignedUserId('BASE_USER')
   })
 
-  describe('Query getEventById', () => {
+  describe('Query event', () => {
     const query = /* GraphQL */ `
       query GetEventById($id: EventId!) {
-        getEventById(id: $id) {
+        event(id: $id) {
           __typename
           ... on Event {
             id
@@ -56,7 +56,7 @@ describe('EventResolver (GraphQL)', () => {
         .send({ query, variables: { id: eventId } })
         .expect(200)
 
-      expect(res.body.data?.getEventById?.__typename).not.toBe('Event')
+      expect(res.body.data?.event?.__typename).not.toBe('Event')
     })
 
     it('should return the event when user is a participant', async () => {
@@ -73,16 +73,16 @@ describe('EventResolver (GraphQL)', () => {
         .send({ query, variables: { id: eventId } })
         .expect(200)
 
-      expect(res.body.data.getEventById).toMatchObject({
+      expect(res.body.data.event).toMatchObject({
         __typename: 'Event',
         id: eventId,
         title: 'Christmas',
         description: 'A nice event',
         eventDate: expect.any(String),
       })
-      expect(res.body.data.getEventById.attendeeIds).toHaveLength(1)
-      expect(res.body.data.getEventById.createdAt).toEqual(expect.any(String))
-      expect(res.body.data.getEventById.updatedAt).toEqual(expect.any(String))
+      expect(res.body.data.event.attendeeIds).toHaveLength(1)
+      expect(res.body.data.event.createdAt).toEqual(expect.any(String))
+      expect(res.body.data.event.updatedAt).toEqual(expect.any(String))
     })
 
     it('should return NotFoundRejection when event does not exist', async () => {
@@ -91,7 +91,7 @@ describe('EventResolver (GraphQL)', () => {
         .send({ query, variables: { id: uuid() } })
         .expect(200)
 
-      expect(res.body.data.getEventById).toMatchObject({
+      expect(res.body.data.event).toMatchObject({
         __typename: 'NotFoundRejection',
       })
     })
@@ -112,7 +112,7 @@ describe('EventResolver (GraphQL)', () => {
         .send({ query, variables: { id: eventId } })
         .expect(200)
 
-      expect(res.body.data.getEventById).toMatchObject({
+      expect(res.body.data.event).toMatchObject({
         __typename: 'NotFoundRejection',
       })
     })
@@ -120,7 +120,7 @@ describe('EventResolver (GraphQL)', () => {
     describe('nested field resolvers', () => {
       const nestedQuery = /* GraphQL */ `
         query GetEventByIdNested($id: EventId!) {
-          getEventById(id: $id) {
+          event(id: $id) {
             __typename
             ... on Event {
               id
@@ -173,7 +173,7 @@ describe('EventResolver (GraphQL)', () => {
           .send({ query: nestedQuery, variables: { id: eventId } })
           .expect(200)
 
-        const event = res.body.data.getEventById
+        const event = res.body.data.event
         expect(event.__typename).toBe('Event')
         expect(event.id).toBe(eventId)
 
@@ -220,7 +220,7 @@ describe('EventResolver (GraphQL)', () => {
           .send({ query: nestedQuery, variables: { id: eventId } })
           .expect(200)
 
-        const event = res.body.data.getEventById
+        const event = res.body.data.event
         expect(event.__typename).toBe('Event')
         expect(event.wishlists).toEqual([])
         expect(event.attendees).toHaveLength(1)
@@ -228,10 +228,10 @@ describe('EventResolver (GraphQL)', () => {
     })
   })
 
-  describe('Query getMyEvents', () => {
+  describe('Query events', () => {
     const query = /* GraphQL */ `
       query GetMyEvents($filters: EventPaginationFilters!) {
-        getMyEvents(filters: $filters) {
+        events(filters: $filters) {
           __typename
           ... on GetEventsPagedResponse {
             data {
@@ -260,7 +260,7 @@ describe('EventResolver (GraphQL)', () => {
         .send({ query, variables: { filters: {} } })
         .expect(200)
 
-      expect(res.body.data?.getMyEvents?.__typename).not.toBe('GetEventsPagedResponse')
+      expect(res.body.data?.events?.__typename).not.toBe('GetEventsPagedResponse')
     })
 
     it('should return only events the current user participates in', async () => {
@@ -284,7 +284,7 @@ describe('EventResolver (GraphQL)', () => {
         .send({ query, variables: { filters: {} } })
         .expect(200)
 
-      const result = res.body.data.getMyEvents
+      const result = res.body.data.events
       expect(result.__typename).toBe('GetEventsPagedResponse')
       expect(result.data).toHaveLength(1)
       expect(result.data[0]).toMatchObject({ id: myEventId, title: 'My event' })
@@ -311,7 +311,7 @@ describe('EventResolver (GraphQL)', () => {
         .send({ query, variables: { filters: { page: 1, limit: 2 } } })
         .expect(200)
 
-      expect(firstPage.body.data.getMyEvents).toMatchObject({
+      expect(firstPage.body.data.events).toMatchObject({
         __typename: 'GetEventsPagedResponse',
         pagination: {
           totalElements: 3,
@@ -320,14 +320,14 @@ describe('EventResolver (GraphQL)', () => {
           pageSize: 2,
         },
       })
-      expect(firstPage.body.data.getMyEvents.data).toHaveLength(2)
+      expect(firstPage.body.data.events.data).toHaveLength(2)
 
       const secondPage = await request
         .post('/graphql')
         .send({ query, variables: { filters: { page: 2, limit: 2 } } })
         .expect(200)
 
-      expect(secondPage.body.data.getMyEvents).toMatchObject({
+      expect(secondPage.body.data.events).toMatchObject({
         __typename: 'GetEventsPagedResponse',
         pagination: {
           totalElements: 3,
@@ -336,10 +336,10 @@ describe('EventResolver (GraphQL)', () => {
           pageSize: 2,
         },
       })
-      expect(secondPage.body.data.getMyEvents.data).toHaveLength(1)
+      expect(secondPage.body.data.events.data).toHaveLength(1)
 
-      const firstPageIds = firstPage.body.data.getMyEvents.data.map((e: { id: string }) => e.id)
-      const secondPageIds = secondPage.body.data.getMyEvents.data.map((e: { id: string }) => e.id)
+      const firstPageIds = firstPage.body.data.events.data.map((e: { id: string }) => e.id)
+      const secondPageIds = secondPage.body.data.events.data.map((e: { id: string }) => e.id)
       expect(firstPageIds).not.toEqual(expect.arrayContaining(secondPageIds))
     })
 
@@ -349,7 +349,7 @@ describe('EventResolver (GraphQL)', () => {
         .send({ query, variables: { filters: {} } })
         .expect(200)
 
-      expect(res.body.data.getMyEvents).toMatchObject({
+      expect(res.body.data.events).toMatchObject({
         __typename: 'GetEventsPagedResponse',
         data: [],
         pagination: {

--- a/apps/api/src/event/infrastructure/resolvers/event.resolver.ts
+++ b/apps/api/src/event/infrastructure/resolvers/event.resolver.ts
@@ -14,7 +14,7 @@ export class EventResolver {
   constructor(private readonly getEventsByUserUseCase: GetEventsByUserUseCase) {}
 
   @Query()
-  async getEventById(
+  async event(
     @Args('id', { type: () => String }) id: EventId,
     @Context() ctx: GraphQLContext,
   ): Promise<GetEventByIdResult> {
@@ -26,7 +26,7 @@ export class EventResolver {
   }
 
   @Query()
-  async getMyEvents(
+  async events(
     @Args('filters', new ZodPipe(EventPaginationFiltersSchema)) filters: EventPaginationFilters,
     @GqlCurrentUser('id') currentUserId: UserId,
   ): Promise<GetMyEventsResult> {

--- a/apps/api/src/gql/generated-types.ts
+++ b/apps/api/src/gql/generated-types.ts
@@ -182,8 +182,6 @@ export type GetPendingEmailChangeResult = ForbiddenRejection | InternalErrorReje
 
 export type GetSecretSantaForEventResult = ForbiddenRejection | InternalErrorRejection | SecretSanta | UnauthorizedRejection;
 
-export type GetUserEmailSettingsResult = ForbiddenRejection | InternalErrorRejection | UnauthorizedRejection | UserEmailSettings;
-
 export type GetWishlistByIdResult = ForbiddenRejection | InternalErrorRejection | NotFoundRejection | UnauthorizedRejection | Wishlist;
 
 export type GetWishlistsPagedResponse = {
@@ -282,7 +280,7 @@ export type Mutation = {
   deleteSecretSanta: DeleteSecretSantaResult;
   deleteSecretSantaUser: DeleteSecretSantaUserResult;
   importItems: ImportItemsResult;
-  linkCurrentUserlWithGoogle: LinkUserToGoogleResult;
+  linkCurrentUserWithGoogle: LinkUserToGoogleResult;
   login: LoginResult;
   loginWithGoogle: LoginWithGoogleResult;
   registerUser: RegisterUserResult;
@@ -371,7 +369,7 @@ export type MutationImportItemsArgs = {
 };
 
 
-export type MutationLinkCurrentUserlWithGoogleArgs = {
+export type MutationLinkCurrentUserWithGoogleArgs = {
   input: LinkUserToGoogleInput;
 };
 
@@ -485,64 +483,63 @@ export type PendingEmailChange = {
 
 export type Query = {
   __typename: 'Query';
-  adminGetAllUsers: AdminGetAllUsersResult;
-  adminGetUserById: AdminGetUserByIdResult;
-  getCurrentUser: GetCurrentUserResult;
-  getEventById?: Maybe<GetEventByIdResult>;
-  getImportableItems: GetImportableItemsResult;
-  getMyEvents: GetMyEventsResult;
-  getMySecretSantaDraw?: Maybe<GetMySecretSantaDrawResult>;
-  getMyWishlists: GetMyWishlistsResult;
-  getPendingEmailChange?: Maybe<GetPendingEmailChangeResult>;
-  getSecretSantaForEvent?: Maybe<GetSecretSantaForEventResult>;
-  getUserEmailSettings: GetUserEmailSettingsResult;
-  getWishlistById?: Maybe<GetWishlistByIdResult>;
+  currentUser: GetCurrentUserResult;
+  event?: Maybe<GetEventByIdResult>;
+  events: GetMyEventsResult;
   health: HealthResult;
+  importableItems: GetImportableItemsResult;
+  mySecretSantaDraw?: Maybe<GetMySecretSantaDrawResult>;
+  pendingEmailChange?: Maybe<GetPendingEmailChangeResult>;
+  secretSanta?: Maybe<GetSecretSantaForEventResult>;
+  user: AdminGetUserByIdResult;
+  users: AdminGetAllUsersResult;
+  wishlist?: Maybe<GetWishlistByIdResult>;
+  wishlists: GetMyWishlistsResult;
 };
 
 
-export type QueryAdminGetAllUsersArgs = {
-  input?: InputMaybe<AdminGetAllUsersPaginationFilters>;
-};
-
-
-export type QueryAdminGetUserByIdArgs = {
-  userId: Scalars['UserId']['input'];
-};
-
-
-export type QueryGetEventByIdArgs = {
+export type QueryEventArgs = {
   id: Scalars['EventId']['input'];
 };
 
 
-export type QueryGetImportableItemsArgs = {
-  wishlistId: Scalars['WishlistId']['input'];
-};
-
-
-export type QueryGetMyEventsArgs = {
+export type QueryEventsArgs = {
   filters: EventPaginationFilters;
 };
 
 
-export type QueryGetMySecretSantaDrawArgs = {
+export type QueryImportableItemsArgs = {
+  wishlistId: Scalars['WishlistId']['input'];
+};
+
+
+export type QueryMySecretSantaDrawArgs = {
   eventId: Scalars['EventId']['input'];
 };
 
 
-export type QueryGetMyWishlistsArgs = {
-  filters: PaginationFilters;
-};
-
-
-export type QueryGetSecretSantaForEventArgs = {
+export type QuerySecretSantaArgs = {
   eventId: Scalars['EventId']['input'];
 };
 
 
-export type QueryGetWishlistByIdArgs = {
+export type QueryUserArgs = {
+  userId: Scalars['UserId']['input'];
+};
+
+
+export type QueryUsersArgs = {
+  input?: InputMaybe<AdminGetAllUsersPaginationFilters>;
+};
+
+
+export type QueryWishlistArgs = {
   id: Scalars['WishlistId']['input'];
+};
+
+
+export type QueryWishlistsArgs = {
+  filters: PaginationFilters;
 };
 
 export type RegisterUserInput = {

--- a/apps/api/src/item/infrastructure/item.graphql
+++ b/apps/api/src/item/infrastructure/item.graphql
@@ -135,5 +135,5 @@ extend type Mutation {
 ########################################################
 
 extend type Query {
-  getImportableItems(wishlistId: WishlistId!): GetImportableItemsResult!
+  importableItems(wishlistId: WishlistId!): GetImportableItemsResult!
 }

--- a/apps/api/src/item/infrastructure/item.resolver.int-spec.ts
+++ b/apps/api/src/item/infrastructure/item.resolver.int-spec.ts
@@ -28,10 +28,10 @@ describe('ItemResolver (GraphQL)', () => {
     fixtures = getFixtures()
   })
 
-  describe('Query getImportableItems', () => {
+  describe('Query importableItems', () => {
     const query = /* GraphQL */ `
       query GetImportableItems($wishlistId: WishlistId!) {
-        getImportableItems(wishlistId: $wishlistId) {
+        importableItems(wishlistId: $wishlistId) {
           __typename
           ... on GetImportableItemsOutput {
             items {
@@ -54,7 +54,7 @@ describe('ItemResolver (GraphQL)', () => {
         .send({ query, variables: { wishlistId: uuid() } })
         .expect(200)
 
-      expect(res.body.data?.getImportableItems?.__typename).not.toBe('GetImportableItemsOutput')
+      expect(res.body.data?.importableItems?.__typename).not.toBe('GetImportableItemsOutput')
     })
 
     describe('when user is authenticated', () => {
@@ -110,7 +110,7 @@ describe('ItemResolver (GraphQL)', () => {
           .send({ query, variables: { wishlistId: targetWishlistId } })
           .expect(200)
 
-        expect(res.body.data.getImportableItems).toMatchObject({
+        expect(res.body.data.importableItems).toMatchObject({
           __typename: 'GetImportableItemsOutput',
           items: [
             {
@@ -136,7 +136,7 @@ describe('ItemResolver (GraphQL)', () => {
 
         const res = await request.post('/graphql').send({ query, variables: { wishlistId } }).expect(200)
 
-        expect(res.body.data.getImportableItems).toEqual({
+        expect(res.body.data.importableItems).toEqual({
           __typename: 'GetImportableItemsOutput',
           items: [],
         })
@@ -148,7 +148,7 @@ describe('ItemResolver (GraphQL)', () => {
           .send({ query, variables: { wishlistId: uuid() } })
           .expect(200)
 
-        expect(res.body.data.getImportableItems.__typename).not.toBe('GetImportableItemsOutput')
+        expect(res.body.data.importableItems.__typename).not.toBe('GetImportableItemsOutput')
       })
 
       it('should return UnauthorizedRejection when user is not the owner of the wishlist', async () => {
@@ -174,7 +174,7 @@ describe('ItemResolver (GraphQL)', () => {
           .send({ query, variables: { wishlistId: otherWishlistId } })
           .expect(200)
 
-        expect(res.body.data.getImportableItems.__typename).toBe('UnauthorizedRejection')
+        expect(res.body.data.importableItems.__typename).toBe('UnauthorizedRejection')
       })
     })
   })
@@ -1127,7 +1127,7 @@ describe('ItemResolver (GraphQL)', () => {
   describe('Field resolver Item.takerUser', () => {
     // The Item.takerUser field resolver returns undefined when the parent Item has no
     // takenById, otherwise it loads the user via the dataloader. Every Item-returning
-    // operation in this resolver (createItem / importItems / getImportableItems) produces
+    // operation in this resolver (createItem / importItems / importableItems) produces
     // an Item with no taker, so we assert the resolver returns null (no taker) for a fresh item.
     const createMutation = /* GraphQL */ `
       mutation CreateItem($input: CreateItemInput!) {

--- a/apps/api/src/item/infrastructure/item.resolver.ts
+++ b/apps/api/src/item/infrastructure/item.resolver.ts
@@ -64,7 +64,7 @@ export class ItemResolver {
   }
 
   @Query()
-  async getImportableItems(
+  async importableItems(
     @Args('wishlistId', new ZodPipe(WishlistIdSchema)) wishlistId: WishlistId,
     @GqlCurrentUser() currentUser: ICurrentUser,
   ): Promise<GetImportableItemsOutput> {

--- a/apps/api/src/secret-santa/infrastructure/resolvers/secret-santa.resolver.int-spec.ts
+++ b/apps/api/src/secret-santa/infrastructure/resolvers/secret-santa.resolver.int-spec.ts
@@ -28,7 +28,7 @@ describe('SecretSantaResolver (GraphQL)', () => {
   describe('Query getSecretSantaForEvent', () => {
     const query = /* GraphQL */ `
       query GetSecretSantaForEvent($eventId: EventId!) {
-        getSecretSantaForEvent(eventId: $eventId) {
+        secretSanta(eventId: $eventId) {
           __typename
           ... on SecretSanta {
             id
@@ -60,7 +60,7 @@ describe('SecretSantaResolver (GraphQL)', () => {
         .send({ query, variables: { eventId: uuid() } })
         .expect(200)
 
-      expectNotSuccess(res, 'getSecretSantaForEvent')
+      expectNotSuccess(res, 'secretSanta')
     })
 
     it('should return null when no secret santa exists for event', async () => {
@@ -72,7 +72,7 @@ describe('SecretSantaResolver (GraphQL)', () => {
 
       const res = await request.post('/graphql').send({ query, variables: { eventId } }).expect(200)
 
-      expect(res.body.data.getSecretSantaForEvent).toBeNull()
+      expect(res.body.data.secretSanta).toBeNull()
     })
 
     it('should return secret santa with resolved event when current user is maintainer', async () => {
@@ -91,7 +91,7 @@ describe('SecretSantaResolver (GraphQL)', () => {
 
       const res = await request.post('/graphql').send({ query, variables: { eventId } }).expect(200)
 
-      expect(res.body.data.getSecretSantaForEvent).toMatchObject({
+      expect(res.body.data.secretSanta).toMatchObject({
         __typename: 'SecretSanta',
         id: secretSantaId,
         eventId,
@@ -129,14 +129,14 @@ describe('SecretSantaResolver (GraphQL)', () => {
 
       const res = await request.post('/graphql').send({ query, variables: { eventId } }).expect(200)
 
-      expect(res.body.data.getSecretSantaForEvent).toMatchObject({ __typename: 'ForbiddenRejection' })
+      expect(res.body.data.secretSanta).toMatchObject({ __typename: 'ForbiddenRejection' })
     })
   })
 
   describe('Query getMySecretSantaDraw', () => {
     const query = /* GraphQL */ `
       query GetMySecretSantaDraw($eventId: EventId!) {
-        getMySecretSantaDraw(eventId: $eventId) {
+        mySecretSantaDraw(eventId: $eventId) {
           __typename
           ... on EventAttendee {
             id
@@ -160,7 +160,7 @@ describe('SecretSantaResolver (GraphQL)', () => {
         .send({ query, variables: { eventId: uuid() } })
         .expect(200)
 
-      expectNotSuccess(res, 'getMySecretSantaDraw')
+      expectNotSuccess(res, 'mySecretSantaDraw')
     })
 
     it('should return null when secret santa is not started and user has no draw', async () => {
@@ -179,7 +179,7 @@ describe('SecretSantaResolver (GraphQL)', () => {
 
       const res = await request.post('/graphql').send({ query, variables: { eventId } }).expect(200)
 
-      expect(res.body.data.getMySecretSantaDraw).toBeNull()
+      expect(res.body.data.mySecretSantaDraw).toBeNull()
     })
 
     it('should return draw with resolved attendee/user when started and user has a draw', async () => {
@@ -214,7 +214,7 @@ describe('SecretSantaResolver (GraphQL)', () => {
 
       const res = await request.post('/graphql').send({ query, variables: { eventId } }).expect(200)
 
-      expect(res.body.data.getMySecretSantaDraw).toMatchObject({
+      expect(res.body.data.mySecretSantaDraw).toMatchObject({
         __typename: 'EventAttendee',
         id: targetAttendeeId,
         role: 'USER',

--- a/apps/api/src/secret-santa/infrastructure/resolvers/secret-santa.resolver.ts
+++ b/apps/api/src/secret-santa/infrastructure/resolvers/secret-santa.resolver.ts
@@ -58,7 +58,7 @@ export class SecretSantaResolver {
   ) {}
 
   @Query()
-  async getSecretSantaForEvent(
+  async secretSanta(
     @Args('eventId', new ZodPipe(EventIdSchema)) eventId: EventId,
     @GqlCurrentUser() currentUser: ICurrentUser,
   ): Promise<GetSecretSantaForEventResult | null> {
@@ -68,7 +68,7 @@ export class SecretSantaResolver {
   }
 
   @Query()
-  async getMySecretSantaDraw(
+  async mySecretSantaDraw(
     @Args('eventId', new ZodPipe(EventIdSchema)) eventId: EventId,
     @GqlCurrentUser() currentUser: ICurrentUser,
   ): Promise<GetMySecretSantaDrawResult | null> {

--- a/apps/api/src/secret-santa/infrastructure/secret-santa.graphql
+++ b/apps/api/src/secret-santa/infrastructure/secret-santa.graphql
@@ -110,8 +110,8 @@ union DeleteSecretSantaUserResult = VoidOutput | UnauthorizedRejection | Forbidd
 ########################################################
 
 extend type Query {
-  getSecretSantaForEvent(eventId: EventId!): GetSecretSantaForEventResult
-  getMySecretSantaDraw(eventId: EventId!): GetMySecretSantaDrawResult
+  secretSanta(eventId: EventId!): GetSecretSantaForEventResult
+  mySecretSantaDraw(eventId: EventId!): GetMySecretSantaDrawResult
 }
 
 ########################################################

--- a/apps/api/src/user/infrastructure/resolvers/user-admin.resolver.int-spec.ts
+++ b/apps/api/src/user/infrastructure/resolvers/user-admin.resolver.int-spec.ts
@@ -17,12 +17,12 @@ describe('UserAdminResolver (GraphQL)', () => {
   })
 
   // ---------------------------------------------------------------------------
-  // adminGetUserById
+  // user
   // ---------------------------------------------------------------------------
-  describe('Query adminGetUserById', () => {
+  describe('Query user', () => {
     const query = /* GraphQL */ `
       query AdminGetUserById($userId: UserId!) {
-        adminGetUserById(userId: $userId) {
+        user(userId: $userId) {
           __typename
           ... on UserFull {
             id
@@ -64,7 +64,7 @@ describe('UserAdminResolver (GraphQL)', () => {
         .expect(200)
 
       // Unauthenticated requests must NOT resolve to a UserFull payload
-      expect(res.body.data?.adminGetUserById?.__typename).not.toBe('UserFull')
+      expect(res.body.data?.user?.__typename).not.toBe('UserFull')
     })
 
     describe('when user is authenticated as BASE_USER (non-admin)', () => {
@@ -86,7 +86,7 @@ describe('UserAdminResolver (GraphQL)', () => {
           .send({ query, variables: { userId: targetUserId } })
           .expect(200)
 
-        expect(res.body.data.adminGetUserById).toMatchObject({ __typename: 'ForbiddenRejection' })
+        expect(res.body.data.user).toMatchObject({ __typename: 'ForbiddenRejection' })
       })
     })
 
@@ -109,7 +109,7 @@ describe('UserAdminResolver (GraphQL)', () => {
           .expect(200)
 
         // insertUser never persists a birthday, so it is always null here.
-        expect(res.body.data.adminGetUserById).toMatchObject({
+        expect(res.body.data.user).toMatchObject({
           __typename: 'UserFull',
           id: targetUserId,
           firstName: 'Target',
@@ -128,7 +128,7 @@ describe('UserAdminResolver (GraphQL)', () => {
           .send({ query, variables: { userId: uuid() } })
           .expect(200)
 
-        expect(res.body.data.adminGetUserById).toMatchObject({ __typename: 'NotFoundRejection' })
+        expect(res.body.data.user).toMatchObject({ __typename: 'NotFoundRejection' })
       })
 
       it('should not return a user when userId is malformed', async () => {
@@ -139,18 +139,18 @@ describe('UserAdminResolver (GraphQL)', () => {
           .send({ query, variables: { userId: 'not-a-uuid' } })
           .expect(200)
 
-        expect(res.body.data.adminGetUserById.__typename).not.toBe('UserFull')
+        expect(res.body.data.user.__typename).not.toBe('UserFull')
       })
     })
   })
 
   // ---------------------------------------------------------------------------
-  // adminGetAllUsers (pagination)
+  // users (pagination)
   // ---------------------------------------------------------------------------
-  describe('Query adminGetAllUsers', () => {
+  describe('Query users', () => {
     const query = /* GraphQL */ `
       query AdminGetAllUsers($input: AdminGetAllUsersPaginationFilters) {
-        adminGetAllUsers(input: $input) {
+        users(input: $input) {
           __typename
           ... on AdminGetAllUsers {
             data {
@@ -187,7 +187,7 @@ describe('UserAdminResolver (GraphQL)', () => {
         .send({ query, variables: { input: {} } })
         .expect(200)
 
-      expect(res.body.data?.adminGetAllUsers?.__typename).not.toBe('AdminGetAllUsers')
+      expect(res.body.data?.users?.__typename).not.toBe('AdminGetAllUsers')
     })
 
     it('should reject a BASE_USER with ForbiddenRejection', async () => {
@@ -198,7 +198,7 @@ describe('UserAdminResolver (GraphQL)', () => {
         .send({ query, variables: { input: {} } })
         .expect(200)
 
-      expect(res.body.data.adminGetAllUsers).toMatchObject({ __typename: 'ForbiddenRejection' })
+      expect(res.body.data.users).toMatchObject({ __typename: 'ForbiddenRejection' })
     })
 
     describe('when user is authenticated as ADMIN_USER', () => {
@@ -216,13 +216,13 @@ describe('UserAdminResolver (GraphQL)', () => {
           .send({ query, variables: { input: { page: 1, limit: 50 } } })
           .expect(200)
 
-        expect(res.body.data.adminGetAllUsers.__typename).toBe('AdminGetAllUsers')
-        expect(res.body.data.adminGetAllUsers.pagination).toMatchObject({
+        expect(res.body.data.users.__typename).toBe('AdminGetAllUsers')
+        expect(res.body.data.users.pagination).toMatchObject({
           totalElements: 3,
           pageNumber: 1,
           pageSize: 50,
         })
-        expect(res.body.data.adminGetAllUsers.data).toHaveLength(3)
+        expect(res.body.data.users.data).toHaveLength(3)
       })
 
       it('should respect pagination (limit / page)', async () => {
@@ -234,8 +234,8 @@ describe('UserAdminResolver (GraphQL)', () => {
           .send({ query, variables: { input: { page: 1, limit: 2 } } })
           .expect(200)
 
-        expect(firstPage.body.data.adminGetAllUsers.data).toHaveLength(2)
-        expect(firstPage.body.data.adminGetAllUsers.pagination).toMatchObject({
+        expect(firstPage.body.data.users.data).toHaveLength(2)
+        expect(firstPage.body.data.users.pagination).toMatchObject({
           totalElements: 3,
           totalPages: 2,
           pageNumber: 1,
@@ -247,8 +247,8 @@ describe('UserAdminResolver (GraphQL)', () => {
           .send({ query, variables: { input: { page: 2, limit: 2 } } })
           .expect(200)
 
-        expect(secondPage.body.data.adminGetAllUsers.data).toHaveLength(1)
-        expect(secondPage.body.data.adminGetAllUsers.pagination).toMatchObject({
+        expect(secondPage.body.data.users.data).toHaveLength(1)
+        expect(secondPage.body.data.users.pagination).toMatchObject({
           totalElements: 3,
           pageNumber: 2,
           pageSize: 2,
@@ -264,9 +264,9 @@ describe('UserAdminResolver (GraphQL)', () => {
           .send({ query, variables: { input: { criteria: 'alice' } } })
           .expect(200)
 
-        expect(res.body.data.adminGetAllUsers.__typename).toBe('AdminGetAllUsers')
-        expect(res.body.data.adminGetAllUsers.data).toHaveLength(1)
-        expect(res.body.data.adminGetAllUsers.data[0]).toMatchObject({ email: 'alice@test.fr' })
+        expect(res.body.data.users.__typename).toBe('AdminGetAllUsers')
+        expect(res.body.data.users.data).toHaveLength(1)
+        expect(res.body.data.users.data[0]).toMatchObject({ email: 'alice@test.fr' })
       })
 
       it.each([
@@ -275,7 +275,7 @@ describe('UserAdminResolver (GraphQL)', () => {
       ])('should return ValidationRejection when $case', async ({ input }) => {
         const res = await request.post(GRAPHQL_PATH).send({ query, variables: { input } }).expect(200)
 
-        expect(res.body.data.adminGetAllUsers).toMatchObject({ __typename: 'ValidationRejection' })
+        expect(res.body.data.users).toMatchObject({ __typename: 'ValidationRejection' })
       })
     })
   })

--- a/apps/api/src/user/infrastructure/resolvers/user-admin.resolver.ts
+++ b/apps/api/src/user/infrastructure/resolvers/user-admin.resolver.ts
@@ -34,7 +34,7 @@ export class UserAdminResolver {
   ) {}
 
   @Query()
-  async adminGetUserById(
+  async user(
     @Args('userId', new ZodPipe(UserIdSchema)) userId: UserId,
     @Context() ctx: GraphQLContext,
   ): Promise<AdminGetUserByIdResult> {
@@ -48,7 +48,7 @@ export class UserAdminResolver {
   }
 
   @Query()
-  async adminGetAllUsers(
+  async users(
     @Args('input', new ZodPipe(AdminGetAllUsersPaginationFiltersSchema)) input: AdminGetAllUsersPaginationFilters,
   ): Promise<AdminGetAllUsersResult> {
     const pageSize = input.limit ?? DEFAULT_RESULT_NUMBER

--- a/apps/api/src/user/infrastructure/resolvers/user.field-resolver.ts
+++ b/apps/api/src/user/infrastructure/resolvers/user.field-resolver.ts
@@ -1,12 +1,17 @@
+import type { ICurrentUser } from '@wishlist/common'
+
 import { Context, Parent, ResolveField, Resolver } from '@nestjs/graphql'
 import { GqlCurrentUser } from '@wishlist/api/auth'
 import { GraphQLContext } from '@wishlist/api/core'
 import { UserId } from '@wishlist/common'
 
-import { User, UserSocial } from '../../../gql/generated-types'
+import { User, UserEmailSettings, UserSocial } from '../../../gql/generated-types'
+import { GetUserEmailSettingUseCase } from '../../application/query/get-user-email-setting.use-case'
 
 @Resolver('User')
 export class UserFieldResolver {
+  constructor(private readonly getUserEmailSettingUseCase: GetUserEmailSettingUseCase) {}
+
   @ResolveField()
   socials(
     @Parent() user: User,
@@ -15,5 +20,20 @@ export class UserFieldResolver {
   ): Promise<UserSocial[] | null> {
     if (user.id !== currentUserId) return Promise.resolve(null)
     return ctx.loaders.userSocialsByUser.load(user.id)
+  }
+
+  @ResolveField()
+  async emailSettings(
+    @Parent() user: User,
+    @GqlCurrentUser() currentUser: ICurrentUser,
+  ): Promise<UserEmailSettings | null> {
+    if (user.id !== currentUser.id) return null
+
+    const result = await this.getUserEmailSettingUseCase.execute({ currentUser })
+
+    return {
+      __typename: 'UserEmailSettings',
+      dailyNewItemNotification: result.daily_new_item_notification,
+    }
   }
 }

--- a/apps/api/src/user/infrastructure/resolvers/user.resolver.int-spec.ts
+++ b/apps/api/src/user/infrastructure/resolvers/user.resolver.int-spec.ts
@@ -19,21 +19,21 @@ import { DateTime } from 'luxon'
  * NotFoundRejection / InternalErrorRejection) thanks to the error-transform plugin.
  *
  * COVERED operations:
- *  - getCurrentUser (Query)            -> unauthenticated + happy path + socials field
+ *  - currentUser (Query)              -> unauthenticated + happy path + socials field
  *  - registerUser (Mutation)          -> happy path + DB verify, duplicate-email conflict, validation (it.each)
  *  - updateUserProfile (Mutation)     -> unauthenticated + happy path + DB verify + validation (it.each)
  *  - changeUserPassword (Mutation)    -> happy path + DB verify, wrong old password, validation (it.each)
- *  - getUserEmailSettings (Query)     -> unauthenticated + happy path (with seeded settings)
+ *  - User.emailSettings field resolver -> unauthenticated + happy path (with seeded settings), via currentUser
  *  - updateUserEmailSettings (Mutation)-> happy path + DB verify
  *  - User.socials field resolver      -> returns own socials shape; returns null for another user's record
  *
  * INTENTIONALLY SKIPPED (require external integrations / OAuth / mail-token round-trips
  * that are out of scope for this high-value subset):
- *  - linkCurrentUserlWithGoogle / unlinkCurrentUserSocial (Google OAuth dependency)
+ *  - linkCurrentUserWithGoogle / unlinkCurrentUserSocial (Google OAuth dependency)
  *  - updateUserPictureFromSocial / removeUserPicture (bucket + social dependency)
  *  - requestEmailChange / confirmEmailChange (mail token round-trip)
  *  - sendResetPasswordEmail / resetPassword (mail token round-trip)
- *  - getPendingEmailChange (depends on requestEmailChange flow)
+ *  - pendingEmailChange (depends on requestEmailChange flow)
  */
 describe('UserResolver (GraphQL)', () => {
   const { getRequest, getFixtures, expectTable } = useTestApp()
@@ -47,10 +47,10 @@ describe('UserResolver (GraphQL)', () => {
     currentUserId = await fixtures.getSignedUserId('BASE_USER')
   })
 
-  describe('Query getCurrentUser', () => {
+  describe('Query currentUser', () => {
     const query = /* GraphQL */ `
-      query GetCurrentUser {
-        getCurrentUser {
+      query CurrentUser {
+        currentUser {
           __typename
           ... on User {
             id
@@ -73,14 +73,14 @@ describe('UserResolver (GraphQL)', () => {
       const res = await anon.post('/graphql').send({ query }).expect(200)
 
       const hasTopLevelError = Array.isArray(res.body.errors) && res.body.errors.length > 0
-      const typename = res.body.data?.getCurrentUser?.__typename
+      const typename = res.body.data?.currentUser?.__typename
       expect(typename !== 'User' || hasTopLevelError).toBe(true)
     })
 
     it('should return the current user when authenticated', async () => {
       const res = await request.post('/graphql').send({ query }).expect(200)
 
-      expect(res.body.data.getCurrentUser).toMatchObject({
+      expect(res.body.data.currentUser).toMatchObject({
         __typename: 'User',
         id: currentUserId,
         firstName: 'John',
@@ -92,8 +92,8 @@ describe('UserResolver (GraphQL)', () => {
 
     it('should resolve the socials field for the current user as an array', async () => {
       const query = /* GraphQL */ `
-        query GetCurrentUserWithSocials {
-          getCurrentUser {
+        query CurrentUserWithSocials {
+          currentUser {
             __typename
             ... on User {
               id
@@ -109,7 +109,7 @@ describe('UserResolver (GraphQL)', () => {
 
       const res = await request.post('/graphql').send({ query }).expect(200)
 
-      const user = res.body.data.getCurrentUser
+      const user = res.body.data.currentUser
       expect(user.__typename).toBe('User')
       expect(user.id).toBe(currentUserId)
       // No socials seeded -> own record resolves to an (empty) array, never null.
@@ -432,13 +432,21 @@ describe('UserResolver (GraphQL)', () => {
     })
   })
 
-  describe('Query getUserEmailSettings', () => {
+  describe('User.emailSettings field resolver', () => {
+    // emailSettings is now a @ResolveField on the User type, reached through the
+    // currentUser query (the only schema entry point returning a User). The field
+    // resolver only resolves settings when the resolved User.id equals the current
+    // user's id (returns null otherwise); currentUser always resolves the signed-in
+    // user so the id-equality guard always passes here.
     const query = /* GraphQL */ `
-      query GetUserEmailSettings {
-        getUserEmailSettings {
+      query CurrentUserEmailSettings {
+        currentUser {
           __typename
-          ... on UserEmailSettings {
-            dailyNewItemNotification
+          ... on User {
+            id
+            emailSettings {
+              dailyNewItemNotification
+            }
           }
           ... on UnauthorizedRejection {
             message
@@ -452,8 +460,8 @@ describe('UserResolver (GraphQL)', () => {
       const res = await anon.post('/graphql').send({ query }).expect(200)
 
       const hasTopLevelError = Array.isArray(res.body.errors) && res.body.errors.length > 0
-      const typename = res.body.data?.getUserEmailSettings?.__typename
-      expect(typename !== 'UserEmailSettings' || hasTopLevelError).toBe(true)
+      const typename = res.body.data?.currentUser?.__typename
+      expect(typename !== 'User' || hasTopLevelError).toBe(true)
     })
 
     it('should return the email settings when they exist', async () => {
@@ -464,8 +472,10 @@ describe('UserResolver (GraphQL)', () => {
 
       const res = await request.post('/graphql').send({ query }).expect(200)
 
-      expect(res.body.data.getUserEmailSettings).toEqual({
-        __typename: 'UserEmailSettings',
+      const user = res.body.data.currentUser
+      expect(user.__typename).toBe('User')
+      expect(user.id).toBe(currentUserId)
+      expect(user.emailSettings).toEqual({
         dailyNewItemNotification: true,
       })
     })
@@ -521,7 +531,7 @@ describe('UserResolver (GraphQL)', () => {
   describe('User.socials field resolver', () => {
     // The field resolver only exposes socials when the resolved User.id equals the
     // current user's id (returns null otherwise). The only schema entry point that
-    // returns a User and supports the socials field is getCurrentUser, which always
+    // returns a User and supports the socials field is currentUser, which always
     // resolves the signed-in user -> the id-equality guard always passes here, so we
     // verify the own-record path returns a (non-null) array. The "another user" guard
     // (returning null) is not reachable via the current schema and is left for a unit
@@ -529,7 +539,7 @@ describe('UserResolver (GraphQL)', () => {
     it('should return a non-null socials array for the current user own record', async () => {
       const query = /* GraphQL */ `
         query OwnSocials {
-          getCurrentUser {
+          currentUser {
             ... on User {
               id
               socials {
@@ -541,7 +551,7 @@ describe('UserResolver (GraphQL)', () => {
       `
 
       const res = await request.post('/graphql').send({ query }).expect(200)
-      const user = res.body.data.getCurrentUser
+      const user = res.body.data.currentUser
 
       expect(user.id).toBe(currentUserId)
       expect(user.socials).not.toBeNull()

--- a/apps/api/src/user/infrastructure/resolvers/user.resolver.ts
+++ b/apps/api/src/user/infrastructure/resolvers/user.resolver.ts
@@ -12,7 +12,6 @@ import {
   ConfirmEmailChangeInput,
   ConfirmEmailChangeResult,
   GetPendingEmailChangeResult,
-  GetUserEmailSettingsResult,
   LinkUserToGoogleInput,
   LinkUserToGoogleResult,
   PendingEmailChange,
@@ -48,7 +47,6 @@ import { UpdateUserEmailSettingUseCase } from '../../application/command/update-
 import { UpdateUserPasswordUseCase } from '../../application/command/update-user-password.use-case'
 import { UpdateUserPictureFromSocialUseCase } from '../../application/command/update-user-picture-from-social.use-case'
 import { GetPendingEmailChangeUseCase } from '../../application/query/get-pending-email-change.use-case'
-import { GetUserEmailSettingUseCase } from '../../application/query/get-user-email-setting.use-case'
 import {
   ChangeUserPasswordInputSchema,
   ConfirmEmailChangeInputSchema,
@@ -76,13 +74,12 @@ export class UserResolver {
     private readonly confirmEmailChangeUseCase: ConfirmEmailChangeUseCase,
     private readonly getPendingEmailChangeUseCase: GetPendingEmailChangeUseCase,
     private readonly updateUserEmailSettingUseCase: UpdateUserEmailSettingUseCase,
-    private readonly getUserEmailSettingUseCase: GetUserEmailSettingUseCase,
     private readonly createPasswordVerificationUseCase: CreatePasswordVerificationUseCase,
     private readonly resetUserPasswordUseCase: ResetUserPasswordUseCase,
   ) {}
 
   @Query()
-  async getCurrentUser(@GqlCurrentUser('id') currentUserId: UserId, @Context() ctx: GraphQLContext): Promise<User> {
+  async currentUser(@GqlCurrentUser('id') currentUserId: UserId, @Context() ctx: GraphQLContext): Promise<User> {
     const user = await ctx.loaders.user.load(currentUserId)
     if (!user) {
       throw new Error('User not found')
@@ -118,7 +115,7 @@ export class UserResolver {
   }
 
   @Mutation()
-  async linkCurrentUserlWithGoogle(
+  async linkCurrentUserWithGoogle(
     @Args('input', new ZodPipe(LinkUserToGoogleInputSchema)) input: LinkUserToGoogleInput,
     @GqlCurrentUser('id') currentUserId: UserId,
     @Context() ctx: GraphQLContext,
@@ -198,9 +195,7 @@ export class UserResolver {
   }
 
   @Query()
-  async getPendingEmailChange(
-    @GqlCurrentUser() currentUser: ICurrentUser,
-  ): Promise<GetPendingEmailChangeResult | null> {
+  async pendingEmailChange(@GqlCurrentUser() currentUser: ICurrentUser): Promise<GetPendingEmailChangeResult | null> {
     const result = await this.getPendingEmailChangeUseCase.execute({ currentUser })
 
     if (!result) {
@@ -238,18 +233,6 @@ export class UserResolver {
       token: input.token,
     })
     return { __typename: 'VoidOutput', success: true }
-  }
-
-  @Query()
-  async getUserEmailSettings(@GqlCurrentUser() currentUser: ICurrentUser): Promise<GetUserEmailSettingsResult> {
-    const result = await this.getUserEmailSettingUseCase.execute({ currentUser })
-
-    const settings: UserEmailSettings = {
-      __typename: 'UserEmailSettings',
-      dailyNewItemNotification: result.daily_new_item_notification,
-    }
-
-    return settings
   }
 
   @Mutation()

--- a/apps/api/src/user/infrastructure/user-admin.graphql
+++ b/apps/api/src/user/infrastructure/user-admin.graphql
@@ -76,8 +76,8 @@ union AdminRemoveUserPictureResult =
   | InternalErrorRejection
 
 extend type Query {
-  adminGetUserById(userId: UserId!): AdminGetUserByIdResult!
-  adminGetAllUsers(input: AdminGetAllUsersPaginationFilters): AdminGetAllUsersResult!
+  user(userId: UserId!): AdminGetUserByIdResult!
+  users(input: AdminGetAllUsersPaginationFilters): AdminGetAllUsersResult!
 }
 
 extend type Mutation {

--- a/apps/api/src/user/infrastructure/user.graphql
+++ b/apps/api/src/user/infrastructure/user.graphql
@@ -22,6 +22,7 @@ type User {
   createdAt: String!
   updatedAt: String!
   socials: [UserSocial!] @resolved
+  emailSettings: UserEmailSettings @resolved
 }
 
 type PendingEmailChange {
@@ -37,12 +38,6 @@ union GetCurrentUserResult = User | UnauthorizedRejection | ForbiddenRejection |
 
 union GetPendingEmailChangeResult =
   | PendingEmailChange
-  | UnauthorizedRejection
-  | ForbiddenRejection
-  | InternalErrorRejection
-
-union GetUserEmailSettingsResult =
-  | UserEmailSettings
   | UnauthorizedRejection
   | ForbiddenRejection
   | InternalErrorRejection
@@ -182,14 +177,13 @@ union ResetPasswordResult =
   | InternalErrorRejection
 
 extend type Query {
-  getCurrentUser: GetCurrentUserResult!
-  getPendingEmailChange: GetPendingEmailChangeResult
-  getUserEmailSettings: GetUserEmailSettingsResult!
+  currentUser: GetCurrentUserResult!
+  pendingEmailChange: GetPendingEmailChangeResult
 }
 
 extend type Mutation {
   registerUser(input: RegisterUserInput!): RegisterUserResult!
-  linkCurrentUserlWithGoogle(input: LinkUserToGoogleInput!): LinkUserToGoogleResult!
+  linkCurrentUserWithGoogle(input: LinkUserToGoogleInput!): LinkUserToGoogleResult!
   unlinkCurrentUserSocial(socialId: UserSocialId!): UnlinkCurrentUserSocialResult!
   updateUserProfile(input: UpdateUserProfileInput!): UpdateUserProfileResult!
   changeUserPassword(input: ChangeUserPasswordInput!): ChangeUserPasswordResult!

--- a/apps/api/src/wishlist/infrastructure/resolvers/wishlist.resolver.int-spec.ts
+++ b/apps/api/src/wishlist/infrastructure/resolvers/wishlist.resolver.int-spec.ts
@@ -36,10 +36,10 @@ describe('WishlistResolver (GraphQL)', () => {
     currentUserId = await fixtures.getSignedUserId('BASE_USER')
   })
 
-  describe('Query getWishlistById', () => {
+  describe('Query wishlist', () => {
     const query = /* GraphQL */ `
       query GetWishlistById($id: WishlistId!) {
-        getWishlistById(id: $id) {
+        wishlist(id: $id) {
           __typename
           ... on Wishlist {
             id
@@ -93,7 +93,7 @@ describe('WishlistResolver (GraphQL)', () => {
         .send({ query, variables: { id: wishlistId } })
         .expect(200)
 
-      expectNotSucceeded(res.body, 'getWishlistById')
+      expectNotSucceeded(res.body, 'wishlist')
     })
 
     it('should return the wishlist with nested owner, coOwner and events on happy path', async () => {
@@ -125,7 +125,7 @@ describe('WishlistResolver (GraphQL)', () => {
         .expect(200)
 
       expect(res.body.errors).toBeUndefined()
-      expect(res.body.data.getWishlistById).toMatchObject({
+      expect(res.body.data.wishlist).toMatchObject({
         __typename: 'Wishlist',
         id: wishlistId,
         title: 'My wishlist',
@@ -164,7 +164,7 @@ describe('WishlistResolver (GraphQL)', () => {
         .send({ query, variables: { id: wishlistId } })
         .expect(200)
 
-      expect(res.body.data.getWishlistById).toMatchObject({
+      expect(res.body.data.wishlist).toMatchObject({
         __typename: 'Wishlist',
         id: wishlistId,
         coOwnerId: null,
@@ -200,7 +200,7 @@ describe('WishlistResolver (GraphQL)', () => {
         .send({ query, variables: { id: wishlistId } })
         .expect(200)
 
-      const wishlist = res.body.data.getWishlistById
+      const wishlist = res.body.data.wishlist
       expect(wishlist.__typename).toBe('Wishlist')
       expect(wishlist.eventIds).toEqual(expect.arrayContaining([accessibleEventId, hiddenEventId]))
       // events field-resolver filters out events the user cannot access
@@ -213,7 +213,7 @@ describe('WishlistResolver (GraphQL)', () => {
         .send({ query, variables: { id: uuid() } })
         .expect(200)
 
-      expect(res.body.data.getWishlistById).toMatchObject({
+      expect(res.body.data.wishlist).toMatchObject({
         __typename: 'NotFoundRejection',
       })
     })
@@ -239,16 +239,16 @@ describe('WishlistResolver (GraphQL)', () => {
         .send({ query, variables: { id: wishlistId } })
         .expect(200)
 
-      expect(res.body.data.getWishlistById).toMatchObject({
+      expect(res.body.data.wishlist).toMatchObject({
         __typename: 'NotFoundRejection',
       })
     })
   })
 
-  describe('Query getMyWishlists', () => {
+  describe('Query wishlists', () => {
     const query = /* GraphQL */ `
       query GetMyWishlists($filters: PaginationFilters!) {
-        getMyWishlists(filters: $filters) {
+        wishlists(filters: $filters) {
           __typename
           ... on GetWishlistsPagedResponse {
             data {
@@ -286,7 +286,7 @@ describe('WishlistResolver (GraphQL)', () => {
         .send({ query, variables: { filters: {} } })
         .expect(200)
 
-      expectNotSucceeded(res.body, 'getMyWishlists')
+      expectNotSucceeded(res.body, 'wishlists')
     })
 
     it('should return only the wishlists owned by the current user with nested fields', async () => {
@@ -319,7 +319,7 @@ describe('WishlistResolver (GraphQL)', () => {
         .expect(200)
 
       expect(res.body.errors).toBeUndefined()
-      const result = res.body.data.getMyWishlists
+      const result = res.body.data.wishlists
       expect(result.__typename).toBe('GetWishlistsPagedResponse')
       expect(result.data).toHaveLength(1)
       expect(result.data[0]).toMatchObject({
@@ -356,7 +356,7 @@ describe('WishlistResolver (GraphQL)', () => {
         .send({ query, variables: { filters: {} } })
         .expect(200)
 
-      const result = res.body.data.getMyWishlists
+      const result = res.body.data.wishlists
       expect(result.__typename).toBe('GetWishlistsPagedResponse')
       expect(result.data).toHaveLength(10)
       expect(result.pagination).toMatchObject({
@@ -386,7 +386,7 @@ describe('WishlistResolver (GraphQL)', () => {
         .send({ query, variables: { filters: { page: 2, limit: 2 } } })
         .expect(200)
 
-      const result = res.body.data.getMyWishlists
+      const result = res.body.data.wishlists
       expect(result.__typename).toBe('GetWishlistsPagedResponse')
       expect(result.data).toHaveLength(2)
       expect(result.pagination).toMatchObject({
@@ -403,7 +403,7 @@ describe('WishlistResolver (GraphQL)', () => {
         .send({ query, variables: { filters: {} } })
         .expect(200)
 
-      const result = res.body.data.getMyWishlists
+      const result = res.body.data.wishlists
       expect(result.__typename).toBe('GetWishlistsPagedResponse')
       expect(result.data).toEqual([])
       expect(result.pagination).toMatchObject({
@@ -421,7 +421,7 @@ describe('WishlistResolver (GraphQL)', () => {
     ])('should not succeed with invalid pagination filters: $case', async ({ filters }) => {
       const res = await request.post('/graphql').send({ query, variables: { filters } }).expect(200)
 
-      expectNotSucceeded(res.body, 'getMyWishlists')
+      expectNotSucceeded(res.body, 'wishlists')
     })
 
     it('should not leak wishlists between users and keep DB state unchanged (read-only query)', async () => {
@@ -450,7 +450,7 @@ describe('WishlistResolver (GraphQL)', () => {
         .send({ query, variables: { filters: {} } })
         .expect(200)
 
-      expect(res.body.data.getMyWishlists.data).toHaveLength(1)
+      expect(res.body.data.wishlists.data).toHaveLength(1)
       // a read-only query must not mutate the table
       await expectTable(Fixtures.WISHLIST_TABLE).hasNumberOfRows(2)
     })

--- a/apps/api/src/wishlist/infrastructure/resolvers/wishlist.resolver.ts
+++ b/apps/api/src/wishlist/infrastructure/resolvers/wishlist.resolver.ts
@@ -13,7 +13,7 @@ export class WishlistResolver {
   constructor(private readonly getWishlistsByUserUseCase: GetWishlistsByUserUseCase) {}
 
   @Query()
-  async getWishlistById(
+  async wishlist(
     @Args('id', { type: () => String }) id: WishlistId,
     @Context() ctx: GraphQLContext,
   ): Promise<GetWishlistByIdResult> {
@@ -25,7 +25,7 @@ export class WishlistResolver {
   }
 
   @Query()
-  async getMyWishlists(
+  async wishlists(
     @Args('filters', new ZodPipe(PaginationFiltersSchema)) filters: PaginationFilters,
     @GqlCurrentUser('id') currentUserId: UserId,
   ): Promise<GetMyWishlistsResult> {

--- a/apps/api/src/wishlist/infrastructure/wishlist.graphql
+++ b/apps/api/src/wishlist/infrastructure/wishlist.graphql
@@ -40,6 +40,6 @@ union GetMyWishlistsResult =
   | InternalErrorRejection
 
 extend type Query {
-  getWishlistById(id: WishlistId!): GetWishlistByIdResult
-  getMyWishlists(filters: PaginationFilters!): GetMyWishlistsResult!
+  wishlist(id: WishlistId!): GetWishlistByIdResult
+  wishlists(filters: PaginationFilters!): GetMyWishlistsResult!
 }

--- a/apps/front/src/components/wishlist/WishlistPage.graphql
+++ b/apps/front/src/components/wishlist/WishlistPage.graphql
@@ -1,5 +1,5 @@
 query WishlistPage($wishlistId: WishlistId!) {
-  getWishlistById(id: $wishlistId) {
+  wishlist(id: $wishlistId) {
     ... on Wishlist {
       id
       title

--- a/apps/front/src/gql/__generated__/graphql.ts
+++ b/apps/front/src/gql/__generated__/graphql.ts
@@ -5,7 +5,7 @@ import { fetchGql } from '../fetcher';
 
 export const WishlistPageDocument = `
     query WishlistPage($wishlistId: WishlistId!) {
-  getWishlistById(id: $wishlistId) {
+  wishlist(id: $wishlistId) {
     ... on Wishlist {
       id
       title

--- a/apps/front/src/gql/__generated__/types.ts
+++ b/apps/front/src/gql/__generated__/types.ts
@@ -16,10 +16,23 @@ export type Scalars = {
   AttendeeId: { input: Ids["AttendeeId"]; output: Ids["AttendeeId"]; }
   EventId: { input: Ids["EventId"]; output: Ids["EventId"]; }
   ItemId: { input: Ids["ItemId"]; output: Ids["ItemId"]; }
+  SecretSantaId: { input: Ids["SecretSantaId"]; output: Ids["SecretSantaId"]; }
+  SecretSantaUserId: { input: Ids["SecretSantaUserId"]; output: Ids["SecretSantaUserId"]; }
   UserId: { input: Ids["UserId"]; output: Ids["UserId"]; }
   UserSocialId: { input: Ids["UserSocialId"]; output: Ids["UserSocialId"]; }
   WishlistId: { input: Ids["WishlistId"]; output: Ids["WishlistId"]; }
 };
+
+export type AddSecretSantaUsersInput = {
+  attendeeIds: Array<Scalars['AttendeeId']['input']>;
+};
+
+export type AddSecretSantaUsersOutput = {
+  __typename?: 'AddSecretSantaUsersOutput';
+  users: Array<SecretSantaUser>;
+};
+
+export type AddSecretSantaUsersResult = AddSecretSantaUsersOutput | ForbiddenRejection | InternalErrorRejection | UnauthorizedRejection | ValidationRejection;
 
 export type AdminDeleteUserResult = ForbiddenRejection | InternalErrorRejection | UnauthorizedRejection | ValidationRejection | VoidOutput;
 
@@ -57,6 +70,8 @@ export enum AttendeeRole {
   User = 'USER'
 }
 
+export type CancelSecretSantaResult = ForbiddenRejection | InternalErrorRejection | UnauthorizedRejection | VoidOutput;
+
 export type ChangeUserPasswordInput = {
   newPassword: Scalars['String']['input'];
   oldPassword: Scalars['String']['input'];
@@ -82,7 +97,19 @@ export type CreateItemInput = {
 
 export type CreateItemResult = ForbiddenRejection | InternalErrorRejection | Item | UnauthorizedRejection | ValidationRejection;
 
+export type CreateSecretSantaInput = {
+  budget?: InputMaybe<Scalars['Int']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  eventId: Scalars['EventId']['input'];
+};
+
+export type CreateSecretSantaResult = ForbiddenRejection | InternalErrorRejection | SecretSanta | UnauthorizedRejection | ValidationRejection;
+
 export type DeleteItemResult = ForbiddenRejection | InternalErrorRejection | UnauthorizedRejection | ValidationRejection | VoidOutput;
+
+export type DeleteSecretSantaResult = ForbiddenRejection | InternalErrorRejection | UnauthorizedRejection | VoidOutput;
+
+export type DeleteSecretSantaUserResult = ForbiddenRejection | InternalErrorRejection | UnauthorizedRejection | VoidOutput;
 
 export type Event = {
   __typename?: 'Event';
@@ -144,11 +171,13 @@ export type GetImportableItemsResult = ForbiddenRejection | GetImportableItemsOu
 
 export type GetMyEventsResult = ForbiddenRejection | GetEventsPagedResponse | InternalErrorRejection | UnauthorizedRejection;
 
+export type GetMySecretSantaDrawResult = EventAttendee | ForbiddenRejection | InternalErrorRejection | UnauthorizedRejection;
+
 export type GetMyWishlistsResult = ForbiddenRejection | GetWishlistsPagedResponse | InternalErrorRejection | UnauthorizedRejection;
 
 export type GetPendingEmailChangeResult = ForbiddenRejection | InternalErrorRejection | PendingEmailChange | UnauthorizedRejection;
 
-export type GetUserEmailSettingsResult = ForbiddenRejection | InternalErrorRejection | UnauthorizedRejection | UserEmailSettings;
+export type GetSecretSantaForEventResult = ForbiddenRejection | InternalErrorRejection | SecretSanta | UnauthorizedRejection;
 
 export type GetWishlistByIdResult = ForbiddenRejection | InternalErrorRejection | NotFoundRejection | UnauthorizedRejection | Wishlist;
 
@@ -235,15 +264,20 @@ export type LoginWithGoogleResult = InternalErrorRejection | LoginWithGoogleOutp
 
 export type Mutation = {
   __typename?: 'Mutation';
+  addSecretSantaUsers: AddSecretSantaUsersResult;
   adminDeleteUser: AdminDeleteUserResult;
   adminRemoveUserPicture: AdminRemoveUserPictureResult;
   adminUpdateUserProfile: AdminUpdateUserProfileResult;
+  cancelSecretSanta: CancelSecretSantaResult;
   changeUserPassword: ChangeUserPasswordResult;
   confirmEmailChange: ConfirmEmailChangeResult;
   createItem: CreateItemResult;
+  createSecretSanta: CreateSecretSantaResult;
   deleteItem: DeleteItemResult;
+  deleteSecretSanta: DeleteSecretSantaResult;
+  deleteSecretSantaUser: DeleteSecretSantaUserResult;
   importItems: ImportItemsResult;
-  linkCurrentUserlWithGoogle: LinkUserToGoogleResult;
+  linkCurrentUserWithGoogle: LinkUserToGoogleResult;
   login: LoginResult;
   loginWithGoogle: LoginWithGoogleResult;
   registerUser: RegisterUserResult;
@@ -252,12 +286,21 @@ export type Mutation = {
   resetPassword: ResetPasswordResult;
   scanItemUrl: ScanItemUrlResult;
   sendResetPasswordEmail: SendResetPasswordEmailResult;
+  startSecretSanta: StartSecretSantaResult;
   toggleItem: ToggleItemResult;
   unlinkCurrentUserSocial: UnlinkCurrentUserSocialResult;
   updateItem: UpdateItemResult;
+  updateSecretSanta: UpdateSecretSantaResult;
+  updateSecretSantaUser: UpdateSecretSantaUserResult;
   updateUserEmailSettings: UpdateUserEmailSettingsResult;
   updateUserPictureFromSocial: UpdateUserPictureFromSocialResult;
   updateUserProfile: UpdateUserProfileResult;
+};
+
+
+export type MutationAddSecretSantaUsersArgs = {
+  id: Scalars['SecretSantaId']['input'];
+  input: AddSecretSantaUsersInput;
 };
 
 
@@ -277,6 +320,11 @@ export type MutationAdminUpdateUserProfileArgs = {
 };
 
 
+export type MutationCancelSecretSantaArgs = {
+  id: Scalars['SecretSantaId']['input'];
+};
+
+
 export type MutationChangeUserPasswordArgs = {
   input: ChangeUserPasswordInput;
 };
@@ -292,8 +340,24 @@ export type MutationCreateItemArgs = {
 };
 
 
+export type MutationCreateSecretSantaArgs = {
+  input: CreateSecretSantaInput;
+};
+
+
 export type MutationDeleteItemArgs = {
   itemId: Scalars['ItemId']['input'];
+};
+
+
+export type MutationDeleteSecretSantaArgs = {
+  id: Scalars['SecretSantaId']['input'];
+};
+
+
+export type MutationDeleteSecretSantaUserArgs = {
+  id: Scalars['SecretSantaId']['input'];
+  secretSantaUserId: Scalars['SecretSantaUserId']['input'];
 };
 
 
@@ -302,7 +366,7 @@ export type MutationImportItemsArgs = {
 };
 
 
-export type MutationLinkCurrentUserlWithGoogleArgs = {
+export type MutationLinkCurrentUserWithGoogleArgs = {
   input: LinkUserToGoogleInput;
 };
 
@@ -342,6 +406,11 @@ export type MutationSendResetPasswordEmailArgs = {
 };
 
 
+export type MutationStartSecretSantaArgs = {
+  id: Scalars['SecretSantaId']['input'];
+};
+
+
 export type MutationToggleItemArgs = {
   itemId: Scalars['ItemId']['input'];
 };
@@ -355,6 +424,19 @@ export type MutationUnlinkCurrentUserSocialArgs = {
 export type MutationUpdateItemArgs = {
   input: UpdateItemInput;
   itemId: Scalars['ItemId']['input'];
+};
+
+
+export type MutationUpdateSecretSantaArgs = {
+  id: Scalars['SecretSantaId']['input'];
+  input: UpdateSecretSantaInput;
+};
+
+
+export type MutationUpdateSecretSantaUserArgs = {
+  id: Scalars['SecretSantaId']['input'];
+  input: UpdateSecretSantaUserInput;
+  secretSantaUserId: Scalars['SecretSantaUserId']['input'];
 };
 
 
@@ -398,52 +480,63 @@ export type PendingEmailChange = {
 
 export type Query = {
   __typename?: 'Query';
-  adminGetAllUsers: AdminGetAllUsersResult;
-  adminGetUserById: AdminGetUserByIdResult;
-  getCurrentUser: GetCurrentUserResult;
-  getEventById?: Maybe<GetEventByIdResult>;
-  getImportableItems: GetImportableItemsResult;
-  getMyEvents: GetMyEventsResult;
-  getMyWishlists: GetMyWishlistsResult;
-  getPendingEmailChange?: Maybe<GetPendingEmailChangeResult>;
-  getUserEmailSettings: GetUserEmailSettingsResult;
-  getWishlistById?: Maybe<GetWishlistByIdResult>;
+  currentUser: GetCurrentUserResult;
+  event?: Maybe<GetEventByIdResult>;
+  events: GetMyEventsResult;
   health: HealthResult;
+  importableItems: GetImportableItemsResult;
+  mySecretSantaDraw?: Maybe<GetMySecretSantaDrawResult>;
+  pendingEmailChange?: Maybe<GetPendingEmailChangeResult>;
+  secretSanta?: Maybe<GetSecretSantaForEventResult>;
+  user: AdminGetUserByIdResult;
+  users: AdminGetAllUsersResult;
+  wishlist?: Maybe<GetWishlistByIdResult>;
+  wishlists: GetMyWishlistsResult;
 };
 
 
-export type QueryAdminGetAllUsersArgs = {
-  input?: InputMaybe<AdminGetAllUsersPaginationFilters>;
-};
-
-
-export type QueryAdminGetUserByIdArgs = {
-  userId: Scalars['UserId']['input'];
-};
-
-
-export type QueryGetEventByIdArgs = {
+export type QueryEventArgs = {
   id: Scalars['EventId']['input'];
 };
 
 
-export type QueryGetImportableItemsArgs = {
-  wishlistId: Scalars['WishlistId']['input'];
-};
-
-
-export type QueryGetMyEventsArgs = {
+export type QueryEventsArgs = {
   filters: EventPaginationFilters;
 };
 
 
-export type QueryGetMyWishlistsArgs = {
-  filters: PaginationFilters;
+export type QueryImportableItemsArgs = {
+  wishlistId: Scalars['WishlistId']['input'];
 };
 
 
-export type QueryGetWishlistByIdArgs = {
+export type QueryMySecretSantaDrawArgs = {
+  eventId: Scalars['EventId']['input'];
+};
+
+
+export type QuerySecretSantaArgs = {
+  eventId: Scalars['EventId']['input'];
+};
+
+
+export type QueryUserArgs = {
+  userId: Scalars['UserId']['input'];
+};
+
+
+export type QueryUsersArgs = {
+  input?: InputMaybe<AdminGetAllUsersPaginationFilters>;
+};
+
+
+export type QueryWishlistArgs = {
   id: Scalars['WishlistId']['input'];
+};
+
+
+export type QueryWishlistsArgs = {
+  filters: PaginationFilters;
 };
 
 export type RegisterUserInput = {
@@ -483,11 +576,39 @@ export type ScanItemUrlOutput = {
 
 export type ScanItemUrlResult = ForbiddenRejection | InternalErrorRejection | ScanItemUrlOutput | UnauthorizedRejection | ValidationRejection;
 
+export type SecretSanta = {
+  __typename?: 'SecretSanta';
+  budget?: Maybe<Scalars['Int']['output']>;
+  createdAt: Scalars['String']['output'];
+  description?: Maybe<Scalars['String']['output']>;
+  event: Event;
+  eventId: Scalars['EventId']['output'];
+  id: Scalars['SecretSantaId']['output'];
+  status: SecretSantaStatus;
+  updatedAt: Scalars['String']['output'];
+  users: Array<SecretSantaUser>;
+};
+
+export enum SecretSantaStatus {
+  Created = 'CREATED',
+  Started = 'STARTED'
+}
+
+export type SecretSantaUser = {
+  __typename?: 'SecretSantaUser';
+  attendee: EventAttendee;
+  attendeeId: Scalars['AttendeeId']['output'];
+  exclusions: Array<Scalars['SecretSantaUserId']['output']>;
+  id: Scalars['SecretSantaUserId']['output'];
+};
+
 export type SendResetPasswordEmailInput = {
   email: Scalars['String']['input'];
 };
 
 export type SendResetPasswordEmailResult = ForbiddenRejection | InternalErrorRejection | UnauthorizedRejection | ValidationRejection | VoidOutput;
+
+export type StartSecretSantaResult = ForbiddenRejection | InternalErrorRejection | UnauthorizedRejection | ValidationRejection | VoidOutput;
 
 export type ToggleItemOutput = {
   __typename?: 'ToggleItemOutput';
@@ -514,6 +635,19 @@ export type UpdateItemInput = {
 
 export type UpdateItemResult = ForbiddenRejection | InternalErrorRejection | UnauthorizedRejection | ValidationRejection | VoidOutput;
 
+export type UpdateSecretSantaInput = {
+  budget?: InputMaybe<Scalars['Int']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type UpdateSecretSantaResult = ForbiddenRejection | InternalErrorRejection | UnauthorizedRejection | ValidationRejection | VoidOutput;
+
+export type UpdateSecretSantaUserInput = {
+  exclusions: Array<Scalars['SecretSantaUserId']['input']>;
+};
+
+export type UpdateSecretSantaUserResult = ForbiddenRejection | InternalErrorRejection | UnauthorizedRejection | ValidationRejection | VoidOutput;
+
 export type UpdateUserEmailSettingsInput = {
   dailyNewItemNotification: Scalars['Boolean']['input'];
 };
@@ -539,6 +673,7 @@ export type User = {
   birthday?: Maybe<Scalars['String']['output']>;
   createdAt: Scalars['String']['output'];
   email: Scalars['String']['output'];
+  emailSettings?: Maybe<UserEmailSettings>;
   firstName: Scalars['String']['output'];
   id: Scalars['UserId']['output'];
   isEnabled: Scalars['Boolean']['output'];
@@ -625,7 +760,7 @@ export type WishlistPageQueryVariables = Exact<{
 }>;
 
 
-export type WishlistPageQuery = { __typename?: 'Query', getWishlistById?:
+export type WishlistPageQuery = { __typename?: 'Query', wishlist?:
     | { __typename?: 'ForbiddenRejection' }
     | { __typename?: 'InternalErrorRejection' }
     | { __typename: 'NotFoundRejection' }


### PR DESCRIPTION
## Summary

Renames `get`-prefixed GraphQL **Query** fields to concise, noun-style names across resolvers, SDL schema files, and resolver integration tests. No behavior changes — only field/method names (and the regenerated codegen output).

This branch is rebased on top of `main` (which already includes the secret-santa GraphQL resolver work via #259), so the diff is **only** the rename commit.

## Renames

| Domain | Before | After |
|---|---|---|
| wishlist | `getWishlistById` / `getMyWishlists` | `wishlist` / `wishlists` |
| event | `getEventById` / `getMyEvents` | `event` / `events` |
| secret-santa | `getSecretSantaForEvent` / `getMySecretSantaDraw` | `secretSanta` / `mySecretSantaDraw` |
| item | `getImportableItems` | `importableItems` |
| user | `getCurrentUser` / `getPendingEmailChange` | `currentUser` / `pendingEmailChange` |
| user-admin | `adminGetUserById(userId)` / `adminGetAllUsers(input)` | `user(userId)` / `users(input)` |

## Also in this PR

- **`getUserEmailSettings` → `User.emailSettings` field resolver.** Converted from a top-level query into a `@ResolveField` on the `User` type (`emailSettings: UserEmailSettings @resolved`), modeled on the existing `socials` resolver — returns `null` when the parent user isn't the current user.
- **Typo fix:** `linkCurrentUserlWithGoogle` mutation → `linkCurrentUserWithGoogle`.
- Updated the `WishlistPage` frontend GraphQL document.
- Regenerated API + frontend GraphQL codegen (`schema.graphql`, `generated-types.ts`, frontend `__generated__`).

## Out of scope (deliberately untouched)

- Result **union** type names (`GetWishlistByIdResult`, etc.) are unchanged.
- REST controllers and the `api-client` — some share method names by coincidence (e.g. `api.item.getImportableItems` is REST, not GraphQL).
- All other mutations.

## Verification (rebased on current main)

- ✅ `yarn typecheck` — 8 projects pass
- ✅ `yarn check` (Biome) — clean
- ✅ Codegen regenerated, no drift
- ✅ Integration tests (`vitest` resolver int-specs) — **177 tests across 7 files pass**

🤖 Generated with [Claude Code](https://claude.com/claude-code)