### PR TITLE
feat(api): expose missing operations via GraphQL (event, wishlist, user)

### DIFF
--- a/apps/api/schema.graphql
+++ b/apps/api/schema.graphql
@@ -10,6 +10,13 @@ schema {
 
 directive @resolved on FIELD_DEFINITION
 
+input AddEventAttendeeInput {
+  email: String!
+  role: AttendeeRole
+}
+
+union AddEventAttendeeResult = EventAttendee | ForbiddenRejection | InternalErrorRejection | NotFoundRejection | UnauthorizedRejection | ValidationRejection
+
 input AddSecretSantaUsersInput {
   attendeeIds: [AttendeeId!]!
 }
@@ -20,7 +27,23 @@ type AddSecretSantaUsersOutput {
 
 union AddSecretSantaUsersResult = AddSecretSantaUsersOutput | ForbiddenRejection | InternalErrorRejection | UnauthorizedRejection | ValidationRejection
 
+input AddWishlistCoOwnerInput {
+  userId: UserId!
+}
+
+union AddWishlistCoOwnerResult = ForbiddenRejection | InternalErrorRejection | NotFoundRejection | UnauthorizedRejection | ValidationRejection | VoidOutput
+
+union AdminDeleteEventAttendeeResult = ForbiddenRejection | InternalErrorRejection | NotFoundRejection | UnauthorizedRejection | ValidationRejection | VoidOutput
+
+union AdminDeleteEventResult = ForbiddenRejection | InternalErrorRejection | NotFoundRejection | UnauthorizedRejection | ValidationRejection | VoidOutput
+
 union AdminDeleteUserResult = ForbiddenRejection | InternalErrorRejection | UnauthorizedRejection | ValidationRejection | VoidOutput
+
+input AdminEventPaginationFilters {
+  limit: Int
+  page: Int
+  userId: UserId
+}
 
 type AdminGetAllUsers {
   data: [UserFull!]!
@@ -35,9 +58,22 @@ input AdminGetAllUsersPaginationFilters {
 
 union AdminGetAllUsersResult = AdminGetAllUsers | ForbiddenRejection | InternalErrorRejection | UnauthorizedRejection | ValidationRejection
 
+union AdminGetEventByIdResult = Event | ForbiddenRejection | InternalErrorRejection | NotFoundRejection | UnauthorizedRejection | ValidationRejection
+
+union AdminGetEventsResult = ForbiddenRejection | GetEventsPagedResponse | InternalErrorRejection | UnauthorizedRejection | ValidationRejection
+
 union AdminGetUserByIdResult = ForbiddenRejection | InternalErrorRejection | UnauthorizedRejection | UserFull | ValidationRejection
 
+type AdminGetWishlists {
+  data: [Wishlist!]!
+  pagination: Pagination!
+}
+
+union AdminGetWishlistsResult = AdminGetWishlists | ForbiddenRejection | InternalErrorRejection | UnauthorizedRejection | ValidationRejection
+
 union AdminRemoveUserPictureResult = ForbiddenRejection | InternalErrorRejection | UnauthorizedRejection | ValidationRejection | VoidOutput
+
+union AdminUpdateEventResult = ForbiddenRejection | InternalErrorRejection | NotFoundRejection | UnauthorizedRejection | ValidationRejection | VoidOutput
 
 input AdminUpdateUserProfileInput {
   birthday: String
@@ -49,6 +85,12 @@ input AdminUpdateUserProfileInput {
 }
 
 union AdminUpdateUserProfileResult = ForbiddenRejection | InternalErrorRejection | UnauthorizedRejection | ValidationRejection | VoidOutput
+
+input AdminWishlistPaginationFilters {
+  limit: Int
+  page: Int
+  userId: UserId!
+}
 
 scalar AttendeeId
 
@@ -66,12 +108,33 @@ input ChangeUserPasswordInput {
 
 union ChangeUserPasswordResult = ForbiddenRejection | InternalErrorRejection | UnauthorizedRejection | ValidationRejection | VoidOutput
 
+type ClosestFriendsOutput {
+  users: [User!]!
+}
+
+union ClosestFriendsResult = ClosestFriendsOutput | ForbiddenRejection | InternalErrorRejection | UnauthorizedRejection | ValidationRejection
+
 input ConfirmEmailChangeInput {
   newEmail: String!
   token: String!
 }
 
 union ConfirmEmailChangeResult = ForbiddenRejection | InternalErrorRejection | UnauthorizedRejection | ValidationRejection | VoidOutput
+
+input CreateEventAttendeeInput {
+  email: String!
+  role: AttendeeRole
+}
+
+input CreateEventInput {
+  attendees: [CreateEventAttendeeInput!]
+  description: String
+  eventDate: String!
+  icon: String
+  title: String!
+}
+
+union CreateEventResult = Event | ForbiddenRejection | InternalErrorRejection | NotFoundRejection | UnauthorizedRejection | ValidationRejection
 
 input CreateItemInput {
   description: String
@@ -92,11 +155,15 @@ input CreateSecretSantaInput {
 
 union CreateSecretSantaResult = ForbiddenRejection | InternalErrorRejection | SecretSanta | UnauthorizedRejection | ValidationRejection
 
+union DeleteEventResult = ForbiddenRejection | InternalErrorRejection | NotFoundRejection | UnauthorizedRejection | ValidationRejection | VoidOutput
+
 union DeleteItemResult = ForbiddenRejection | InternalErrorRejection | UnauthorizedRejection | ValidationRejection | VoidOutput
 
 union DeleteSecretSantaResult = ForbiddenRejection | InternalErrorRejection | UnauthorizedRejection | VoidOutput
 
 union DeleteSecretSantaUserResult = ForbiddenRejection | InternalErrorRejection | UnauthorizedRejection | VoidOutput
+
+union DeleteWishlistResult = ForbiddenRejection | InternalErrorRejection | NotFoundRejection | UnauthorizedRejection | ValidationRejection | VoidOutput
 
 type Event {
   attendeeIds: [AttendeeId!]!
@@ -216,6 +283,8 @@ input LinkUserToGoogleInput {
 
 union LinkUserToGoogleResult = ForbiddenRejection | InternalErrorRejection | UnauthorizedRejection | UserSocial | ValidationRejection
 
+union LinkWishlistToEventResult = ForbiddenRejection | InternalErrorRejection | NotFoundRejection | UnauthorizedRejection | ValidationRejection | VoidOutput
+
 input LoginInput {
   email: String!
   password: String!
@@ -241,24 +310,36 @@ type LoginWithGoogleOutput {
 union LoginWithGoogleResult = InternalErrorRejection | LoginWithGoogleOutput | UnauthorizedRejection | ValidationRejection
 
 type Mutation {
+  addEventAttendee(eventId: EventId!, input: AddEventAttendeeInput!): AddEventAttendeeResult!
   addSecretSantaUsers(id: SecretSantaId!, input: AddSecretSantaUsersInput!): AddSecretSantaUsersResult!
+  addWishlistCoOwner(id: WishlistId!, input: AddWishlistCoOwnerInput!): AddWishlistCoOwnerResult!
+  adminDeleteEvent(id: EventId!): AdminDeleteEventResult!
+  adminDeleteEventAttendee(attendeeId: AttendeeId!, eventId: EventId!): AdminDeleteEventAttendeeResult!
   adminDeleteUser(userId: UserId!): AdminDeleteUserResult!
   adminRemoveUserPicture(userId: UserId!): AdminRemoveUserPictureResult!
+  adminUpdateEvent(id: EventId!, input: UpdateEventInput!): AdminUpdateEventResult!
   adminUpdateUserProfile(input: AdminUpdateUserProfileInput!, userId: UserId!): AdminUpdateUserProfileResult!
   cancelSecretSanta(id: SecretSantaId!): CancelSecretSantaResult!
   changeUserPassword(input: ChangeUserPasswordInput!): ChangeUserPasswordResult!
   confirmEmailChange(input: ConfirmEmailChangeInput!): ConfirmEmailChangeResult!
+  createEvent(input: CreateEventInput!): CreateEventResult!
   createItem(input: CreateItemInput!): CreateItemResult!
   createSecretSanta(input: CreateSecretSantaInput!): CreateSecretSantaResult!
+  deleteEvent(id: EventId!): DeleteEventResult!
   deleteItem(itemId: ItemId!): DeleteItemResult!
   deleteSecretSanta(id: SecretSantaId!): DeleteSecretSantaResult!
   deleteSecretSantaUser(id: SecretSantaId!, secretSantaUserId: SecretSantaUserId!): DeleteSecretSantaUserResult!
+  deleteWishlist(id: WishlistId!): DeleteWishlistResult!
   importItems(input: ImportItemsInput!): ImportItemsResult!
   linkCurrentUserWithGoogle(input: LinkUserToGoogleInput!): LinkUserToGoogleResult!
+  linkWishlistToEvent(eventId: EventId!, id: WishlistId!): LinkWishlistToEventResult!
   login(input: LoginInput!): LoginResult!
   loginWithGoogle(input: LoginWithGoogleInput!): LoginWithGoogleResult!
   registerUser(input: RegisterUserInput!): RegisterUserResult!
+  removeEventAttendee(attendeeId: AttendeeId!, eventId: EventId!): RemoveEventAttendeeResult!
   removeUserPicture: RemoveUserPictureResult!
+  removeWishlistCoOwner(id: WishlistId!): RemoveWishlistCoOwnerResult!
+  removeWishlistLogo(id: WishlistId!): RemoveWishlistLogoResult!
   requestEmailChange(input: RequestEmailChangeInput!): RequestEmailChangeResult!
   resetPassword(input: ResetPasswordInput!): ResetPasswordResult!
   scanItemUrl(input: ScanItemUrlInput!): ScanItemUrlResult!
@@ -266,12 +347,15 @@ type Mutation {
   startSecretSanta(id: SecretSantaId!): StartSecretSantaResult!
   toggleItem(itemId: ItemId!): ToggleItemResult!
   unlinkCurrentUserSocial(socialId: UserSocialId!): UnlinkCurrentUserSocialResult!
+  unlinkWishlistFromEvent(eventId: EventId!, id: WishlistId!): UnlinkWishlistFromEventResult!
+  updateEvent(id: EventId!, input: UpdateEventInput!): UpdateEventResult!
   updateItem(input: UpdateItemInput!, itemId: ItemId!): UpdateItemResult!
   updateSecretSanta(id: SecretSantaId!, input: UpdateSecretSantaInput!): UpdateSecretSantaResult!
   updateSecretSantaUser(id: SecretSantaId!, input: UpdateSecretSantaUserInput!, secretSantaUserId: SecretSantaUserId!): UpdateSecretSantaUserResult!
   updateUserEmailSettings(input: UpdateUserEmailSettingsInput!): UpdateUserEmailSettingsResult!
   updateUserPictureFromSocial(input: UpdateUserPictureFromSocialInput!): UpdateUserPictureFromSocialResult!
   updateUserProfile(input: UpdateUserProfileInput!): UpdateUserProfileResult!
+  updateWishlist(id: WishlistId!, input: UpdateWishlistInput!): UpdateWishlistResult!
 }
 
 type NotFoundRejection {
@@ -296,6 +380,12 @@ type PendingEmailChange {
 }
 
 type Query {
+  adminEvent(id: EventId!): AdminGetEventByIdResult!
+  adminEvents(filters: AdminEventPaginationFilters!): AdminGetEventsResult!
+  adminUser(userId: UserId!): AdminGetUserByIdResult!
+  adminUsers(input: AdminGetAllUsersPaginationFilters): AdminGetAllUsersResult!
+  adminWishlists(filters: AdminWishlistPaginationFilters!): AdminGetWishlistsResult!
+  closestFriends(limit: Int): ClosestFriendsResult!
   currentUser: GetCurrentUserResult!
   event(id: EventId!): GetEventByIdResult
   events(filters: EventPaginationFilters!): GetMyEventsResult!
@@ -303,9 +393,8 @@ type Query {
   importableItems(wishlistId: WishlistId!): GetImportableItemsResult!
   mySecretSantaDraw(eventId: EventId!): GetMySecretSantaDrawResult
   pendingEmailChange: GetPendingEmailChangeResult
+  searchUsers(keyword: String!): SearchUsersResult!
   secretSanta(eventId: EventId!): GetSecretSantaForEventResult
-  user(userId: UserId!): AdminGetUserByIdResult!
-  users(input: AdminGetAllUsersPaginationFilters): AdminGetAllUsersResult!
   wishlist(id: WishlistId!): GetWishlistByIdResult
   wishlists(filters: PaginationFilters!): GetMyWishlistsResult!
 }
@@ -320,7 +409,13 @@ input RegisterUserInput {
 
 union RegisterUserResult = ForbiddenRejection | InternalErrorRejection | UnauthorizedRejection | User | ValidationRejection
 
+union RemoveEventAttendeeResult = ForbiddenRejection | InternalErrorRejection | NotFoundRejection | UnauthorizedRejection | ValidationRejection | VoidOutput
+
 union RemoveUserPictureResult = ForbiddenRejection | InternalErrorRejection | UnauthorizedRejection | ValidationRejection | VoidOutput
+
+union RemoveWishlistCoOwnerResult = ForbiddenRejection | InternalErrorRejection | NotFoundRejection | UnauthorizedRejection | ValidationRejection | VoidOutput
+
+union RemoveWishlistLogoResult = ForbiddenRejection | InternalErrorRejection | NotFoundRejection | UnauthorizedRejection | ValidationRejection | VoidOutput
 
 input RequestEmailChangeInput {
   newEmail: String!
@@ -345,6 +440,12 @@ type ScanItemUrlOutput {
 }
 
 union ScanItemUrlResult = ForbiddenRejection | InternalErrorRejection | ScanItemUrlOutput | UnauthorizedRejection | ValidationRejection
+
+type SearchUsersOutput {
+  users: [User!]!
+}
+
+union SearchUsersResult = ForbiddenRejection | InternalErrorRejection | SearchUsersOutput | UnauthorizedRejection | ValidationRejection
 
 type SecretSanta {
   budget: Int
@@ -395,6 +496,17 @@ type UnauthorizedRejection {
 
 union UnlinkCurrentUserSocialResult = ForbiddenRejection | InternalErrorRejection | UnauthorizedRejection | ValidationRejection | VoidOutput
 
+union UnlinkWishlistFromEventResult = ForbiddenRejection | InternalErrorRejection | NotFoundRejection | UnauthorizedRejection | ValidationRejection | VoidOutput
+
+input UpdateEventInput {
+  description: String
+  eventDate: String!
+  icon: String
+  title: String!
+}
+
+union UpdateEventResult = ForbiddenRejection | InternalErrorRejection | NotFoundRejection | UnauthorizedRejection | ValidationRejection | VoidOutput
+
 input UpdateItemInput {
   description: String
   name: String!
@@ -437,6 +549,13 @@ input UpdateUserProfileInput {
 }
 
 union UpdateUserProfileResult = ForbiddenRejection | InternalErrorRejection | UnauthorizedRejection | User | ValidationRejection
+
+input UpdateWishlistInput {
+  description: String
+  title: String!
+}
+
+union UpdateWishlistResult = ForbiddenRejection | InternalErrorRejection | NotFoundRejection | UnauthorizedRejection | ValidationRejection | VoidOutput
 
 type User {
   birthday: String

--- a/apps/api/src/event/infrastructure/event.graphql
+++ b/apps/api/src/event/infrastructure/event.graphql
@@ -48,7 +48,138 @@ union GetEventByIdResult =
 
 union GetMyEventsResult = GetEventsPagedResponse | UnauthorizedRejection | ForbiddenRejection | InternalErrorRejection
 
+########################################################
+###############   Input Types   ########################
+########################################################
+
+input CreateEventAttendeeInput {
+  email: String!
+  role: AttendeeRole
+}
+
+input CreateEventInput {
+  title: String!
+  description: String
+  icon: String
+  eventDate: String!
+  attendees: [CreateEventAttendeeInput!]
+}
+
+input UpdateEventInput {
+  title: String!
+  description: String
+  icon: String
+  eventDate: String!
+}
+
+input AddEventAttendeeInput {
+  email: String!
+  role: AttendeeRole
+}
+
+input AdminEventPaginationFilters {
+  page: Int
+  limit: Int
+  userId: UserId
+}
+
+########################################################
+###############   Result Unions   ######################
+########################################################
+
+union CreateEventResult =
+  | Event
+  | ValidationRejection
+  | UnauthorizedRejection
+  | ForbiddenRejection
+  | NotFoundRejection
+  | InternalErrorRejection
+
+union UpdateEventResult =
+  | VoidOutput
+  | ValidationRejection
+  | UnauthorizedRejection
+  | ForbiddenRejection
+  | NotFoundRejection
+  | InternalErrorRejection
+
+union DeleteEventResult =
+  | VoidOutput
+  | ValidationRejection
+  | UnauthorizedRejection
+  | ForbiddenRejection
+  | NotFoundRejection
+  | InternalErrorRejection
+
+union AddEventAttendeeResult =
+  | EventAttendee
+  | ValidationRejection
+  | UnauthorizedRejection
+  | ForbiddenRejection
+  | NotFoundRejection
+  | InternalErrorRejection
+
+union RemoveEventAttendeeResult =
+  | VoidOutput
+  | ValidationRejection
+  | UnauthorizedRejection
+  | ForbiddenRejection
+  | NotFoundRejection
+  | InternalErrorRejection
+
+union AdminGetEventByIdResult =
+  | Event
+  | ValidationRejection
+  | UnauthorizedRejection
+  | ForbiddenRejection
+  | NotFoundRejection
+  | InternalErrorRejection
+
+union AdminGetEventsResult =
+  | GetEventsPagedResponse
+  | ValidationRejection
+  | UnauthorizedRejection
+  | ForbiddenRejection
+  | InternalErrorRejection
+
+union AdminUpdateEventResult =
+  | VoidOutput
+  | ValidationRejection
+  | UnauthorizedRejection
+  | ForbiddenRejection
+  | NotFoundRejection
+  | InternalErrorRejection
+
+union AdminDeleteEventResult =
+  | VoidOutput
+  | ValidationRejection
+  | UnauthorizedRejection
+  | ForbiddenRejection
+  | NotFoundRejection
+  | InternalErrorRejection
+
+union AdminDeleteEventAttendeeResult =
+  | VoidOutput
+  | ValidationRejection
+  | UnauthorizedRejection
+  | ForbiddenRejection
+  | NotFoundRejection
+  | InternalErrorRejection
+
 extend type Query {
   event(id: EventId!): GetEventByIdResult
   events(filters: EventPaginationFilters!): GetMyEventsResult!
+  adminEvent(id: EventId!): AdminGetEventByIdResult!
+  adminEvents(filters: AdminEventPaginationFilters!): AdminGetEventsResult!
+}
+
+extend type Mutation {
+  createEvent(input: CreateEventInput!): CreateEventResult!
+  updateEvent(id: EventId!, input: UpdateEventInput!): UpdateEventResult!
+  deleteEvent(id: EventId!): DeleteEventResult!
+  addEventAttendee(eventId: EventId!, input: AddEventAttendeeInput!): AddEventAttendeeResult!
+  removeEventAttendee(eventId: EventId!, attendeeId: AttendeeId!): RemoveEventAttendeeResult!
+  adminUpdateEvent(id: EventId!, input: UpdateEventInput!): AdminUpdateEventResult!
+  adminDeleteEvent(id: EventId!): AdminDeleteEventResult!
+  adminDeleteEventAttendee(eventId: EventId!, attendeeId: AttendeeId!): AdminDeleteEventAttendeeResult!
 }

--- a/apps/api/src/event/infrastructure/event.mapper.ts
+++ b/apps/api/src/event/infrastructure/event.mapper.ts
@@ -2,7 +2,13 @@ import type { Wishlist } from '@wishlist/api/wishlist'
 import type { Event, EventAttendee } from '../domain'
 
 import { wishlistMapper } from '@wishlist/api/wishlist'
-import { AttendeeRole, type DetailedEventDto, type EventWithCountsDto, type MiniEventDto } from '@wishlist/common'
+import {
+  type AttendeeDto,
+  AttendeeRole,
+  type DetailedEventDto,
+  type EventWithCountsDto,
+  type MiniEventDto,
+} from '@wishlist/common'
 import { DateTime } from 'luxon'
 import { match } from 'ts-pattern'
 
@@ -75,10 +81,26 @@ function toGqlEventAttendee(eventAttendee: EventAttendee): GqlEventAttendee {
   }
 }
 
+function toGqlEventAttendeeFromDto(attendee: AttendeeDto): GqlEventAttendee {
+  const role = match(attendee.role)
+    .with(AttendeeRole.MAINTAINER, () => GqlAttendeeRole.Maintainer)
+    .with(AttendeeRole.USER, () => GqlAttendeeRole.User)
+    .exhaustive()
+
+  return {
+    __typename: 'EventAttendee',
+    id: attendee.id,
+    userId: attendee.user?.id,
+    pendingEmail: attendee.pending_email,
+    role,
+  }
+}
+
 export const eventMapper = {
   toMiniEventDto,
   toDetailedEventDto,
   toEventWithCountsDto,
   toGqlEvent,
   toGqlEventAttendee,
+  toGqlEventAttendeeFromDto,
 }

--- a/apps/api/src/event/infrastructure/event.module.ts
+++ b/apps/api/src/event/infrastructure/event.module.ts
@@ -9,7 +9,9 @@ import { EventDataLoaderFactory } from './event.dataloader'
 import { EventAttendeeDataLoaderFactory } from './event-attendee.dataloader'
 import { EventFieldResolver } from './resolvers/event.field-resolver'
 import { EventResolver } from './resolvers/event.resolver'
+import { EventAdminResolver } from './resolvers/event-admin.resolver'
 import { EventAttendeeFieldResolver } from './resolvers/event-attendee.field-resolver'
+import { EventMutationResolver } from './resolvers/event-mutation.resolver'
 
 @Module({
   controllers: [EventController, EventAttendeeController, EventAdminController, EventAttendeeAdminController],
@@ -18,6 +20,8 @@ import { EventAttendeeFieldResolver } from './resolvers/event-attendee.field-res
     EventDataLoaderFactory,
     EventAttendeeDataLoaderFactory,
     EventResolver,
+    EventMutationResolver,
+    EventAdminResolver,
     EventFieldResolver,
     EventAttendeeFieldResolver,
   ],

--- a/apps/api/src/event/infrastructure/event.schema.ts
+++ b/apps/api/src/event/infrastructure/event.schema.ts
@@ -1,8 +1,70 @@
 import { PaginationFiltersSchema } from '@wishlist/api/core/graphql'
+import { AttendeeId, AttendeeRole, EventId, UserId } from '@wishlist/common'
 import z from 'zod'
 
-import { EventPaginationFilters } from '../../gql/generated-types'
+import {
+  AddEventAttendeeInput,
+  AdminEventPaginationFilters,
+  CreateEventInput,
+  EventPaginationFilters,
+  AttendeeRole as GqlAttendeeRole,
+  UpdateEventInput,
+} from '../../gql/generated-types'
+
+export const EventIdSchema = z.string().transform(val => val as EventId)
+export const AttendeeIdSchema = z.string().transform(val => val as AttendeeId)
+export const UserIdSchema = z.string().transform(val => val as UserId)
+
+// The GraphQL AttendeeRole enum wire values (MAINTAINER / USER) map to the
+// domain AttendeeRole enum values (maintainer / user).
+const GqlAttendeeRoleSchema = z.enum(GqlAttendeeRole)
 
 export const EventPaginationFiltersSchema = PaginationFiltersSchema.extend({
   onlyFuture: z.boolean().default(false),
 }) satisfies z.ZodType<EventPaginationFilters>
+
+export const AdminEventPaginationFiltersSchema = z.object({
+  page: z.number().int().min(1).optional(),
+  limit: z.number().int().min(1).optional(),
+  userId: UserIdSchema.optional(),
+}) satisfies z.ZodType<AdminEventPaginationFilters>
+
+const iconSchema = z
+  .string()
+  .max(10)
+  .regex(/^[\p{Emoji}\p{Emoji_Modifier}\p{Emoji_Component}\p{Emoji_Modifier_Base}\p{Emoji_Presentation}]+$/u, {
+    message: 'icon must be a valid emoji',
+  })
+
+export const CreateEventInputSchema = z.object({
+  title: z.string().nonempty().max(100),
+  description: z.string().max(2000).optional(),
+  icon: iconSchema.optional(),
+  eventDate: z.iso.date({ message: 'eventDate must be in format YYYY-MM-DD' }),
+  attendees: z
+    .array(
+      z.object({
+        email: z.email().max(200).toLowerCase(),
+        role: GqlAttendeeRoleSchema.optional(),
+      }),
+    )
+    .optional(),
+}) satisfies z.ZodType<CreateEventInput>
+
+export const UpdateEventInputSchema = z.object({
+  title: z.string().nonempty().max(100),
+  description: z.string().max(2000).optional(),
+  icon: iconSchema.optional(),
+  eventDate: z.iso.date({ message: 'eventDate must be in format YYYY-MM-DD' }),
+}) satisfies z.ZodType<UpdateEventInput>
+
+export const AddEventAttendeeInputSchema = z.object({
+  email: z.email().max(200).toLowerCase(),
+  role: GqlAttendeeRoleSchema.optional(),
+}) satisfies z.ZodType<AddEventAttendeeInput>
+
+// Maps GraphQL enum value (MAINTAINER / USER) to the domain AttendeeRole enum.
+export function toDomainAttendeeRole(role?: GqlAttendeeRole): AttendeeRole | undefined {
+  if (!role) return undefined
+  return role === GqlAttendeeRole.Maintainer ? AttendeeRole.MAINTAINER : AttendeeRole.USER
+}

--- a/apps/api/src/event/infrastructure/resolvers/event-admin.resolver.int-spec.ts
+++ b/apps/api/src/event/infrastructure/resolvers/event-admin.resolver.int-spec.ts
@@ -1,0 +1,365 @@
+import type { RequestApp } from '@wishlist/api-test-utils'
+
+import { Fixtures, useTestApp } from '@wishlist/api-test-utils'
+import { uuid } from '@wishlist/common'
+import { DateTime } from 'luxon'
+
+/**
+ * Integration tests for the GraphQL EventAdminResolver (@IsAdmin()).
+ *
+ * GraphQL always returns HTTP 200; thrown Nest exceptions map to typed
+ * rejections placed at data.<field>. Non-admin users are rejected by the admin
+ * guard (ForbiddenRejection).
+ */
+const GRAPHQL_PATH = '/graphql'
+
+const futureDate = () => DateTime.now().plus({ days: 30 }).toISODate() as string
+
+describe('EventAdminResolver (GraphQL)', () => {
+  const { getRequest, getFixtures, expectTable } = useTestApp()
+  let fixtures: Fixtures
+
+  beforeEach(() => {
+    fixtures = getFixtures()
+  })
+
+  describe('Query adminEvent', () => {
+    const query = /* GraphQL */ `
+      query AdminEvent($id: EventId!) {
+        adminEvent(id: $id) {
+          __typename
+          ... on Event {
+            id
+            title
+          }
+          ... on ForbiddenRejection {
+            message
+          }
+          ... on UnauthorizedRejection {
+            message
+          }
+        }
+      }
+    `
+
+    it('should not succeed when unauthenticated', async () => {
+      const request = await getRequest()
+      const res = await request
+        .post(GRAPHQL_PATH)
+        .send({ query, variables: { id: uuid() } })
+        .expect(200)
+
+      expect(res.body.data?.adminEvent?.__typename).not.toBe('Event')
+    })
+
+    it('should reject with ForbiddenRejection for a non-admin user', async () => {
+      const request = await getRequest({ signedAs: 'BASE_USER' })
+      const currentUserId = await fixtures.getSignedUserId('BASE_USER')
+      const { eventId } = await fixtures.insertEventWithMaintainer({ title: 'Event', maintainerId: currentUserId })
+
+      const res = await request
+        .post(GRAPHQL_PATH)
+        .send({ query, variables: { id: eventId } })
+        .expect(200)
+
+      expect(res.body.data.adminEvent.__typename).toBe('ForbiddenRejection')
+    })
+
+    describe('when user is admin', () => {
+      let request: RequestApp
+
+      beforeEach(async () => {
+        request = await getRequest({ signedAs: 'ADMIN_USER' })
+      })
+
+      it('should return any event (even one the admin does not own)', async () => {
+        const ownerId = await fixtures.insertUser({ email: 'owner@test.com', firstname: 'O', lastname: 'W' })
+        const { eventId } = await fixtures.insertEventWithMaintainer({ title: 'Owned', maintainerId: ownerId })
+
+        const res = await request
+          .post(GRAPHQL_PATH)
+          .send({ query, variables: { id: eventId } })
+          .expect(200)
+
+        expect(res.body.data.adminEvent).toMatchObject({ __typename: 'Event', id: eventId, title: 'Owned' })
+      })
+
+      it('should return NotFoundRejection when the event does not exist', async () => {
+        const res = await request
+          .post(GRAPHQL_PATH)
+          .send({ query, variables: { id: uuid() } })
+          .expect(200)
+
+        expect(res.body.data.adminEvent.__typename).toBe('NotFoundRejection')
+      })
+    })
+  })
+
+  describe('Query adminEvents', () => {
+    const query = /* GraphQL */ `
+      query AdminEvents($filters: AdminEventPaginationFilters!) {
+        adminEvents(filters: $filters) {
+          __typename
+          ... on GetEventsPagedResponse {
+            data {
+              id
+              title
+            }
+            pagination {
+              totalElements
+              pageNumber
+              pageSize
+            }
+          }
+          ... on ForbiddenRejection {
+            message
+          }
+        }
+      }
+    `
+
+    it('should reject with ForbiddenRejection for a non-admin user', async () => {
+      const request = await getRequest({ signedAs: 'BASE_USER' })
+      const res = await request
+        .post(GRAPHQL_PATH)
+        .send({ query, variables: { filters: {} } })
+        .expect(200)
+
+      expect(res.body.data.adminEvents.__typename).toBe('ForbiddenRejection')
+    })
+
+    describe('when user is admin', () => {
+      let request: RequestApp
+
+      beforeEach(async () => {
+        request = await getRequest({ signedAs: 'ADMIN_USER' })
+      })
+
+      it('should return all events paginated', async () => {
+        const ownerId = await fixtures.insertUser({ email: 'owner@test.com', firstname: 'O', lastname: 'W' })
+        await fixtures.insertEventWithMaintainer({ title: 'Event A', maintainerId: ownerId })
+        await fixtures.insertEventWithMaintainer({ title: 'Event B', maintainerId: ownerId })
+
+        const res = await request
+          .post(GRAPHQL_PATH)
+          .send({ query, variables: { filters: {} } })
+          .expect(200)
+
+        expect(res.body.data.adminEvents.__typename).toBe('GetEventsPagedResponse')
+        expect(res.body.data.adminEvents.data.length).toBeGreaterThanOrEqual(2)
+        expect(res.body.data.adminEvents.pagination.totalElements).toBeGreaterThanOrEqual(2)
+      })
+
+      it('should filter events by userId', async () => {
+        const targetUserId = await fixtures.insertUser({ email: 'target@test.com', firstname: 'T', lastname: 'U' })
+        const otherUserId = await fixtures.insertUser({ email: 'other@test.com', firstname: 'O', lastname: 'U' })
+        const { eventId: targetEventId } = await fixtures.insertEventWithMaintainer({
+          title: 'Target Event',
+          maintainerId: targetUserId,
+        })
+        await fixtures.insertEventWithMaintainer({ title: 'Other Event', maintainerId: otherUserId })
+
+        const res = await request
+          .post(GRAPHQL_PATH)
+          .send({ query, variables: { filters: { userId: targetUserId } } })
+          .expect(200)
+
+        expect(res.body.data.adminEvents.__typename).toBe('GetEventsPagedResponse')
+        expect(res.body.data.adminEvents.data).toEqual([
+          expect.objectContaining({ id: targetEventId, title: 'Target Event' }),
+        ])
+      })
+    })
+  })
+
+  describe('Mutation adminUpdateEvent', () => {
+    const mutation = /* GraphQL */ `
+      mutation AdminUpdateEvent($id: EventId!, $input: UpdateEventInput!) {
+        adminUpdateEvent(id: $id, input: $input) {
+          __typename
+          ... on VoidOutput {
+            success
+          }
+          ... on ForbiddenRejection {
+            message
+          }
+        }
+      }
+    `
+
+    it('should reject with ForbiddenRejection for a non-admin user', async () => {
+      const request = await getRequest({ signedAs: 'BASE_USER' })
+      const res = await request
+        .post(GRAPHQL_PATH)
+        .send({ query: mutation, variables: { id: uuid(), input: { title: 'X', eventDate: futureDate() } } })
+        .expect(200)
+
+      expect(res.body.data.adminUpdateEvent.__typename).toBe('ForbiddenRejection')
+    })
+
+    describe('when user is admin', () => {
+      let request: RequestApp
+
+      beforeEach(async () => {
+        request = await getRequest({ signedAs: 'ADMIN_USER' })
+      })
+
+      it('should update any event', async () => {
+        const ownerId = await fixtures.insertUser({ email: 'owner@test.com', firstname: 'O', lastname: 'W' })
+        const { eventId } = await fixtures.insertEventWithMaintainer({ title: 'Original', maintainerId: ownerId })
+
+        const res = await request
+          .post(GRAPHQL_PATH)
+          .send({
+            query: mutation,
+            variables: { id: eventId, input: { title: 'Admin Updated', eventDate: futureDate() } },
+          })
+          .expect(200)
+
+        expect(res.body.data.adminUpdateEvent).toEqual({ __typename: 'VoidOutput', success: true })
+
+        await expectTable(Fixtures.EVENT_TABLE).row(0).toMatchObject({ id: eventId, title: 'Admin Updated' })
+      })
+
+      it('should return ValidationRejection when title is empty', async () => {
+        const ownerId = await fixtures.insertUser({ email: 'owner@test.com', firstname: 'O', lastname: 'W' })
+        const { eventId } = await fixtures.insertEventWithMaintainer({ title: 'Original', maintainerId: ownerId })
+
+        const res = await request
+          .post(GRAPHQL_PATH)
+          .send({ query: mutation, variables: { id: eventId, input: { title: '', eventDate: futureDate() } } })
+          .expect(200)
+
+        expect(res.body.data.adminUpdateEvent.__typename).toBe('ValidationRejection')
+      })
+
+      it('should return NotFoundRejection when the event does not exist', async () => {
+        const res = await request
+          .post(GRAPHQL_PATH)
+          .send({ query: mutation, variables: { id: uuid(), input: { title: 'X', eventDate: futureDate() } } })
+          .expect(200)
+
+        expect(res.body.data.adminUpdateEvent.__typename).toBe('NotFoundRejection')
+      })
+    })
+  })
+
+  describe('Mutation adminDeleteEvent', () => {
+    const mutation = /* GraphQL */ `
+      mutation AdminDeleteEvent($id: EventId!) {
+        adminDeleteEvent(id: $id) {
+          __typename
+          ... on VoidOutput {
+            success
+          }
+          ... on ForbiddenRejection {
+            message
+          }
+        }
+      }
+    `
+
+    it('should reject with ForbiddenRejection for a non-admin user', async () => {
+      const request = await getRequest({ signedAs: 'BASE_USER' })
+      const res = await request
+        .post(GRAPHQL_PATH)
+        .send({ query: mutation, variables: { id: uuid() } })
+        .expect(200)
+
+      expect(res.body.data.adminDeleteEvent.__typename).toBe('ForbiddenRejection')
+    })
+
+    describe('when user is admin', () => {
+      let request: RequestApp
+
+      beforeEach(async () => {
+        request = await getRequest({ signedAs: 'ADMIN_USER' })
+      })
+
+      it('should delete any event without wishlists', async () => {
+        const ownerId = await fixtures.insertUser({ email: 'owner@test.com', firstname: 'O', lastname: 'W' })
+        const { eventId } = await fixtures.insertEventWithMaintainer({ title: 'To Delete', maintainerId: ownerId })
+
+        const res = await request
+          .post(GRAPHQL_PATH)
+          .send({ query: mutation, variables: { id: eventId } })
+          .expect(200)
+
+        expect(res.body.data.adminDeleteEvent).toEqual({ __typename: 'VoidOutput', success: true })
+
+        await expectTable(Fixtures.EVENT_TABLE).hasNumberOfRows(0)
+      })
+
+      it('should return NotFoundRejection when the event does not exist', async () => {
+        const res = await request
+          .post(GRAPHQL_PATH)
+          .send({ query: mutation, variables: { id: uuid() } })
+          .expect(200)
+
+        expect(res.body.data.adminDeleteEvent.__typename).toBe('NotFoundRejection')
+      })
+    })
+  })
+
+  describe('Mutation adminDeleteEventAttendee', () => {
+    const mutation = /* GraphQL */ `
+      mutation AdminDeleteEventAttendee($eventId: EventId!, $attendeeId: AttendeeId!) {
+        adminDeleteEventAttendee(eventId: $eventId, attendeeId: $attendeeId) {
+          __typename
+          ... on VoidOutput {
+            success
+          }
+          ... on ForbiddenRejection {
+            message
+          }
+        }
+      }
+    `
+
+    it('should reject with ForbiddenRejection for a non-admin user', async () => {
+      const request = await getRequest({ signedAs: 'BASE_USER' })
+      const res = await request
+        .post(GRAPHQL_PATH)
+        .send({ query: mutation, variables: { eventId: uuid(), attendeeId: uuid() } })
+        .expect(200)
+
+      expect(res.body.data.adminDeleteEventAttendee.__typename).toBe('ForbiddenRejection')
+    })
+
+    describe('when user is admin', () => {
+      let request: RequestApp
+
+      beforeEach(async () => {
+        request = await getRequest({ signedAs: 'ADMIN_USER' })
+      })
+
+      it('should delete an attendee from any event', async () => {
+        const ownerId = await fixtures.insertUser({ email: 'owner@test.com', firstname: 'O', lastname: 'W' })
+        const { eventId } = await fixtures.insertEventWithMaintainer({ title: 'Event', maintainerId: ownerId })
+        const attendeeId = await fixtures.insertPendingAttendee({ eventId, tempUserEmail: 'pending@test.com' })
+
+        const res = await request
+          .post(GRAPHQL_PATH)
+          .send({ query: mutation, variables: { eventId, attendeeId } })
+          .expect(200)
+
+        expect(res.body.data.adminDeleteEventAttendee).toEqual({ __typename: 'VoidOutput', success: true })
+
+        // Only the maintainer attendee remains
+        await expectTable(Fixtures.EVENT_ATTENDEE_TABLE).hasNumberOfRows(1)
+      })
+
+      it('should return NotFoundRejection when the attendee does not exist', async () => {
+        const ownerId = await fixtures.insertUser({ email: 'owner@test.com', firstname: 'O', lastname: 'W' })
+        const { eventId } = await fixtures.insertEventWithMaintainer({ title: 'Event', maintainerId: ownerId })
+
+        const res = await request
+          .post(GRAPHQL_PATH)
+          .send({ query: mutation, variables: { eventId, attendeeId: uuid() } })
+          .expect(200)
+
+        expect(res.body.data.adminDeleteEventAttendee.__typename).toBe('NotFoundRejection')
+      })
+    })
+  })
+})

--- a/apps/api/src/event/infrastructure/resolvers/event-admin.resolver.ts
+++ b/apps/api/src/event/infrastructure/resolvers/event-admin.resolver.ts
@@ -1,0 +1,136 @@
+import type { ICurrentUser } from '@wishlist/common'
+
+import { NotFoundException } from '@nestjs/common'
+import { Args, Context, Mutation, Query, Resolver } from '@nestjs/graphql'
+import { GqlCurrentUser, IsAdmin } from '@wishlist/api/auth'
+import { DEFAULT_RESULT_NUMBER, GraphQLContext, ZodPipe } from '@wishlist/api/core'
+import { AttendeeId, createPagedResponse, EventId } from '@wishlist/common'
+
+import {
+  AdminDeleteEventAttendeeResult,
+  AdminDeleteEventResult,
+  AdminEventPaginationFilters,
+  AdminGetEventByIdResult,
+  AdminGetEventsResult,
+  AdminUpdateEventResult,
+  Event as GqlEvent,
+  UpdateEventInput,
+} from '../../../gql/generated-types'
+import { DeleteAttendeeUseCase } from '../../application/command/delete-attendee.use-case'
+import { DeleteEventUseCase } from '../../application/command/delete-event.use-case'
+import { UpdateEventUseCase } from '../../application/command/update-event.use-case'
+import { GetEventsUseCase } from '../../application/query/get-events.use-case'
+import { GetEventsForUserUseCase } from '../../application/query/get-events-for-user.use-case'
+import {
+  AdminEventPaginationFiltersSchema,
+  AttendeeIdSchema,
+  EventIdSchema,
+  UpdateEventInputSchema,
+} from '../event.schema'
+
+@IsAdmin()
+@Resolver()
+export class EventAdminResolver {
+  constructor(
+    private readonly getEventsUseCase: GetEventsUseCase,
+    private readonly getEventsForUserUseCase: GetEventsForUserUseCase,
+    private readonly updateEventUseCase: UpdateEventUseCase,
+    private readonly deleteEventUseCase: DeleteEventUseCase,
+    private readonly deleteAttendeeUseCase: DeleteAttendeeUseCase,
+  ) {}
+
+  @Query()
+  async adminEvent(
+    @Args('id', new ZodPipe(EventIdSchema)) id: EventId,
+    @Context() ctx: GraphQLContext,
+  ): Promise<AdminGetEventByIdResult> {
+    // canView returns true for admins, so the dataloader resolves any event.
+    const event = await ctx.loaders.event.load(id)
+    if (!event) {
+      throw new NotFoundException(`Event with id ${id} not found`)
+    }
+    return event
+  }
+
+  @Query()
+  async adminEvents(
+    @Args('filters', new ZodPipe(AdminEventPaginationFiltersSchema)) filters: AdminEventPaginationFilters,
+    @Context() ctx: GraphQLContext,
+  ): Promise<AdminGetEventsResult> {
+    const pageSize = filters.limit ?? DEFAULT_RESULT_NUMBER
+    const pageNumber = filters.page ?? 1
+
+    const pagedDtos = filters.userId
+      ? await this.getEventsForUserUseCase.execute({
+          userId: filters.userId,
+          pageNumber,
+          pageSize,
+          ignorePastEvents: false,
+        })
+      : await this.getEventsUseCase.execute({ pageNumber, pageSize })
+
+    // Load full Event object types (with wishlistIds/attendeeIds) for the page of ids.
+    const loadedEvents = await ctx.loaders.event.loadMany(pagedDtos.resources.map(event => event.id))
+    const events = loadedEvents.filter((event): event is GqlEvent => event !== null && !(event instanceof Error))
+
+    const pagedResponse = createPagedResponse({
+      resources: events,
+      options: {
+        pageSize,
+        totalElements: pagedDtos.pagination.total_elements,
+        pageNumber,
+      },
+    })
+
+    return {
+      __typename: 'GetEventsPagedResponse',
+      data: pagedResponse.resources,
+      pagination: {
+        __typename: 'Pagination',
+        totalPages: pagedResponse.pagination.total_pages,
+        totalElements: pagedResponse.pagination.total_elements,
+        pageNumber: pagedResponse.pagination.page_number,
+        pageSize: pagedResponse.pagination.pages_size,
+      },
+    }
+  }
+
+  @Mutation()
+  async adminUpdateEvent(
+    @Args('id', new ZodPipe(EventIdSchema)) id: EventId,
+    @Args('input', new ZodPipe(UpdateEventInputSchema)) input: UpdateEventInput,
+    @GqlCurrentUser() currentUser: ICurrentUser,
+  ): Promise<AdminUpdateEventResult> {
+    await this.updateEventUseCase.execute({
+      currentUser,
+      eventId: id,
+      updateEvent: {
+        title: input.title,
+        description: input.description ?? undefined,
+        icon: input.icon ?? undefined,
+        eventDate: new Date(input.eventDate),
+      },
+    })
+
+    return { __typename: 'VoidOutput', success: true }
+  }
+
+  @Mutation()
+  async adminDeleteEvent(
+    @Args('id', new ZodPipe(EventIdSchema)) id: EventId,
+    @GqlCurrentUser() currentUser: ICurrentUser,
+  ): Promise<AdminDeleteEventResult> {
+    await this.deleteEventUseCase.execute({ currentUser, eventId: id })
+    return { __typename: 'VoidOutput', success: true }
+  }
+
+  @Mutation()
+  async adminDeleteEventAttendee(
+    @Args('eventId', new ZodPipe(EventIdSchema)) eventId: EventId,
+    @Args('attendeeId', new ZodPipe(AttendeeIdSchema)) attendeeId: AttendeeId,
+    @GqlCurrentUser() currentUser: ICurrentUser,
+  ): Promise<AdminDeleteEventAttendeeResult> {
+    await this.deleteAttendeeUseCase.execute({ currentUser, eventId, attendeeId })
+    return { __typename: 'VoidOutput', success: true }
+  }
+}

--- a/apps/api/src/event/infrastructure/resolvers/event-mutation.resolver.int-spec.ts
+++ b/apps/api/src/event/infrastructure/resolvers/event-mutation.resolver.int-spec.ts
@@ -1,0 +1,576 @@
+import type { RequestApp } from '@wishlist/api-test-utils'
+
+import { Fixtures, useTestApp } from '@wishlist/api-test-utils'
+import { uuid } from '@wishlist/common'
+import { DateTime } from 'luxon'
+
+/**
+ * Integration tests for the GraphQL EventMutationResolver.
+ *
+ * GraphQL always returns HTTP 200; thrown Nest exceptions are mapped by the
+ * error transform plugin to typed rejections placed at data.<field>:
+ *   ZodValidationException  -> ValidationRejection
+ *   UnauthorizedException   -> UnauthorizedRejection
+ *   NotFoundException       -> NotFoundRejection
+ *   ForbiddenException      -> ForbiddenRejection
+ *   other HttpException     -> InternalErrorRejection
+ */
+const GRAPHQL_PATH = '/graphql'
+
+const futureDate = () => DateTime.now().plus({ days: 30 }).toISODate() as string
+
+describe('EventMutationResolver (GraphQL)', () => {
+  const { getRequest, getFixtures, expectTable } = useTestApp()
+  let fixtures: Fixtures
+
+  beforeEach(() => {
+    fixtures = getFixtures()
+  })
+
+  describe('Mutation createEvent', () => {
+    const mutation = /* GraphQL */ `
+      mutation CreateEvent($input: CreateEventInput!) {
+        createEvent(input: $input) {
+          __typename
+          ... on Event {
+            id
+            title
+            description
+            icon
+            eventDate
+            attendeeIds
+          }
+          ... on ValidationRejection {
+            errors {
+              field
+              message
+            }
+          }
+          ... on UnauthorizedRejection {
+            message
+          }
+        }
+      }
+    `
+
+    it('should not succeed when not authenticated', async () => {
+      const request = await getRequest()
+      const res = await request
+        .post(GRAPHQL_PATH)
+        .send({ query: mutation, variables: { input: { title: 'My Event', eventDate: futureDate() } } })
+        .expect(200)
+
+      expect(res.body.data?.createEvent?.__typename).not.toBe('Event')
+      await expectTable(Fixtures.EVENT_TABLE).hasNumberOfRows(0)
+    })
+
+    describe('when user is authenticated', () => {
+      let request: RequestApp
+      let currentUserId: string
+
+      beforeEach(async () => {
+        request = await getRequest({ signedAs: 'BASE_USER' })
+        currentUserId = await fixtures.getSignedUserId('BASE_USER')
+      })
+
+      it('should create an event successfully (creator becomes maintainer attendee)', async () => {
+        const eventDate = futureDate()
+        const res = await request
+          .post(GRAPHQL_PATH)
+          .send({
+            query: mutation,
+            variables: {
+              input: { title: 'Christmas', description: 'Family party', icon: '🎄', eventDate },
+            },
+          })
+          .expect(200)
+
+        expect(res.body.data.createEvent).toMatchObject({
+          __typename: 'Event',
+          id: expect.toBeString(),
+          title: 'Christmas',
+          description: 'Family party',
+          icon: '🎄',
+          eventDate,
+        })
+        // Creator is automatically added as a maintainer attendee.
+        expect(res.body.data.createEvent.attendeeIds).toHaveLength(1)
+
+        await expectTable(Fixtures.EVENT_TABLE).hasNumberOfRows(1).row(0).toMatchObject({
+          id: res.body.data.createEvent.id,
+          title: 'Christmas',
+          description: 'Family party',
+          icon: '🎄',
+        })
+
+        await expectTable(Fixtures.EVENT_ATTENDEE_TABLE).hasNumberOfRows(1).row(0).toMatchObject({
+          event_id: res.body.data.createEvent.id,
+          user_id: currentUserId,
+          role: 'maintainer',
+        })
+      })
+
+      it('should create an event with an additional attendee', async () => {
+        const eventDate = futureDate()
+        const res = await request
+          .post(GRAPHQL_PATH)
+          .send({
+            query: mutation,
+            variables: {
+              input: {
+                title: 'New Year',
+                eventDate,
+                attendees: [{ email: 'invited@test.com', role: 'USER' }],
+              },
+            },
+          })
+          .expect(200)
+
+        expect(res.body.data.createEvent.__typename).toBe('Event')
+        expect(res.body.data.createEvent.attendeeIds).toHaveLength(2)
+
+        await expectTable(Fixtures.EVENT_TABLE).hasNumberOfRows(1)
+        await expectTable(Fixtures.EVENT_ATTENDEE_TABLE).hasNumberOfRows(2)
+      })
+
+      it.each([
+        { case: 'empty title', input: { title: '', eventDate: futureDate() }, field: 'title' },
+        { case: 'title too long', input: { title: 'a'.repeat(101), eventDate: futureDate() }, field: 'title' },
+        { case: 'invalid event date', input: { title: 'Event', eventDate: 'not-a-date' }, field: 'eventDate' },
+        { case: 'invalid icon', input: { title: 'Event', eventDate: futureDate(), icon: 'abc' }, field: 'icon' },
+        {
+          case: 'invalid attendee email',
+          input: { title: 'Event', eventDate: futureDate(), attendees: [{ email: 'not-an-email' }] },
+          field: 'attendees',
+        },
+      ])('should return ValidationRejection when invalid input: $case', async ({ input, field }) => {
+        const res = await request.post(GRAPHQL_PATH).send({ query: mutation, variables: { input } }).expect(200)
+
+        expect(res.body.data.createEvent.__typename).toBe('ValidationRejection')
+        expect(res.body.data.createEvent.errors).toEqual(
+          expect.arrayContaining([expect.objectContaining({ field: expect.stringContaining(field) })]),
+        )
+
+        await expectTable(Fixtures.EVENT_TABLE).hasNumberOfRows(0)
+      })
+    })
+  })
+
+  describe('Mutation updateEvent', () => {
+    const mutation = /* GraphQL */ `
+      mutation UpdateEvent($id: EventId!, $input: UpdateEventInput!) {
+        updateEvent(id: $id, input: $input) {
+          __typename
+          ... on VoidOutput {
+            success
+          }
+          ... on ValidationRejection {
+            errors {
+              field
+              message
+            }
+          }
+          ... on UnauthorizedRejection {
+            message
+          }
+        }
+      }
+    `
+
+    it('should not succeed when not authenticated', async () => {
+      const request = await getRequest()
+      const res = await request
+        .post(GRAPHQL_PATH)
+        .send({ query: mutation, variables: { id: uuid(), input: { title: 'Updated', eventDate: futureDate() } } })
+        .expect(200)
+
+      expect(res.body.data?.updateEvent?.__typename).not.toBe('VoidOutput')
+    })
+
+    describe('when user is authenticated', () => {
+      let request: RequestApp
+      let currentUserId: string
+
+      beforeEach(async () => {
+        request = await getRequest({ signedAs: 'BASE_USER' })
+        currentUserId = await fixtures.getSignedUserId('BASE_USER')
+      })
+
+      it('should update an event the user maintains', async () => {
+        const { eventId } = await fixtures.insertEventWithMaintainer({
+          title: 'Original',
+          maintainerId: currentUserId,
+        })
+
+        const eventDate = futureDate()
+        const res = await request
+          .post(GRAPHQL_PATH)
+          .send({
+            query: mutation,
+            variables: { id: eventId, input: { title: 'Updated Title', description: 'New desc', eventDate } },
+          })
+          .expect(200)
+
+        expect(res.body.data.updateEvent).toEqual({ __typename: 'VoidOutput', success: true })
+
+        await expectTable(Fixtures.EVENT_TABLE).hasNumberOfRows(1).row(0).toMatchObject({
+          id: eventId,
+          title: 'Updated Title',
+          description: 'New desc',
+        })
+      })
+
+      it('should return ValidationRejection when title is empty', async () => {
+        const { eventId } = await fixtures.insertEventWithMaintainer({
+          title: 'Original',
+          maintainerId: currentUserId,
+        })
+
+        const res = await request
+          .post(GRAPHQL_PATH)
+          .send({ query: mutation, variables: { id: eventId, input: { title: '', eventDate: futureDate() } } })
+          .expect(200)
+
+        expect(res.body.data.updateEvent.__typename).toBe('ValidationRejection')
+
+        await expectTable(Fixtures.EVENT_TABLE).hasNumberOfRows(1).row(0).toMatchObject({ title: 'Original' })
+      })
+
+      it('should return NotFoundRejection when the event does not exist', async () => {
+        const res = await request
+          .post(GRAPHQL_PATH)
+          .send({ query: mutation, variables: { id: uuid(), input: { title: 'Updated', eventDate: futureDate() } } })
+          .expect(200)
+
+        expect(res.body.data.updateEvent.__typename).toBe('NotFoundRejection')
+      })
+
+      it('should return UnauthorizedRejection when the user is not a maintainer', async () => {
+        const otherUserId = await fixtures.insertUser({
+          email: 'other@test.com',
+          firstname: 'Other',
+          lastname: 'User',
+        })
+
+        const { eventId } = await fixtures.insertEventWithMaintainer({
+          title: 'Original',
+          maintainerId: otherUserId,
+        })
+
+        const res = await request
+          .post(GRAPHQL_PATH)
+          .send({ query: mutation, variables: { id: eventId, input: { title: 'Hacked', eventDate: futureDate() } } })
+          .expect(200)
+
+        expect(res.body.data.updateEvent.__typename).toBe('UnauthorizedRejection')
+
+        await expectTable(Fixtures.EVENT_TABLE).hasNumberOfRows(1).row(0).toMatchObject({ title: 'Original' })
+      })
+    })
+  })
+
+  describe('Mutation deleteEvent', () => {
+    const mutation = /* GraphQL */ `
+      mutation DeleteEvent($id: EventId!) {
+        deleteEvent(id: $id) {
+          __typename
+          ... on VoidOutput {
+            success
+          }
+          ... on UnauthorizedRejection {
+            message
+          }
+        }
+      }
+    `
+
+    it('should not succeed when not authenticated', async () => {
+      const request = await getRequest()
+      const res = await request
+        .post(GRAPHQL_PATH)
+        .send({ query: mutation, variables: { id: uuid() } })
+        .expect(200)
+
+      expect(res.body.data?.deleteEvent?.__typename).not.toBe('VoidOutput')
+    })
+
+    describe('when user is authenticated', () => {
+      let request: RequestApp
+      let currentUserId: string
+
+      beforeEach(async () => {
+        request = await getRequest({ signedAs: 'BASE_USER' })
+        currentUserId = await fixtures.getSignedUserId('BASE_USER')
+      })
+
+      it('should delete an event the user maintains (no wishlists)', async () => {
+        const { eventId } = await fixtures.insertEventWithMaintainer({
+          title: 'To Delete',
+          maintainerId: currentUserId,
+        })
+
+        const res = await request
+          .post(GRAPHQL_PATH)
+          .send({ query: mutation, variables: { id: eventId } })
+          .expect(200)
+
+        expect(res.body.data.deleteEvent).toEqual({ __typename: 'VoidOutput', success: true })
+
+        await expectTable(Fixtures.EVENT_TABLE).hasNumberOfRows(0)
+        await expectTable(Fixtures.EVENT_ATTENDEE_TABLE).hasNumberOfRows(0)
+      })
+
+      it('should return NotFoundRejection when the event does not exist', async () => {
+        const res = await request
+          .post(GRAPHQL_PATH)
+          .send({ query: mutation, variables: { id: uuid() } })
+          .expect(200)
+
+        expect(res.body.data.deleteEvent.__typename).toBe('NotFoundRejection')
+      })
+
+      it('should return UnauthorizedRejection when the user is not a maintainer', async () => {
+        const otherUserId = await fixtures.insertUser({
+          email: 'other@test.com',
+          firstname: 'Other',
+          lastname: 'User',
+        })
+
+        const { eventId } = await fixtures.insertEventWithMaintainer({
+          title: 'Other Event',
+          maintainerId: otherUserId,
+        })
+
+        const res = await request
+          .post(GRAPHQL_PATH)
+          .send({ query: mutation, variables: { id: eventId } })
+          .expect(200)
+
+        expect(res.body.data.deleteEvent.__typename).toBe('UnauthorizedRejection')
+
+        await expectTable(Fixtures.EVENT_TABLE).hasNumberOfRows(1)
+      })
+    })
+  })
+
+  describe('Mutation addEventAttendee', () => {
+    const mutation = /* GraphQL */ `
+      mutation AddEventAttendee($eventId: EventId!, $input: AddEventAttendeeInput!) {
+        addEventAttendee(eventId: $eventId, input: $input) {
+          __typename
+          ... on EventAttendee {
+            id
+            pendingEmail
+            role
+          }
+          ... on ValidationRejection {
+            errors {
+              field
+              message
+            }
+          }
+          ... on UnauthorizedRejection {
+            message
+          }
+        }
+      }
+    `
+
+    it('should not succeed when not authenticated', async () => {
+      const request = await getRequest()
+      const res = await request
+        .post(GRAPHQL_PATH)
+        .send({ query: mutation, variables: { eventId: uuid(), input: { email: 'a@test.com' } } })
+        .expect(200)
+
+      expect(res.body.data?.addEventAttendee?.__typename).not.toBe('EventAttendee')
+    })
+
+    describe('when user is authenticated', () => {
+      let request: RequestApp
+      let currentUserId: string
+
+      beforeEach(async () => {
+        request = await getRequest({ signedAs: 'BASE_USER' })
+        currentUserId = await fixtures.getSignedUserId('BASE_USER')
+      })
+
+      it('should add a pending attendee to an event the user maintains', async () => {
+        const { eventId } = await fixtures.insertEventWithMaintainer({
+          title: 'Event',
+          maintainerId: currentUserId,
+        })
+
+        const res = await request
+          .post(GRAPHQL_PATH)
+          .send({
+            query: mutation,
+            variables: { eventId, input: { email: 'invited@test.com', role: 'USER' } },
+          })
+          .expect(200)
+
+        expect(res.body.data.addEventAttendee).toMatchObject({
+          __typename: 'EventAttendee',
+          id: expect.toBeString(),
+          pendingEmail: 'invited@test.com',
+          role: 'USER',
+        })
+
+        // 1 maintainer + 1 new attendee
+        await expectTable(Fixtures.EVENT_ATTENDEE_TABLE).hasNumberOfRows(2)
+      })
+
+      it('should return ValidationRejection when the email is invalid', async () => {
+        const { eventId } = await fixtures.insertEventWithMaintainer({
+          title: 'Event',
+          maintainerId: currentUserId,
+        })
+
+        const res = await request
+          .post(GRAPHQL_PATH)
+          .send({ query: mutation, variables: { eventId, input: { email: 'not-an-email' } } })
+          .expect(200)
+
+        expect(res.body.data.addEventAttendee.__typename).toBe('ValidationRejection')
+        expect(res.body.data.addEventAttendee.errors).toEqual(
+          expect.arrayContaining([expect.objectContaining({ field: 'email' })]),
+        )
+
+        await expectTable(Fixtures.EVENT_ATTENDEE_TABLE).hasNumberOfRows(1)
+      })
+
+      it('should return NotFoundRejection when the event does not exist', async () => {
+        const res = await request
+          .post(GRAPHQL_PATH)
+          .send({ query: mutation, variables: { eventId: uuid(), input: { email: 'invited@test.com' } } })
+          .expect(200)
+
+        expect(res.body.data.addEventAttendee.__typename).toBe('NotFoundRejection')
+      })
+
+      it('should return UnauthorizedRejection when the user is not a maintainer', async () => {
+        const otherUserId = await fixtures.insertUser({
+          email: 'other@test.com',
+          firstname: 'Other',
+          lastname: 'User',
+        })
+
+        const { eventId } = await fixtures.insertEventWithMaintainer({
+          title: 'Other Event',
+          maintainerId: otherUserId,
+        })
+
+        const res = await request
+          .post(GRAPHQL_PATH)
+          .send({ query: mutation, variables: { eventId, input: { email: 'invited@test.com' } } })
+          .expect(200)
+
+        expect(res.body.data.addEventAttendee.__typename).toBe('UnauthorizedRejection')
+
+        await expectTable(Fixtures.EVENT_ATTENDEE_TABLE).hasNumberOfRows(1)
+      })
+    })
+  })
+
+  describe('Mutation removeEventAttendee', () => {
+    const mutation = /* GraphQL */ `
+      mutation RemoveEventAttendee($eventId: EventId!, $attendeeId: AttendeeId!) {
+        removeEventAttendee(eventId: $eventId, attendeeId: $attendeeId) {
+          __typename
+          ... on VoidOutput {
+            success
+          }
+          ... on UnauthorizedRejection {
+            message
+          }
+        }
+      }
+    `
+
+    it('should not succeed when not authenticated', async () => {
+      const request = await getRequest()
+      const res = await request
+        .post(GRAPHQL_PATH)
+        .send({ query: mutation, variables: { eventId: uuid(), attendeeId: uuid() } })
+        .expect(200)
+
+      expect(res.body.data?.removeEventAttendee?.__typename).not.toBe('VoidOutput')
+    })
+
+    describe('when user is authenticated', () => {
+      let request: RequestApp
+      let currentUserId: string
+
+      beforeEach(async () => {
+        request = await getRequest({ signedAs: 'BASE_USER' })
+        currentUserId = await fixtures.getSignedUserId('BASE_USER')
+      })
+
+      it('should remove a pending attendee from an event the user maintains', async () => {
+        const { eventId } = await fixtures.insertEventWithMaintainer({
+          title: 'Event',
+          maintainerId: currentUserId,
+        })
+
+        const attendeeId = await fixtures.insertPendingAttendee({
+          eventId,
+          tempUserEmail: 'pending@test.com',
+        })
+
+        const res = await request
+          .post(GRAPHQL_PATH)
+          .send({ query: mutation, variables: { eventId, attendeeId } })
+          .expect(200)
+
+        expect(res.body.data.removeEventAttendee).toEqual({ __typename: 'VoidOutput', success: true })
+
+        // Only the maintainer attendee remains
+        await expectTable(Fixtures.EVENT_ATTENDEE_TABLE).hasNumberOfRows(1).row(0).toMatchObject({
+          user_id: currentUserId,
+          role: 'maintainer',
+        })
+      })
+
+      it('should return NotFoundRejection when the attendee does not exist on the event', async () => {
+        const { eventId } = await fixtures.insertEventWithMaintainer({
+          title: 'Event',
+          maintainerId: currentUserId,
+        })
+
+        const res = await request
+          .post(GRAPHQL_PATH)
+          .send({ query: mutation, variables: { eventId, attendeeId: uuid() } })
+          .expect(200)
+
+        expect(res.body.data.removeEventAttendee.__typename).toBe('NotFoundRejection')
+      })
+
+      it('should return UnauthorizedRejection when the user is not a maintainer', async () => {
+        const otherUserId = await fixtures.insertUser({
+          email: 'other@test.com',
+          firstname: 'Other',
+          lastname: 'User',
+        })
+
+        const { eventId } = await fixtures.insertEventWithMaintainer({
+          title: 'Other Event',
+          maintainerId: otherUserId,
+        })
+
+        const attendeeId = await fixtures.insertPendingAttendee({
+          eventId,
+          tempUserEmail: 'pending@test.com',
+        })
+
+        const res = await request
+          .post(GRAPHQL_PATH)
+          .send({ query: mutation, variables: { eventId, attendeeId } })
+          .expect(200)
+
+        expect(res.body.data.removeEventAttendee.__typename).toBe('UnauthorizedRejection')
+
+        await expectTable(Fixtures.EVENT_ATTENDEE_TABLE).hasNumberOfRows(2)
+      })
+    })
+  })
+})

--- a/apps/api/src/event/infrastructure/resolvers/event-mutation.resolver.ts
+++ b/apps/api/src/event/infrastructure/resolvers/event-mutation.resolver.ts
@@ -1,0 +1,129 @@
+import type { ICurrentUser } from '@wishlist/common'
+
+import { NotFoundException } from '@nestjs/common'
+import { Args, Context, Mutation, Resolver } from '@nestjs/graphql'
+import { GqlCurrentUser } from '@wishlist/api/auth'
+import { GraphQLContext, ZodPipe } from '@wishlist/api/core'
+import { AttendeeId, EventId } from '@wishlist/common'
+
+import {
+  AddEventAttendeeInput,
+  AddEventAttendeeResult,
+  CreateEventInput,
+  CreateEventResult,
+  DeleteEventResult,
+  RemoveEventAttendeeResult,
+  UpdateEventInput,
+  UpdateEventResult,
+} from '../../../gql/generated-types'
+import { AddAttendeeUseCase } from '../../application/command/add-attendee.use-case'
+import { CreateEventUseCase } from '../../application/command/create-event.use-case'
+import { DeleteAttendeeUseCase } from '../../application/command/delete-attendee.use-case'
+import { DeleteEventUseCase } from '../../application/command/delete-event.use-case'
+import { UpdateEventUseCase } from '../../application/command/update-event.use-case'
+import { eventMapper } from '../event.mapper'
+import {
+  AddEventAttendeeInputSchema,
+  AttendeeIdSchema,
+  CreateEventInputSchema,
+  EventIdSchema,
+  toDomainAttendeeRole,
+  UpdateEventInputSchema,
+} from '../event.schema'
+
+@Resolver()
+export class EventMutationResolver {
+  constructor(
+    private readonly createEventUseCase: CreateEventUseCase,
+    private readonly updateEventUseCase: UpdateEventUseCase,
+    private readonly deleteEventUseCase: DeleteEventUseCase,
+    private readonly addAttendeeUseCase: AddAttendeeUseCase,
+    private readonly deleteAttendeeUseCase: DeleteAttendeeUseCase,
+  ) {}
+
+  @Mutation()
+  async createEvent(
+    @Args('input', new ZodPipe(CreateEventInputSchema)) input: CreateEventInput,
+    @GqlCurrentUser() currentUser: ICurrentUser,
+    @Context() ctx: GraphQLContext,
+  ): Promise<CreateEventResult> {
+    const createdEvent = await this.createEventUseCase.execute({
+      currentUser,
+      newEvent: {
+        title: input.title,
+        description: input.description ?? undefined,
+        icon: input.icon ?? undefined,
+        eventDate: new Date(input.eventDate),
+        attendees: input.attendees?.map(attendee => ({
+          email: attendee.email,
+          role: toDomainAttendeeRole(attendee.role ?? undefined),
+        })),
+      },
+    })
+
+    // The create use-case returns a MiniEventDto; reload the full Event via the
+    // dataloader so the resolver returns a complete Event object type.
+    const loadedEvent = await ctx.loaders.event.load(createdEvent.id)
+    if (!loadedEvent) {
+      throw new NotFoundException(`Event with id ${createdEvent.id} not found`)
+    }
+    return loadedEvent
+  }
+
+  @Mutation()
+  async updateEvent(
+    @Args('id', new ZodPipe(EventIdSchema)) id: EventId,
+    @Args('input', new ZodPipe(UpdateEventInputSchema)) input: UpdateEventInput,
+    @GqlCurrentUser() currentUser: ICurrentUser,
+  ): Promise<UpdateEventResult> {
+    await this.updateEventUseCase.execute({
+      currentUser,
+      eventId: id,
+      updateEvent: {
+        title: input.title,
+        description: input.description ?? undefined,
+        icon: input.icon ?? undefined,
+        eventDate: new Date(input.eventDate),
+      },
+    })
+
+    return { __typename: 'VoidOutput', success: true }
+  }
+
+  @Mutation()
+  async deleteEvent(
+    @Args('id', new ZodPipe(EventIdSchema)) id: EventId,
+    @GqlCurrentUser() currentUser: ICurrentUser,
+  ): Promise<DeleteEventResult> {
+    await this.deleteEventUseCase.execute({ currentUser, eventId: id })
+    return { __typename: 'VoidOutput', success: true }
+  }
+
+  @Mutation()
+  async addEventAttendee(
+    @Args('eventId', new ZodPipe(EventIdSchema)) eventId: EventId,
+    @Args('input', new ZodPipe(AddEventAttendeeInputSchema)) input: AddEventAttendeeInput,
+    @GqlCurrentUser() currentUser: ICurrentUser,
+  ): Promise<AddEventAttendeeResult> {
+    const attendee = await this.addAttendeeUseCase.execute({
+      currentUser,
+      eventId,
+      newAttendee: {
+        email: input.email,
+        role: toDomainAttendeeRole(input.role ?? undefined),
+      },
+    })
+
+    return eventMapper.toGqlEventAttendeeFromDto(attendee)
+  }
+
+  @Mutation()
+  async removeEventAttendee(
+    @Args('eventId', new ZodPipe(EventIdSchema)) eventId: EventId,
+    @Args('attendeeId', new ZodPipe(AttendeeIdSchema)) attendeeId: AttendeeId,
+    @GqlCurrentUser() currentUser: ICurrentUser,
+  ): Promise<RemoveEventAttendeeResult> {
+    await this.deleteAttendeeUseCase.execute({ currentUser, eventId, attendeeId })
+    return { __typename: 'VoidOutput', success: true }
+  }
+}

--- a/apps/api/src/gql/generated-types.ts
+++ b/apps/api/src/gql/generated-types.ts
@@ -28,6 +28,13 @@ export type Scalars = {
   WishlistId: { input: Ids["WishlistId"]; output: Ids["WishlistId"]; }
 };
 
+export type AddEventAttendeeInput = {
+  email: Scalars['String']['input'];
+  role?: InputMaybe<AttendeeRole>;
+};
+
+export type AddEventAttendeeResult = EventAttendee | ForbiddenRejection | InternalErrorRejection | NotFoundRejection | UnauthorizedRejection | ValidationRejection;
+
 export type AddSecretSantaUsersInput = {
   attendeeIds: Array<Scalars['AttendeeId']['input']>;
 };
@@ -39,7 +46,23 @@ export type AddSecretSantaUsersOutput = {
 
 export type AddSecretSantaUsersResult = AddSecretSantaUsersOutput | ForbiddenRejection | InternalErrorRejection | UnauthorizedRejection | ValidationRejection;
 
+export type AddWishlistCoOwnerInput = {
+  userId: Scalars['UserId']['input'];
+};
+
+export type AddWishlistCoOwnerResult = ForbiddenRejection | InternalErrorRejection | NotFoundRejection | UnauthorizedRejection | ValidationRejection | VoidOutput;
+
+export type AdminDeleteEventAttendeeResult = ForbiddenRejection | InternalErrorRejection | NotFoundRejection | UnauthorizedRejection | ValidationRejection | VoidOutput;
+
+export type AdminDeleteEventResult = ForbiddenRejection | InternalErrorRejection | NotFoundRejection | UnauthorizedRejection | ValidationRejection | VoidOutput;
+
 export type AdminDeleteUserResult = ForbiddenRejection | InternalErrorRejection | UnauthorizedRejection | ValidationRejection | VoidOutput;
+
+export type AdminEventPaginationFilters = {
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  userId?: InputMaybe<Scalars['UserId']['input']>;
+};
 
 export type AdminGetAllUsers = {
   __typename: 'AdminGetAllUsers';
@@ -55,9 +78,23 @@ export type AdminGetAllUsersPaginationFilters = {
 
 export type AdminGetAllUsersResult = AdminGetAllUsers | ForbiddenRejection | InternalErrorRejection | UnauthorizedRejection | ValidationRejection;
 
+export type AdminGetEventByIdResult = Event | ForbiddenRejection | InternalErrorRejection | NotFoundRejection | UnauthorizedRejection | ValidationRejection;
+
+export type AdminGetEventsResult = ForbiddenRejection | GetEventsPagedResponse | InternalErrorRejection | UnauthorizedRejection | ValidationRejection;
+
 export type AdminGetUserByIdResult = ForbiddenRejection | InternalErrorRejection | UnauthorizedRejection | UserFull | ValidationRejection;
 
+export type AdminGetWishlists = {
+  __typename: 'AdminGetWishlists';
+  data: Array<Wishlist>;
+  pagination: Pagination;
+};
+
+export type AdminGetWishlistsResult = AdminGetWishlists | ForbiddenRejection | InternalErrorRejection | UnauthorizedRejection | ValidationRejection;
+
 export type AdminRemoveUserPictureResult = ForbiddenRejection | InternalErrorRejection | UnauthorizedRejection | ValidationRejection | VoidOutput;
+
+export type AdminUpdateEventResult = ForbiddenRejection | InternalErrorRejection | NotFoundRejection | UnauthorizedRejection | ValidationRejection | VoidOutput;
 
 export type AdminUpdateUserProfileInput = {
   birthday?: InputMaybe<Scalars['String']['input']>;
@@ -69,6 +106,12 @@ export type AdminUpdateUserProfileInput = {
 };
 
 export type AdminUpdateUserProfileResult = ForbiddenRejection | InternalErrorRejection | UnauthorizedRejection | ValidationRejection | VoidOutput;
+
+export type AdminWishlistPaginationFilters = {
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  userId: Scalars['UserId']['input'];
+};
 
 export enum AttendeeRole {
   Maintainer = 'MAINTAINER',
@@ -84,12 +127,34 @@ export type ChangeUserPasswordInput = {
 
 export type ChangeUserPasswordResult = ForbiddenRejection | InternalErrorRejection | UnauthorizedRejection | ValidationRejection | VoidOutput;
 
+export type ClosestFriendsOutput = {
+  __typename: 'ClosestFriendsOutput';
+  users: Array<User>;
+};
+
+export type ClosestFriendsResult = ClosestFriendsOutput | ForbiddenRejection | InternalErrorRejection | UnauthorizedRejection | ValidationRejection;
+
 export type ConfirmEmailChangeInput = {
   newEmail: Scalars['String']['input'];
   token: Scalars['String']['input'];
 };
 
 export type ConfirmEmailChangeResult = ForbiddenRejection | InternalErrorRejection | UnauthorizedRejection | ValidationRejection | VoidOutput;
+
+export type CreateEventAttendeeInput = {
+  email: Scalars['String']['input'];
+  role?: InputMaybe<AttendeeRole>;
+};
+
+export type CreateEventInput = {
+  attendees?: InputMaybe<Array<CreateEventAttendeeInput>>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  eventDate: Scalars['String']['input'];
+  icon?: InputMaybe<Scalars['String']['input']>;
+  title: Scalars['String']['input'];
+};
+
+export type CreateEventResult = Event | ForbiddenRejection | InternalErrorRejection | NotFoundRejection | UnauthorizedRejection | ValidationRejection;
 
 export type CreateItemInput = {
   description?: InputMaybe<Scalars['String']['input']>;
@@ -110,11 +175,15 @@ export type CreateSecretSantaInput = {
 
 export type CreateSecretSantaResult = ForbiddenRejection | InternalErrorRejection | SecretSanta | UnauthorizedRejection | ValidationRejection;
 
+export type DeleteEventResult = ForbiddenRejection | InternalErrorRejection | NotFoundRejection | UnauthorizedRejection | ValidationRejection | VoidOutput;
+
 export type DeleteItemResult = ForbiddenRejection | InternalErrorRejection | UnauthorizedRejection | ValidationRejection | VoidOutput;
 
 export type DeleteSecretSantaResult = ForbiddenRejection | InternalErrorRejection | UnauthorizedRejection | VoidOutput;
 
 export type DeleteSecretSantaUserResult = ForbiddenRejection | InternalErrorRejection | UnauthorizedRejection | VoidOutput;
+
+export type DeleteWishlistResult = ForbiddenRejection | InternalErrorRejection | NotFoundRejection | UnauthorizedRejection | ValidationRejection | VoidOutput;
 
 export type Event = {
   __typename: 'Event';
@@ -239,6 +308,8 @@ export type LinkUserToGoogleInput = {
 
 export type LinkUserToGoogleResult = ForbiddenRejection | InternalErrorRejection | UnauthorizedRejection | UserSocial | ValidationRejection;
 
+export type LinkWishlistToEventResult = ForbiddenRejection | InternalErrorRejection | NotFoundRejection | UnauthorizedRejection | ValidationRejection | VoidOutput;
+
 export type LoginInput = {
   email: Scalars['String']['input'];
   password: Scalars['String']['input'];
@@ -267,24 +338,36 @@ export type LoginWithGoogleResult = InternalErrorRejection | LoginWithGoogleOutp
 
 export type Mutation = {
   __typename: 'Mutation';
+  addEventAttendee: AddEventAttendeeResult;
   addSecretSantaUsers: AddSecretSantaUsersResult;
+  addWishlistCoOwner: AddWishlistCoOwnerResult;
+  adminDeleteEvent: AdminDeleteEventResult;
+  adminDeleteEventAttendee: AdminDeleteEventAttendeeResult;
   adminDeleteUser: AdminDeleteUserResult;
   adminRemoveUserPicture: AdminRemoveUserPictureResult;
+  adminUpdateEvent: AdminUpdateEventResult;
   adminUpdateUserProfile: AdminUpdateUserProfileResult;
   cancelSecretSanta: CancelSecretSantaResult;
   changeUserPassword: ChangeUserPasswordResult;
   confirmEmailChange: ConfirmEmailChangeResult;
+  createEvent: CreateEventResult;
   createItem: CreateItemResult;
   createSecretSanta: CreateSecretSantaResult;
+  deleteEvent: DeleteEventResult;
   deleteItem: DeleteItemResult;
   deleteSecretSanta: DeleteSecretSantaResult;
   deleteSecretSantaUser: DeleteSecretSantaUserResult;
+  deleteWishlist: DeleteWishlistResult;
   importItems: ImportItemsResult;
   linkCurrentUserWithGoogle: LinkUserToGoogleResult;
+  linkWishlistToEvent: LinkWishlistToEventResult;
   login: LoginResult;
   loginWithGoogle: LoginWithGoogleResult;
   registerUser: RegisterUserResult;
+  removeEventAttendee: RemoveEventAttendeeResult;
   removeUserPicture: RemoveUserPictureResult;
+  removeWishlistCoOwner: RemoveWishlistCoOwnerResult;
+  removeWishlistLogo: RemoveWishlistLogoResult;
   requestEmailChange: RequestEmailChangeResult;
   resetPassword: ResetPasswordResult;
   scanItemUrl: ScanItemUrlResult;
@@ -292,18 +375,44 @@ export type Mutation = {
   startSecretSanta: StartSecretSantaResult;
   toggleItem: ToggleItemResult;
   unlinkCurrentUserSocial: UnlinkCurrentUserSocialResult;
+  unlinkWishlistFromEvent: UnlinkWishlistFromEventResult;
+  updateEvent: UpdateEventResult;
   updateItem: UpdateItemResult;
   updateSecretSanta: UpdateSecretSantaResult;
   updateSecretSantaUser: UpdateSecretSantaUserResult;
   updateUserEmailSettings: UpdateUserEmailSettingsResult;
   updateUserPictureFromSocial: UpdateUserPictureFromSocialResult;
   updateUserProfile: UpdateUserProfileResult;
+  updateWishlist: UpdateWishlistResult;
+};
+
+
+export type MutationAddEventAttendeeArgs = {
+  eventId: Scalars['EventId']['input'];
+  input: AddEventAttendeeInput;
 };
 
 
 export type MutationAddSecretSantaUsersArgs = {
   id: Scalars['SecretSantaId']['input'];
   input: AddSecretSantaUsersInput;
+};
+
+
+export type MutationAddWishlistCoOwnerArgs = {
+  id: Scalars['WishlistId']['input'];
+  input: AddWishlistCoOwnerInput;
+};
+
+
+export type MutationAdminDeleteEventArgs = {
+  id: Scalars['EventId']['input'];
+};
+
+
+export type MutationAdminDeleteEventAttendeeArgs = {
+  attendeeId: Scalars['AttendeeId']['input'];
+  eventId: Scalars['EventId']['input'];
 };
 
 
@@ -314,6 +423,12 @@ export type MutationAdminDeleteUserArgs = {
 
 export type MutationAdminRemoveUserPictureArgs = {
   userId: Scalars['UserId']['input'];
+};
+
+
+export type MutationAdminUpdateEventArgs = {
+  id: Scalars['EventId']['input'];
+  input: UpdateEventInput;
 };
 
 
@@ -338,6 +453,11 @@ export type MutationConfirmEmailChangeArgs = {
 };
 
 
+export type MutationCreateEventArgs = {
+  input: CreateEventInput;
+};
+
+
 export type MutationCreateItemArgs = {
   input: CreateItemInput;
 };
@@ -345,6 +465,11 @@ export type MutationCreateItemArgs = {
 
 export type MutationCreateSecretSantaArgs = {
   input: CreateSecretSantaInput;
+};
+
+
+export type MutationDeleteEventArgs = {
+  id: Scalars['EventId']['input'];
 };
 
 
@@ -364,6 +489,11 @@ export type MutationDeleteSecretSantaUserArgs = {
 };
 
 
+export type MutationDeleteWishlistArgs = {
+  id: Scalars['WishlistId']['input'];
+};
+
+
 export type MutationImportItemsArgs = {
   input: ImportItemsInput;
 };
@@ -371,6 +501,12 @@ export type MutationImportItemsArgs = {
 
 export type MutationLinkCurrentUserWithGoogleArgs = {
   input: LinkUserToGoogleInput;
+};
+
+
+export type MutationLinkWishlistToEventArgs = {
+  eventId: Scalars['EventId']['input'];
+  id: Scalars['WishlistId']['input'];
 };
 
 
@@ -386,6 +522,22 @@ export type MutationLoginWithGoogleArgs = {
 
 export type MutationRegisterUserArgs = {
   input: RegisterUserInput;
+};
+
+
+export type MutationRemoveEventAttendeeArgs = {
+  attendeeId: Scalars['AttendeeId']['input'];
+  eventId: Scalars['EventId']['input'];
+};
+
+
+export type MutationRemoveWishlistCoOwnerArgs = {
+  id: Scalars['WishlistId']['input'];
+};
+
+
+export type MutationRemoveWishlistLogoArgs = {
+  id: Scalars['WishlistId']['input'];
 };
 
 
@@ -424,6 +576,18 @@ export type MutationUnlinkCurrentUserSocialArgs = {
 };
 
 
+export type MutationUnlinkWishlistFromEventArgs = {
+  eventId: Scalars['EventId']['input'];
+  id: Scalars['WishlistId']['input'];
+};
+
+
+export type MutationUpdateEventArgs = {
+  id: Scalars['EventId']['input'];
+  input: UpdateEventInput;
+};
+
+
 export type MutationUpdateItemArgs = {
   input: UpdateItemInput;
   itemId: Scalars['ItemId']['input'];
@@ -457,6 +621,12 @@ export type MutationUpdateUserProfileArgs = {
   input: UpdateUserProfileInput;
 };
 
+
+export type MutationUpdateWishlistArgs = {
+  id: Scalars['WishlistId']['input'];
+  input: UpdateWishlistInput;
+};
+
 export type NotFoundRejection = {
   __typename: 'NotFoundRejection';
   message: Scalars['String']['output'];
@@ -483,6 +653,12 @@ export type PendingEmailChange = {
 
 export type Query = {
   __typename: 'Query';
+  adminEvent: AdminGetEventByIdResult;
+  adminEvents: AdminGetEventsResult;
+  adminUser: AdminGetUserByIdResult;
+  adminUsers: AdminGetAllUsersResult;
+  adminWishlists: AdminGetWishlistsResult;
+  closestFriends: ClosestFriendsResult;
   currentUser: GetCurrentUserResult;
   event?: Maybe<GetEventByIdResult>;
   events: GetMyEventsResult;
@@ -490,11 +666,40 @@ export type Query = {
   importableItems: GetImportableItemsResult;
   mySecretSantaDraw?: Maybe<GetMySecretSantaDrawResult>;
   pendingEmailChange?: Maybe<GetPendingEmailChangeResult>;
+  searchUsers: SearchUsersResult;
   secretSanta?: Maybe<GetSecretSantaForEventResult>;
-  user: AdminGetUserByIdResult;
-  users: AdminGetAllUsersResult;
   wishlist?: Maybe<GetWishlistByIdResult>;
   wishlists: GetMyWishlistsResult;
+};
+
+
+export type QueryAdminEventArgs = {
+  id: Scalars['EventId']['input'];
+};
+
+
+export type QueryAdminEventsArgs = {
+  filters: AdminEventPaginationFilters;
+};
+
+
+export type QueryAdminUserArgs = {
+  userId: Scalars['UserId']['input'];
+};
+
+
+export type QueryAdminUsersArgs = {
+  input?: InputMaybe<AdminGetAllUsersPaginationFilters>;
+};
+
+
+export type QueryAdminWishlistsArgs = {
+  filters: AdminWishlistPaginationFilters;
+};
+
+
+export type QueryClosestFriendsArgs = {
+  limit?: InputMaybe<Scalars['Int']['input']>;
 };
 
 
@@ -518,18 +723,13 @@ export type QueryMySecretSantaDrawArgs = {
 };
 
 
+export type QuerySearchUsersArgs = {
+  keyword: Scalars['String']['input'];
+};
+
+
 export type QuerySecretSantaArgs = {
   eventId: Scalars['EventId']['input'];
-};
-
-
-export type QueryUserArgs = {
-  userId: Scalars['UserId']['input'];
-};
-
-
-export type QueryUsersArgs = {
-  input?: InputMaybe<AdminGetAllUsersPaginationFilters>;
 };
 
 
@@ -552,7 +752,13 @@ export type RegisterUserInput = {
 
 export type RegisterUserResult = ForbiddenRejection | InternalErrorRejection | UnauthorizedRejection | User | ValidationRejection;
 
+export type RemoveEventAttendeeResult = ForbiddenRejection | InternalErrorRejection | NotFoundRejection | UnauthorizedRejection | ValidationRejection | VoidOutput;
+
 export type RemoveUserPictureResult = ForbiddenRejection | InternalErrorRejection | UnauthorizedRejection | ValidationRejection | VoidOutput;
+
+export type RemoveWishlistCoOwnerResult = ForbiddenRejection | InternalErrorRejection | NotFoundRejection | UnauthorizedRejection | ValidationRejection | VoidOutput;
+
+export type RemoveWishlistLogoResult = ForbiddenRejection | InternalErrorRejection | NotFoundRejection | UnauthorizedRejection | ValidationRejection | VoidOutput;
 
 export type RequestEmailChangeInput = {
   newEmail: Scalars['String']['input'];
@@ -578,6 +784,13 @@ export type ScanItemUrlOutput = {
 };
 
 export type ScanItemUrlResult = ForbiddenRejection | InternalErrorRejection | ScanItemUrlOutput | UnauthorizedRejection | ValidationRejection;
+
+export type SearchUsersOutput = {
+  __typename: 'SearchUsersOutput';
+  users: Array<User>;
+};
+
+export type SearchUsersResult = ForbiddenRejection | InternalErrorRejection | SearchUsersOutput | UnauthorizedRejection | ValidationRejection;
 
 export type SecretSanta = {
   __typename: 'SecretSanta';
@@ -626,6 +839,17 @@ export type UnauthorizedRejection = {
 
 export type UnlinkCurrentUserSocialResult = ForbiddenRejection | InternalErrorRejection | UnauthorizedRejection | ValidationRejection | VoidOutput;
 
+export type UnlinkWishlistFromEventResult = ForbiddenRejection | InternalErrorRejection | NotFoundRejection | UnauthorizedRejection | ValidationRejection | VoidOutput;
+
+export type UpdateEventInput = {
+  description?: InputMaybe<Scalars['String']['input']>;
+  eventDate: Scalars['String']['input'];
+  icon?: InputMaybe<Scalars['String']['input']>;
+  title: Scalars['String']['input'];
+};
+
+export type UpdateEventResult = ForbiddenRejection | InternalErrorRejection | NotFoundRejection | UnauthorizedRejection | ValidationRejection | VoidOutput;
+
 export type UpdateItemInput = {
   description?: InputMaybe<Scalars['String']['input']>;
   name: Scalars['String']['input'];
@@ -668,6 +892,13 @@ export type UpdateUserProfileInput = {
 };
 
 export type UpdateUserProfileResult = ForbiddenRejection | InternalErrorRejection | UnauthorizedRejection | User | ValidationRejection;
+
+export type UpdateWishlistInput = {
+  description?: InputMaybe<Scalars['String']['input']>;
+  title: Scalars['String']['input'];
+};
+
+export type UpdateWishlistResult = ForbiddenRejection | InternalErrorRejection | NotFoundRejection | UnauthorizedRejection | ValidationRejection | VoidOutput;
 
 export type User = {
   __typename: 'User';

--- a/apps/api/src/user/infrastructure/resolvers/user-admin.resolver.int-spec.ts
+++ b/apps/api/src/user/infrastructure/resolvers/user-admin.resolver.int-spec.ts
@@ -19,10 +19,10 @@ describe('UserAdminResolver (GraphQL)', () => {
   // ---------------------------------------------------------------------------
   // user
   // ---------------------------------------------------------------------------
-  describe('Query user', () => {
+  describe('Query adminUser', () => {
     const query = /* GraphQL */ `
       query AdminGetUserById($userId: UserId!) {
-        user(userId: $userId) {
+        adminUser(userId: $userId) {
           __typename
           ... on UserFull {
             id
@@ -64,7 +64,7 @@ describe('UserAdminResolver (GraphQL)', () => {
         .expect(200)
 
       // Unauthenticated requests must NOT resolve to a UserFull payload
-      expect(res.body.data?.user?.__typename).not.toBe('UserFull')
+      expect(res.body.data?.adminUser?.__typename).not.toBe('UserFull')
     })
 
     describe('when user is authenticated as BASE_USER (non-admin)', () => {
@@ -86,7 +86,7 @@ describe('UserAdminResolver (GraphQL)', () => {
           .send({ query, variables: { userId: targetUserId } })
           .expect(200)
 
-        expect(res.body.data.user).toMatchObject({ __typename: 'ForbiddenRejection' })
+        expect(res.body.data.adminUser).toMatchObject({ __typename: 'ForbiddenRejection' })
       })
     })
 
@@ -109,7 +109,7 @@ describe('UserAdminResolver (GraphQL)', () => {
           .expect(200)
 
         // insertUser never persists a birthday, so it is always null here.
-        expect(res.body.data.user).toMatchObject({
+        expect(res.body.data.adminUser).toMatchObject({
           __typename: 'UserFull',
           id: targetUserId,
           firstName: 'Target',
@@ -128,7 +128,7 @@ describe('UserAdminResolver (GraphQL)', () => {
           .send({ query, variables: { userId: uuid() } })
           .expect(200)
 
-        expect(res.body.data.user).toMatchObject({ __typename: 'NotFoundRejection' })
+        expect(res.body.data.adminUser).toMatchObject({ __typename: 'NotFoundRejection' })
       })
 
       it('should not return a user when userId is malformed', async () => {
@@ -139,7 +139,7 @@ describe('UserAdminResolver (GraphQL)', () => {
           .send({ query, variables: { userId: 'not-a-uuid' } })
           .expect(200)
 
-        expect(res.body.data.user.__typename).not.toBe('UserFull')
+        expect(res.body.data.adminUser.__typename).not.toBe('UserFull')
       })
     })
   })
@@ -147,10 +147,10 @@ describe('UserAdminResolver (GraphQL)', () => {
   // ---------------------------------------------------------------------------
   // users (pagination)
   // ---------------------------------------------------------------------------
-  describe('Query users', () => {
+  describe('Query adminUsers', () => {
     const query = /* GraphQL */ `
       query AdminGetAllUsers($input: AdminGetAllUsersPaginationFilters) {
-        users(input: $input) {
+        adminUsers(input: $input) {
           __typename
           ... on AdminGetAllUsers {
             data {
@@ -187,7 +187,7 @@ describe('UserAdminResolver (GraphQL)', () => {
         .send({ query, variables: { input: {} } })
         .expect(200)
 
-      expect(res.body.data?.users?.__typename).not.toBe('AdminGetAllUsers')
+      expect(res.body.data?.adminUsers?.__typename).not.toBe('AdminGetAllUsers')
     })
 
     it('should reject a BASE_USER with ForbiddenRejection', async () => {
@@ -198,7 +198,7 @@ describe('UserAdminResolver (GraphQL)', () => {
         .send({ query, variables: { input: {} } })
         .expect(200)
 
-      expect(res.body.data.users).toMatchObject({ __typename: 'ForbiddenRejection' })
+      expect(res.body.data.adminUsers).toMatchObject({ __typename: 'ForbiddenRejection' })
     })
 
     describe('when user is authenticated as ADMIN_USER', () => {
@@ -216,13 +216,13 @@ describe('UserAdminResolver (GraphQL)', () => {
           .send({ query, variables: { input: { page: 1, limit: 50 } } })
           .expect(200)
 
-        expect(res.body.data.users.__typename).toBe('AdminGetAllUsers')
-        expect(res.body.data.users.pagination).toMatchObject({
+        expect(res.body.data.adminUsers.__typename).toBe('AdminGetAllUsers')
+        expect(res.body.data.adminUsers.pagination).toMatchObject({
           totalElements: 3,
           pageNumber: 1,
           pageSize: 50,
         })
-        expect(res.body.data.users.data).toHaveLength(3)
+        expect(res.body.data.adminUsers.data).toHaveLength(3)
       })
 
       it('should respect pagination (limit / page)', async () => {
@@ -234,8 +234,8 @@ describe('UserAdminResolver (GraphQL)', () => {
           .send({ query, variables: { input: { page: 1, limit: 2 } } })
           .expect(200)
 
-        expect(firstPage.body.data.users.data).toHaveLength(2)
-        expect(firstPage.body.data.users.pagination).toMatchObject({
+        expect(firstPage.body.data.adminUsers.data).toHaveLength(2)
+        expect(firstPage.body.data.adminUsers.pagination).toMatchObject({
           totalElements: 3,
           totalPages: 2,
           pageNumber: 1,
@@ -247,8 +247,8 @@ describe('UserAdminResolver (GraphQL)', () => {
           .send({ query, variables: { input: { page: 2, limit: 2 } } })
           .expect(200)
 
-        expect(secondPage.body.data.users.data).toHaveLength(1)
-        expect(secondPage.body.data.users.pagination).toMatchObject({
+        expect(secondPage.body.data.adminUsers.data).toHaveLength(1)
+        expect(secondPage.body.data.adminUsers.pagination).toMatchObject({
           totalElements: 3,
           pageNumber: 2,
           pageSize: 2,
@@ -264,9 +264,9 @@ describe('UserAdminResolver (GraphQL)', () => {
           .send({ query, variables: { input: { criteria: 'alice' } } })
           .expect(200)
 
-        expect(res.body.data.users.__typename).toBe('AdminGetAllUsers')
-        expect(res.body.data.users.data).toHaveLength(1)
-        expect(res.body.data.users.data[0]).toMatchObject({ email: 'alice@test.fr' })
+        expect(res.body.data.adminUsers.__typename).toBe('AdminGetAllUsers')
+        expect(res.body.data.adminUsers.data).toHaveLength(1)
+        expect(res.body.data.adminUsers.data[0]).toMatchObject({ email: 'alice@test.fr' })
       })
 
       it.each([
@@ -275,7 +275,7 @@ describe('UserAdminResolver (GraphQL)', () => {
       ])('should return ValidationRejection when $case', async ({ input }) => {
         const res = await request.post(GRAPHQL_PATH).send({ query, variables: { input } }).expect(200)
 
-        expect(res.body.data.users).toMatchObject({ __typename: 'ValidationRejection' })
+        expect(res.body.data.adminUsers).toMatchObject({ __typename: 'ValidationRejection' })
       })
     })
   })

--- a/apps/api/src/user/infrastructure/resolvers/user-admin.resolver.ts
+++ b/apps/api/src/user/infrastructure/resolvers/user-admin.resolver.ts
@@ -34,7 +34,7 @@ export class UserAdminResolver {
   ) {}
 
   @Query()
-  async user(
+  async adminUser(
     @Args('userId', new ZodPipe(UserIdSchema)) userId: UserId,
     @Context() ctx: GraphQLContext,
   ): Promise<AdminGetUserByIdResult> {
@@ -48,7 +48,7 @@ export class UserAdminResolver {
   }
 
   @Query()
-  async users(
+  async adminUsers(
     @Args('input', new ZodPipe(AdminGetAllUsersPaginationFiltersSchema)) input: AdminGetAllUsersPaginationFilters,
   ): Promise<AdminGetAllUsersResult> {
     const pageSize = input.limit ?? DEFAULT_RESULT_NUMBER

--- a/apps/api/src/user/infrastructure/resolvers/user.resolver.int-spec.ts
+++ b/apps/api/src/user/infrastructure/resolvers/user.resolver.int-spec.ts
@@ -558,4 +558,117 @@ describe('UserResolver (GraphQL)', () => {
       expect(Array.isArray(user.socials)).toBe(true)
     })
   })
+
+  describe('Query searchUsers', () => {
+    const query = /* GraphQL */ `
+      query SearchUsers($keyword: String!) {
+        searchUsers(keyword: $keyword) {
+          __typename
+          ... on SearchUsersOutput {
+            users {
+              id
+              firstName
+              lastName
+              email
+            }
+          }
+          ... on ValidationRejection {
+            errors {
+              field
+              message
+            }
+          }
+          ... on UnauthorizedRejection {
+            message
+          }
+        }
+      }
+    `
+
+    it('should not succeed when not authenticated', async () => {
+      const anon = await getRequest()
+      const res = await anon
+        .post('/graphql')
+        .send({ query, variables: { keyword: 'someone' } })
+        .expect(200)
+
+      expect(res.body.data?.searchUsers?.__typename).not.toBe('SearchUsersOutput')
+    })
+
+    it('should return matching users excluding the current user', async () => {
+      const targetId = await fixtures.insertUser({
+        email: 'zorglub@test.fr',
+        firstname: 'Zorglub',
+        lastname: 'Searchable',
+      })
+
+      const res = await request
+        .post('/graphql')
+        .send({ query, variables: { keyword: 'Zorglub' } })
+        .expect(200)
+
+      expect(res.body.data.searchUsers.__typename).toBe('SearchUsersOutput')
+      const ids = res.body.data.searchUsers.users.map((u: { id: string }) => u.id)
+      expect(ids).toContain(targetId)
+      expect(ids).not.toContain(currentUserId)
+    })
+
+    it.each([
+      { keyword: '', case: 'empty keyword' },
+      { keyword: 'a', case: 'keyword too short' },
+    ])('should return ValidationRejection when invalid input: $case', async ({ keyword }) => {
+      const res = await request.post('/graphql').send({ query, variables: { keyword } }).expect(200)
+
+      expect(res.body.data.searchUsers.__typename).toBe('ValidationRejection')
+    })
+  })
+
+  describe('Query closestFriends', () => {
+    const query = /* GraphQL */ `
+      query ClosestFriends($limit: Int) {
+        closestFriends(limit: $limit) {
+          __typename
+          ... on ClosestFriendsOutput {
+            users {
+              id
+              firstName
+              lastName
+            }
+          }
+          ... on ValidationRejection {
+            errors {
+              field
+              message
+            }
+          }
+          ... on UnauthorizedRejection {
+            message
+          }
+        }
+      }
+    `
+
+    it('should not succeed when not authenticated', async () => {
+      const anon = await getRequest()
+      const res = await anon.post('/graphql').send({ query, variables: {} }).expect(200)
+
+      expect(res.body.data?.closestFriends?.__typename).not.toBe('ClosestFriendsOutput')
+    })
+
+    it('should return a ClosestFriendsOutput for an authenticated user', async () => {
+      const res = await request.post('/graphql').send({ query, variables: {} }).expect(200)
+
+      expect(res.body.data.closestFriends.__typename).toBe('ClosestFriendsOutput')
+      expect(Array.isArray(res.body.data.closestFriends.users)).toBe(true)
+    })
+
+    it('should return ValidationRejection when limit exceeds the maximum', async () => {
+      const res = await request
+        .post('/graphql')
+        .send({ query, variables: { limit: 51 } })
+        .expect(200)
+
+      expect(res.body.data.closestFriends.__typename).toBe('ValidationRejection')
+    })
+  })
 })

--- a/apps/api/src/user/infrastructure/resolvers/user.resolver.ts
+++ b/apps/api/src/user/infrastructure/resolvers/user.resolver.ts
@@ -9,6 +9,7 @@ import { RealIP } from 'nestjs-real-ip'
 import {
   ChangeUserPasswordInput,
   ChangeUserPasswordResult,
+  ClosestFriendsResult,
   ConfirmEmailChangeInput,
   ConfirmEmailChangeResult,
   GetPendingEmailChangeResult,
@@ -22,6 +23,7 @@ import {
   RequestEmailChangeResult,
   ResetPasswordInput,
   ResetPasswordResult,
+  SearchUsersResult,
   SendResetPasswordEmailInput,
   SendResetPasswordEmailResult,
   UnlinkCurrentUserSocialResult,
@@ -46,14 +48,18 @@ import { UpdateUserUseCase } from '../../application/command/update-user.use-cas
 import { UpdateUserEmailSettingUseCase } from '../../application/command/update-user-email-setting.use-case'
 import { UpdateUserPasswordUseCase } from '../../application/command/update-user-password.use-case'
 import { UpdateUserPictureFromSocialUseCase } from '../../application/command/update-user-picture-from-social.use-case'
+import { GetClosestFriendsUseCase } from '../../application/query/get-closest-friends.use-case'
 import { GetPendingEmailChangeUseCase } from '../../application/query/get-pending-email-change.use-case'
+import { GetUsersByCriteriaUseCase } from '../../application/query/get-users-by-criteria.use-case'
 import {
   ChangeUserPasswordInputSchema,
+  ClosestFriendsLimitSchema,
   ConfirmEmailChangeInputSchema,
   LinkUserToGoogleInputSchema,
   RegisterUserInputSchema,
   RequestEmailChangeInputSchema,
   ResetPasswordInputSchema,
+  SearchUsersKeywordSchema,
   SendResetPasswordEmailInputSchema,
   UpdateUserEmailSettingsInputSchema,
   UpdateUserPictureFromSocialInputSchema,
@@ -76,6 +82,8 @@ export class UserResolver {
     private readonly updateUserEmailSettingUseCase: UpdateUserEmailSettingUseCase,
     private readonly createPasswordVerificationUseCase: CreatePasswordVerificationUseCase,
     private readonly resetUserPasswordUseCase: ResetUserPasswordUseCase,
+    private readonly getUsersByCriteriaUseCase: GetUsersByCriteriaUseCase,
+    private readonly getClosestFriendsUseCase: GetClosestFriendsUseCase,
   ) {}
 
   @Query()
@@ -85,6 +93,36 @@ export class UserResolver {
       throw new Error('User not found')
     }
     return user
+  }
+
+  @Query()
+  async searchUsers(
+    @Args('keyword', new ZodPipe(SearchUsersKeywordSchema)) keyword: string,
+    @GqlCurrentUser() currentUser: ICurrentUser,
+    @Context() ctx: GraphQLContext,
+  ): Promise<SearchUsersResult> {
+    const miniUsers = await this.getUsersByCriteriaUseCase.execute({ currentUser, criteria: keyword })
+    const users = await Promise.all(miniUsers.map(user => ctx.loaders.user.load(user.id)))
+
+    return {
+      __typename: 'SearchUsersOutput',
+      users: users.filter((user): user is User => !!user),
+    }
+  }
+
+  @Query()
+  async closestFriends(
+    @Args('limit', new ZodPipe(ClosestFriendsLimitSchema)) limit: number | undefined,
+    @GqlCurrentUser('id') currentUserId: UserId,
+    @Context() ctx: GraphQLContext,
+  ): Promise<ClosestFriendsResult> {
+    const miniUsers = await this.getClosestFriendsUseCase.execute({ userId: currentUserId, limit: limit ?? 20 })
+    const users = await Promise.all(miniUsers.map(user => ctx.loaders.user.load(user.id)))
+
+    return {
+      __typename: 'ClosestFriendsOutput',
+      users: users.filter((user): user is User => !!user),
+    }
   }
 
   @Public()

--- a/apps/api/src/user/infrastructure/user-admin.graphql
+++ b/apps/api/src/user/infrastructure/user-admin.graphql
@@ -76,8 +76,8 @@ union AdminRemoveUserPictureResult =
   | InternalErrorRejection
 
 extend type Query {
-  user(userId: UserId!): AdminGetUserByIdResult!
-  users(input: AdminGetAllUsersPaginationFilters): AdminGetAllUsersResult!
+  adminUser(userId: UserId!): AdminGetUserByIdResult!
+  adminUsers(input: AdminGetAllUsersPaginationFilters): AdminGetAllUsersResult!
 }
 
 extend type Mutation {

--- a/apps/api/src/user/infrastructure/user.graphql
+++ b/apps/api/src/user/infrastructure/user.graphql
@@ -36,6 +36,28 @@ type UserEmailSettings {
 
 union GetCurrentUserResult = User | UnauthorizedRejection | ForbiddenRejection | InternalErrorRejection
 
+type SearchUsersOutput {
+  users: [User!]!
+}
+
+type ClosestFriendsOutput {
+  users: [User!]!
+}
+
+union SearchUsersResult =
+  | SearchUsersOutput
+  | ValidationRejection
+  | UnauthorizedRejection
+  | ForbiddenRejection
+  | InternalErrorRejection
+
+union ClosestFriendsResult =
+  | ClosestFriendsOutput
+  | ValidationRejection
+  | UnauthorizedRejection
+  | ForbiddenRejection
+  | InternalErrorRejection
+
 union GetPendingEmailChangeResult =
   | PendingEmailChange
   | UnauthorizedRejection
@@ -179,6 +201,8 @@ union ResetPasswordResult =
 extend type Query {
   currentUser: GetCurrentUserResult!
   pendingEmailChange: GetPendingEmailChangeResult
+  searchUsers(keyword: String!): SearchUsersResult!
+  closestFriends(limit: Int): ClosestFriendsResult!
 }
 
 extend type Mutation {

--- a/apps/api/src/user/infrastructure/user.schema.ts
+++ b/apps/api/src/user/infrastructure/user.schema.ts
@@ -16,6 +16,10 @@ import z from 'zod'
 
 export const UserIdSchema = z.string().transform(val => val as UserId)
 
+export const SearchUsersKeywordSchema = z.string().trim().min(2).max(100)
+
+export const ClosestFriendsLimitSchema = z.number().int().min(1).max(50).optional()
+
 export const UpdateUserProfileInputSchema = z.object({
   firstname: z.string().nonempty().max(50),
   lastname: z.string().nonempty().max(50),

--- a/apps/api/src/wishlist/infrastructure/resolvers/wishlist-admin.resolver.int-spec.ts
+++ b/apps/api/src/wishlist/infrastructure/resolvers/wishlist-admin.resolver.int-spec.ts
@@ -1,0 +1,200 @@
+import type { RequestApp } from '@wishlist/api-test-utils'
+
+import { Fixtures, useTestApp } from '@wishlist/api-test-utils'
+import { uuid } from '@wishlist/common'
+
+const GRAPHQL_PATH = '/graphql'
+
+/**
+ * Integration tests for the GraphQL WishlistAdminResolver (@IsAdmin).
+ *
+ * GraphQL always returns HTTP 200; thrown Nest exceptions are mapped to typed
+ * rejections placed at data.<field>. A non-admin authenticated user is rejected
+ * with a ForbiddenRejection.
+ */
+describe('WishlistAdminResolver (GraphQL)', () => {
+  const { getRequest, getFixtures } = useTestApp()
+  let fixtures: Fixtures
+
+  beforeEach(() => {
+    fixtures = getFixtures()
+  })
+
+  describe('Query adminWishlists', () => {
+    const query = /* GraphQL */ `
+      query AdminWishlists($filters: AdminWishlistPaginationFilters!) {
+        adminWishlists(filters: $filters) {
+          __typename
+          ... on AdminGetWishlists {
+            data {
+              id
+              title
+              ownerId
+            }
+            pagination {
+              totalPages
+              totalElements
+              pageNumber
+              pageSize
+            }
+          }
+          ... on ForbiddenRejection {
+            message
+          }
+          ... on ValidationRejection {
+            errors {
+              field
+              message
+            }
+          }
+        }
+      }
+    `
+
+    it('should not succeed when unauthenticated', async () => {
+      const request = await getRequest()
+      const res = await request
+        .post(GRAPHQL_PATH)
+        .send({ query, variables: { filters: { userId: uuid() } } })
+        .expect(200)
+
+      expect(res.body.data?.adminWishlists?.__typename).not.toBe('AdminGetWishlists')
+    })
+
+    it('should reject a BASE_USER with ForbiddenRejection', async () => {
+      const request = await getRequest({ signedAs: 'BASE_USER' })
+      const res = await request
+        .post(GRAPHQL_PATH)
+        .send({ query, variables: { filters: { userId: uuid() } } })
+        .expect(200)
+
+      expect(res.body.data.adminWishlists).toMatchObject({ __typename: 'ForbiddenRejection' })
+    })
+
+    describe('when user is authenticated as ADMIN_USER', () => {
+      let request: RequestApp
+
+      beforeEach(async () => {
+        request = await getRequest({ signedAs: 'ADMIN_USER' })
+      })
+
+      it("should return a paginated list of a given user's wishlists", async () => {
+        const targetUserId = await fixtures.insertUser({
+          email: 'target@test.fr',
+          firstname: 'Target',
+          lastname: 'User',
+        })
+
+        const { eventId } = await fixtures.insertEventWithMaintainer({
+          title: 'Target Event',
+          maintainerId: targetUserId,
+        })
+
+        const wishlistId = await fixtures.insertWishlist({
+          eventIds: [eventId],
+          userId: targetUserId,
+          title: 'Target Wishlist',
+        })
+
+        // A wishlist owned by another user, which must NOT be returned
+        const otherUserId = await fixtures.insertUser({
+          email: 'other@test.fr',
+          firstname: 'Other',
+          lastname: 'User',
+        })
+        const { eventId: otherEventId } = await fixtures.insertEventWithMaintainer({
+          title: 'Other Event',
+          maintainerId: otherUserId,
+        })
+        await fixtures.insertWishlist({
+          eventIds: [otherEventId],
+          userId: otherUserId,
+          title: 'Other Wishlist',
+        })
+
+        const res = await request
+          .post(GRAPHQL_PATH)
+          .send({ query, variables: { filters: { userId: targetUserId, page: 1, limit: 50 } } })
+          .expect(200)
+
+        expect(res.body.data.adminWishlists.__typename).toBe('AdminGetWishlists')
+        expect(res.body.data.adminWishlists.data).toEqual([
+          expect.objectContaining({ id: wishlistId, title: 'Target Wishlist', ownerId: targetUserId }),
+        ])
+        expect(res.body.data.adminWishlists.pagination).toMatchObject({
+          totalElements: 1,
+          pageNumber: 1,
+          pageSize: 50,
+        })
+      })
+
+      it('should respect pagination (limit / page)', async () => {
+        const targetUserId = await fixtures.insertUser({
+          email: 'target@test.fr',
+          firstname: 'Target',
+          lastname: 'User',
+        })
+
+        const { eventId } = await fixtures.insertEventWithMaintainer({
+          title: 'Target Event',
+          maintainerId: targetUserId,
+        })
+
+        await fixtures.insertWishlist({ eventIds: [eventId], userId: targetUserId, title: 'WL 1' })
+        await fixtures.insertWishlist({ eventIds: [eventId], userId: targetUserId, title: 'WL 2' })
+        await fixtures.insertWishlist({ eventIds: [eventId], userId: targetUserId, title: 'WL 3' })
+
+        const firstPage = await request
+          .post(GRAPHQL_PATH)
+          .send({ query, variables: { filters: { userId: targetUserId, page: 1, limit: 2 } } })
+          .expect(200)
+
+        expect(firstPage.body.data.adminWishlists.data).toHaveLength(2)
+        expect(firstPage.body.data.adminWishlists.pagination).toMatchObject({
+          totalElements: 3,
+          totalPages: 2,
+          pageNumber: 1,
+          pageSize: 2,
+        })
+
+        const secondPage = await request
+          .post(GRAPHQL_PATH)
+          .send({ query, variables: { filters: { userId: targetUserId, page: 2, limit: 2 } } })
+          .expect(200)
+
+        expect(secondPage.body.data.adminWishlists.data).toHaveLength(1)
+        expect(secondPage.body.data.adminWishlists.pagination).toMatchObject({
+          totalElements: 3,
+          pageNumber: 2,
+          pageSize: 2,
+        })
+      })
+
+      it('should return an empty list when the user has no wishlist', async () => {
+        const targetUserId = await fixtures.insertUser({
+          email: 'target@test.fr',
+          firstname: 'Target',
+          lastname: 'User',
+        })
+
+        const res = await request
+          .post(GRAPHQL_PATH)
+          .send({ query, variables: { filters: { userId: targetUserId } } })
+          .expect(200)
+
+        expect(res.body.data.adminWishlists.__typename).toBe('AdminGetWishlists')
+        expect(res.body.data.adminWishlists.data).toEqual([])
+        expect(res.body.data.adminWishlists.pagination).toMatchObject({ totalElements: 0 })
+      })
+
+      it.each([
+        { filters: { userId: uuid(), page: 0 }, case: 'page below minimum' },
+        { filters: { userId: uuid(), limit: 0 }, case: 'limit below minimum' },
+      ])('should return ValidationRejection when $case', async ({ filters }) => {
+        const res = await request.post(GRAPHQL_PATH).send({ query, variables: { filters } }).expect(200)
+
+        expect(res.body.data.adminWishlists).toMatchObject({ __typename: 'ValidationRejection' })
+      })
+    })
+  })
+})

--- a/apps/api/src/wishlist/infrastructure/resolvers/wishlist-admin.resolver.ts
+++ b/apps/api/src/wishlist/infrastructure/resolvers/wishlist-admin.resolver.ts
@@ -1,0 +1,46 @@
+import { Args, Query, Resolver } from '@nestjs/graphql'
+import { IsAdmin } from '@wishlist/api/auth'
+import { DEFAULT_RESULT_NUMBER, ZodPipe } from '@wishlist/api/core'
+import { createPagedResponse } from '@wishlist/common'
+
+import { AdminGetWishlistsResult, AdminWishlistPaginationFilters } from '../../../gql/generated-types'
+import { GetWishlistsByUserUseCase } from '../../application/query/get-wishlists-by-user.use-case'
+import { wishlistMapper } from '../wishlist.mapper'
+import { AdminWishlistPaginationFiltersSchema } from '../wishlist.schema'
+
+@IsAdmin()
+@Resolver()
+export class WishlistAdminResolver {
+  constructor(private readonly getWishlistsByUserUseCase: GetWishlistsByUserUseCase) {}
+
+  @Query()
+  async adminWishlists(
+    @Args('filters', new ZodPipe(AdminWishlistPaginationFiltersSchema)) filters: AdminWishlistPaginationFilters,
+  ): Promise<AdminGetWishlistsResult> {
+    const pageSize = filters.limit ?? DEFAULT_RESULT_NUMBER
+    const pageNumber = filters.page ?? 1
+
+    const { wishlists, totalCount } = await this.getWishlistsByUserUseCase.execute({
+      userId: filters.userId,
+      pageNumber,
+      pageSize,
+    })
+
+    const pagedResponse = createPagedResponse({
+      resources: wishlists.map(wishlist => wishlistMapper.toGqlWishlist({ wishlist, currentUserId: filters.userId })),
+      options: { pageSize, totalElements: totalCount, pageNumber },
+    })
+
+    return {
+      __typename: 'AdminGetWishlists',
+      data: pagedResponse.resources,
+      pagination: {
+        __typename: 'Pagination',
+        totalPages: pagedResponse.pagination.total_pages,
+        totalElements: pagedResponse.pagination.total_elements,
+        pageNumber: pagedResponse.pagination.page_number,
+        pageSize: pagedResponse.pagination.pages_size,
+      },
+    }
+  }
+}

--- a/apps/api/src/wishlist/infrastructure/resolvers/wishlist-mutation.resolver.int-spec.ts
+++ b/apps/api/src/wishlist/infrastructure/resolvers/wishlist-mutation.resolver.int-spec.ts
@@ -1,0 +1,843 @@
+import type { RequestApp } from '@wishlist/api-test-utils'
+
+import { Fixtures, useTestApp } from '@wishlist/api-test-utils'
+import { uuid } from '@wishlist/common'
+
+const GRAPHQL_PATH = '/graphql'
+
+/**
+ * Integration tests for the GraphQL WishlistMutationResolver.
+ *
+ * GraphQL always returns HTTP 200; thrown Nest exceptions are mapped to typed
+ * rejections placed at data.<field>:
+ *   ZodValidationException -> ValidationRejection
+ *   UnauthorizedException  -> UnauthorizedRejection
+ *   NotFoundException      -> NotFoundRejection
+ *   ForbiddenException     -> ForbiddenRejection
+ *   other HttpException    -> InternalErrorRejection
+ */
+describe('WishlistMutationResolver (GraphQL)', () => {
+  const { getRequest, getFixtures, expectTable } = useTestApp()
+  let fixtures: Fixtures
+
+  beforeEach(() => {
+    fixtures = getFixtures()
+  })
+
+  // ---------------------------------------------------------------------------
+  // updateWishlist
+  // ---------------------------------------------------------------------------
+  describe('Mutation updateWishlist', () => {
+    const mutation = /* GraphQL */ `
+      mutation UpdateWishlist($id: WishlistId!, $input: UpdateWishlistInput!) {
+        updateWishlist(id: $id, input: $input) {
+          __typename
+          ... on VoidOutput {
+            success
+          }
+          ... on ValidationRejection {
+            errors {
+              field
+              message
+            }
+          }
+          ... on UnauthorizedRejection {
+            message
+          }
+        }
+      }
+    `
+
+    it('should not succeed when not authenticated', async () => {
+      const request = await getRequest()
+      const res = await request
+        .post(GRAPHQL_PATH)
+        .send({ query: mutation, variables: { id: uuid(), input: { title: 'Updated' } } })
+        .expect(200)
+
+      expect(res.body.data?.updateWishlist?.__typename).not.toBe('VoidOutput')
+    })
+
+    describe('when user is authenticated', () => {
+      let request: RequestApp
+      let currentUserId: string
+
+      beforeEach(async () => {
+        request = await getRequest({ signedAs: 'BASE_USER' })
+        currentUserId = await fixtures.getSignedUserId('BASE_USER')
+      })
+
+      it('should update the wishlist successfully', async () => {
+        const { eventId } = await fixtures.insertEventWithMaintainer({
+          title: 'Test Event',
+          maintainerId: currentUserId,
+        })
+
+        const wishlistId = await fixtures.insertWishlist({
+          eventIds: [eventId],
+          userId: currentUserId,
+          title: 'Original',
+          description: 'Original description',
+        })
+
+        const res = await request
+          .post(GRAPHQL_PATH)
+          .send({
+            query: mutation,
+            variables: { id: wishlistId, input: { title: 'Updated', description: 'Updated description' } },
+          })
+          .expect(200)
+
+        expect(res.body.data.updateWishlist).toEqual({ __typename: 'VoidOutput', success: true })
+
+        await expectTable(Fixtures.WISHLIST_TABLE).hasNumberOfRows(1).row(0).toMatchObject({
+          id: wishlistId,
+          title: 'Updated',
+          description: 'Updated description',
+          updated_at: expect.toBeDate(),
+        })
+      })
+
+      it.each([
+        { case: 'empty title', input: { title: '' }, field: 'title' },
+        { case: 'title too long', input: { title: 'a'.repeat(101) }, field: 'title' },
+        {
+          case: 'description too long',
+          input: { title: 'Valid', description: 'a'.repeat(2001) },
+          field: 'description',
+        },
+      ])('should return ValidationRejection when invalid input: $case', async ({ input, field }) => {
+        const { eventId } = await fixtures.insertEventWithMaintainer({
+          title: 'Test Event',
+          maintainerId: currentUserId,
+        })
+
+        const wishlistId = await fixtures.insertWishlist({
+          eventIds: [eventId],
+          userId: currentUserId,
+          title: 'Original',
+        })
+
+        const res = await request
+          .post(GRAPHQL_PATH)
+          .send({ query: mutation, variables: { id: wishlistId, input } })
+          .expect(200)
+
+        expect(res.body.data.updateWishlist.__typename).toBe('ValidationRejection')
+        expect(res.body.data.updateWishlist.errors).toEqual(
+          expect.arrayContaining([expect.objectContaining({ field })]),
+        )
+
+        await expectTable(Fixtures.WISHLIST_TABLE).hasNumberOfRows(1).row(0).toMatchObject({
+          id: wishlistId,
+          title: 'Original',
+        })
+      })
+
+      it('should return NotFoundRejection when wishlist does not exist', async () => {
+        const res = await request
+          .post(GRAPHQL_PATH)
+          .send({ query: mutation, variables: { id: uuid(), input: { title: 'Updated' } } })
+          .expect(200)
+
+        expect(res.body.data.updateWishlist.__typename).toBe('NotFoundRejection')
+      })
+
+      it('should return UnauthorizedRejection when user is not owner/co-owner', async () => {
+        const otherUserId = await fixtures.insertUser({
+          email: 'other@test.com',
+          firstname: 'Other',
+          lastname: 'User',
+        })
+
+        const { eventId } = await fixtures.insertEventWithMaintainer({
+          title: 'Other Event',
+          maintainerId: otherUserId,
+        })
+
+        const wishlistId = await fixtures.insertWishlist({
+          eventIds: [eventId],
+          userId: otherUserId,
+          title: 'Other Wishlist',
+        })
+
+        const res = await request
+          .post(GRAPHQL_PATH)
+          .send({ query: mutation, variables: { id: wishlistId, input: { title: 'Hacked' } } })
+          .expect(200)
+
+        expect(res.body.data.updateWishlist.__typename).toBe('UnauthorizedRejection')
+
+        await expectTable(Fixtures.WISHLIST_TABLE).hasNumberOfRows(1).row(0).toMatchObject({
+          id: wishlistId,
+          title: 'Other Wishlist',
+        })
+      })
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // deleteWishlist
+  // ---------------------------------------------------------------------------
+  describe('Mutation deleteWishlist', () => {
+    const mutation = /* GraphQL */ `
+      mutation DeleteWishlist($id: WishlistId!) {
+        deleteWishlist(id: $id) {
+          __typename
+          ... on VoidOutput {
+            success
+          }
+          ... on UnauthorizedRejection {
+            message
+          }
+        }
+      }
+    `
+
+    it('should not succeed when not authenticated', async () => {
+      const request = await getRequest()
+      const res = await request
+        .post(GRAPHQL_PATH)
+        .send({ query: mutation, variables: { id: uuid() } })
+        .expect(200)
+
+      expect(res.body.data?.deleteWishlist?.__typename).not.toBe('VoidOutput')
+    })
+
+    describe('when user is authenticated', () => {
+      let request: RequestApp
+      let currentUserId: string
+
+      beforeEach(async () => {
+        request = await getRequest({ signedAs: 'BASE_USER' })
+        currentUserId = await fixtures.getSignedUserId('BASE_USER')
+      })
+
+      it('should delete the wishlist successfully', async () => {
+        const { eventId } = await fixtures.insertEventWithMaintainer({
+          title: 'Test Event',
+          maintainerId: currentUserId,
+        })
+
+        const wishlistId = await fixtures.insertWishlist({
+          eventIds: [eventId],
+          userId: currentUserId,
+          title: 'My Wishlist',
+        })
+
+        const res = await request
+          .post(GRAPHQL_PATH)
+          .send({ query: mutation, variables: { id: wishlistId } })
+          .expect(200)
+
+        expect(res.body.data.deleteWishlist).toEqual({ __typename: 'VoidOutput', success: true })
+
+        await expectTable(Fixtures.WISHLIST_TABLE).hasNumberOfRows(0)
+      })
+
+      it('should return NotFoundRejection when wishlist does not exist', async () => {
+        const res = await request
+          .post(GRAPHQL_PATH)
+          .send({ query: mutation, variables: { id: uuid() } })
+          .expect(200)
+
+        expect(res.body.data.deleteWishlist.__typename).toBe('NotFoundRejection')
+      })
+
+      it('should return UnauthorizedRejection when user is not owner/co-owner and not delete it', async () => {
+        const otherUserId = await fixtures.insertUser({
+          email: 'other@test.com',
+          firstname: 'Other',
+          lastname: 'User',
+        })
+
+        const { eventId } = await fixtures.insertEventWithMaintainer({
+          title: 'Other Event',
+          maintainerId: otherUserId,
+        })
+
+        const wishlistId = await fixtures.insertWishlist({
+          eventIds: [eventId],
+          userId: otherUserId,
+          title: 'Other Wishlist',
+        })
+
+        const res = await request
+          .post(GRAPHQL_PATH)
+          .send({ query: mutation, variables: { id: wishlistId } })
+          .expect(200)
+
+        expect(res.body.data.deleteWishlist.__typename).toBe('UnauthorizedRejection')
+
+        await expectTable(Fixtures.WISHLIST_TABLE).hasNumberOfRows(1)
+      })
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // linkWishlistToEvent
+  // ---------------------------------------------------------------------------
+  describe('Mutation linkWishlistToEvent', () => {
+    const mutation = /* GraphQL */ `
+      mutation LinkWishlistToEvent($id: WishlistId!, $eventId: EventId!) {
+        linkWishlistToEvent(id: $id, eventId: $eventId) {
+          __typename
+          ... on VoidOutput {
+            success
+          }
+          ... on UnauthorizedRejection {
+            message
+          }
+        }
+      }
+    `
+
+    it('should not succeed when not authenticated', async () => {
+      const request = await getRequest()
+      const res = await request
+        .post(GRAPHQL_PATH)
+        .send({ query: mutation, variables: { id: uuid(), eventId: uuid() } })
+        .expect(200)
+
+      expect(res.body.data?.linkWishlistToEvent?.__typename).not.toBe('VoidOutput')
+    })
+
+    describe('when user is authenticated', () => {
+      let request: RequestApp
+      let currentUserId: string
+
+      beforeEach(async () => {
+        request = await getRequest({ signedAs: 'BASE_USER' })
+        currentUserId = await fixtures.getSignedUserId('BASE_USER')
+      })
+
+      it('should link the wishlist to another event successfully', async () => {
+        const { eventId: firstEventId } = await fixtures.insertEventWithMaintainer({
+          title: 'First Event',
+          maintainerId: currentUserId,
+        })
+
+        const { eventId: secondEventId } = await fixtures.insertEventWithMaintainer({
+          title: 'Second Event',
+          maintainerId: currentUserId,
+        })
+
+        const wishlistId = await fixtures.insertWishlist({
+          eventIds: [firstEventId],
+          userId: currentUserId,
+          title: 'My Wishlist',
+        })
+
+        const res = await request
+          .post(GRAPHQL_PATH)
+          .send({ query: mutation, variables: { id: wishlistId, eventId: secondEventId } })
+          .expect(200)
+
+        expect(res.body.data.linkWishlistToEvent).toEqual({ __typename: 'VoidOutput', success: true })
+
+        await expectTable(Fixtures.EVENT_WISHLIST_TABLE).hasNumberOfRows(2)
+      })
+
+      it('should return NotFoundRejection when wishlist does not exist', async () => {
+        const { eventId } = await fixtures.insertEventWithMaintainer({
+          title: 'Event',
+          maintainerId: currentUserId,
+        })
+
+        const res = await request
+          .post(GRAPHQL_PATH)
+          .send({ query: mutation, variables: { id: uuid(), eventId } })
+          .expect(200)
+
+        expect(res.body.data.linkWishlistToEvent.__typename).toBe('NotFoundRejection')
+      })
+
+      it('should return UnauthorizedRejection when user is not owner/co-owner', async () => {
+        const otherUserId = await fixtures.insertUser({
+          email: 'other@test.com',
+          firstname: 'Other',
+          lastname: 'User',
+        })
+
+        const { eventId: otherEventId } = await fixtures.insertEventWithMaintainer({
+          title: 'Other Event',
+          maintainerId: otherUserId,
+        })
+
+        const wishlistId = await fixtures.insertWishlist({
+          eventIds: [otherEventId],
+          userId: otherUserId,
+          title: 'Other Wishlist',
+        })
+
+        const { eventId: myEventId } = await fixtures.insertEventWithMaintainer({
+          title: 'My Event',
+          maintainerId: currentUserId,
+        })
+
+        const res = await request
+          .post(GRAPHQL_PATH)
+          .send({ query: mutation, variables: { id: wishlistId, eventId: myEventId } })
+          .expect(200)
+
+        expect(res.body.data.linkWishlistToEvent.__typename).toBe('UnauthorizedRejection')
+
+        await expectTable(Fixtures.EVENT_WISHLIST_TABLE).hasNumberOfRows(1)
+      })
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // unlinkWishlistFromEvent
+  // ---------------------------------------------------------------------------
+  describe('Mutation unlinkWishlistFromEvent', () => {
+    const mutation = /* GraphQL */ `
+      mutation UnlinkWishlistFromEvent($id: WishlistId!, $eventId: EventId!) {
+        unlinkWishlistFromEvent(id: $id, eventId: $eventId) {
+          __typename
+          ... on VoidOutput {
+            success
+          }
+          ... on UnauthorizedRejection {
+            message
+          }
+        }
+      }
+    `
+
+    it('should not succeed when not authenticated', async () => {
+      const request = await getRequest()
+      const res = await request
+        .post(GRAPHQL_PATH)
+        .send({ query: mutation, variables: { id: uuid(), eventId: uuid() } })
+        .expect(200)
+
+      expect(res.body.data?.unlinkWishlistFromEvent?.__typename).not.toBe('VoidOutput')
+    })
+
+    describe('when user is authenticated', () => {
+      let request: RequestApp
+      let currentUserId: string
+
+      beforeEach(async () => {
+        request = await getRequest({ signedAs: 'BASE_USER' })
+        currentUserId = await fixtures.getSignedUserId('BASE_USER')
+      })
+
+      it('should unlink the wishlist from an event successfully (keeping at least one)', async () => {
+        const { eventId: firstEventId } = await fixtures.insertEventWithMaintainer({
+          title: 'First Event',
+          maintainerId: currentUserId,
+        })
+
+        const { eventId: secondEventId } = await fixtures.insertEventWithMaintainer({
+          title: 'Second Event',
+          maintainerId: currentUserId,
+        })
+
+        const wishlistId = await fixtures.insertWishlist({
+          eventIds: [firstEventId, secondEventId],
+          userId: currentUserId,
+          title: 'My Wishlist',
+        })
+
+        const res = await request
+          .post(GRAPHQL_PATH)
+          .send({ query: mutation, variables: { id: wishlistId, eventId: secondEventId } })
+          .expect(200)
+
+        expect(res.body.data.unlinkWishlistFromEvent).toEqual({ __typename: 'VoidOutput', success: true })
+
+        await expectTable(Fixtures.EVENT_WISHLIST_TABLE).hasNumberOfRows(1).row(0).toMatchObject({
+          event_id: firstEventId,
+          wishlist_id: wishlistId,
+        })
+      })
+
+      it('should return NotFoundRejection when wishlist does not exist', async () => {
+        const res = await request
+          .post(GRAPHQL_PATH)
+          .send({ query: mutation, variables: { id: uuid(), eventId: uuid() } })
+          .expect(200)
+
+        expect(res.body.data.unlinkWishlistFromEvent.__typename).toBe('NotFoundRejection')
+      })
+
+      it('should return UnauthorizedRejection when user is not owner/co-owner', async () => {
+        const otherUserId = await fixtures.insertUser({
+          email: 'other@test.com',
+          firstname: 'Other',
+          lastname: 'User',
+        })
+
+        const { eventId: firstEventId } = await fixtures.insertEventWithMaintainer({
+          title: 'First Event',
+          maintainerId: otherUserId,
+        })
+
+        const { eventId: secondEventId } = await fixtures.insertEventWithMaintainer({
+          title: 'Second Event',
+          maintainerId: otherUserId,
+        })
+
+        const wishlistId = await fixtures.insertWishlist({
+          eventIds: [firstEventId, secondEventId],
+          userId: otherUserId,
+          title: 'Other Wishlist',
+        })
+
+        const res = await request
+          .post(GRAPHQL_PATH)
+          .send({ query: mutation, variables: { id: wishlistId, eventId: secondEventId } })
+          .expect(200)
+
+        expect(res.body.data.unlinkWishlistFromEvent.__typename).toBe('UnauthorizedRejection')
+
+        await expectTable(Fixtures.EVENT_WISHLIST_TABLE).hasNumberOfRows(2)
+      })
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // addWishlistCoOwner
+  // ---------------------------------------------------------------------------
+  describe('Mutation addWishlistCoOwner', () => {
+    const mutation = /* GraphQL */ `
+      mutation AddWishlistCoOwner($id: WishlistId!, $input: AddWishlistCoOwnerInput!) {
+        addWishlistCoOwner(id: $id, input: $input) {
+          __typename
+          ... on VoidOutput {
+            success
+          }
+          ... on UnauthorizedRejection {
+            message
+          }
+        }
+      }
+    `
+
+    it('should not succeed when not authenticated', async () => {
+      const request = await getRequest()
+      const res = await request
+        .post(GRAPHQL_PATH)
+        .send({ query: mutation, variables: { id: uuid(), input: { userId: uuid() } } })
+        .expect(200)
+
+      expect(res.body.data?.addWishlistCoOwner?.__typename).not.toBe('VoidOutput')
+    })
+
+    describe('when user is authenticated', () => {
+      let request: RequestApp
+      let currentUserId: string
+
+      beforeEach(async () => {
+        request = await getRequest({ signedAs: 'BASE_USER' })
+        currentUserId = await fixtures.getSignedUserId('BASE_USER')
+      })
+
+      it('should add a co-owner to a public wishlist successfully', async () => {
+        const coOwnerId = await fixtures.insertUser({
+          email: 'coowner@test.com',
+          firstname: 'Co',
+          lastname: 'Owner',
+        })
+
+        const { eventId } = await fixtures.insertEventWithMaintainer({
+          title: 'Test Event',
+          maintainerId: currentUserId,
+        })
+
+        const wishlistId = await fixtures.insertWishlist({
+          eventIds: [eventId],
+          userId: currentUserId,
+          title: 'Public Wishlist',
+          hideItems: false,
+        })
+
+        const res = await request
+          .post(GRAPHQL_PATH)
+          .send({ query: mutation, variables: { id: wishlistId, input: { userId: coOwnerId } } })
+          .expect(200)
+
+        expect(res.body.data.addWishlistCoOwner).toEqual({ __typename: 'VoidOutput', success: true })
+
+        await expectTable(Fixtures.WISHLIST_TABLE).hasNumberOfRows(1).row(0).toMatchObject({
+          id: wishlistId,
+          co_owner_id: coOwnerId,
+        })
+      })
+
+      it('should return NotFoundRejection when wishlist does not exist', async () => {
+        const coOwnerId = await fixtures.insertUser({
+          email: 'coowner@test.com',
+          firstname: 'Co',
+          lastname: 'Owner',
+        })
+
+        const res = await request
+          .post(GRAPHQL_PATH)
+          .send({ query: mutation, variables: { id: uuid(), input: { userId: coOwnerId } } })
+          .expect(200)
+
+        expect(res.body.data.addWishlistCoOwner.__typename).toBe('NotFoundRejection')
+      })
+
+      it('should return UnauthorizedRejection when user is not the owner', async () => {
+        const otherUserId = await fixtures.insertUser({
+          email: 'other@test.com',
+          firstname: 'Other',
+          lastname: 'User',
+        })
+
+        const coOwnerId = await fixtures.insertUser({
+          email: 'coowner@test.com',
+          firstname: 'Co',
+          lastname: 'Owner',
+        })
+
+        const { eventId } = await fixtures.insertEventWithMaintainer({
+          title: 'Other Event',
+          maintainerId: otherUserId,
+        })
+
+        const wishlistId = await fixtures.insertWishlist({
+          eventIds: [eventId],
+          userId: otherUserId,
+          title: 'Other Wishlist',
+          hideItems: false,
+        })
+
+        const res = await request
+          .post(GRAPHQL_PATH)
+          .send({ query: mutation, variables: { id: wishlistId, input: { userId: coOwnerId } } })
+          .expect(200)
+
+        expect(res.body.data.addWishlistCoOwner.__typename).toBe('UnauthorizedRejection')
+
+        await expectTable(Fixtures.WISHLIST_TABLE).hasNumberOfRows(1).row(0).toMatchObject({
+          id: wishlistId,
+          co_owner_id: null,
+        })
+      })
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // removeWishlistCoOwner
+  // ---------------------------------------------------------------------------
+  describe('Mutation removeWishlistCoOwner', () => {
+    const mutation = /* GraphQL */ `
+      mutation RemoveWishlistCoOwner($id: WishlistId!) {
+        removeWishlistCoOwner(id: $id) {
+          __typename
+          ... on VoidOutput {
+            success
+          }
+          ... on UnauthorizedRejection {
+            message
+          }
+        }
+      }
+    `
+
+    it('should not succeed when not authenticated', async () => {
+      const request = await getRequest()
+      const res = await request
+        .post(GRAPHQL_PATH)
+        .send({ query: mutation, variables: { id: uuid() } })
+        .expect(200)
+
+      expect(res.body.data?.removeWishlistCoOwner?.__typename).not.toBe('VoidOutput')
+    })
+
+    describe('when user is authenticated', () => {
+      let request: RequestApp
+      let currentUserId: string
+
+      beforeEach(async () => {
+        request = await getRequest({ signedAs: 'BASE_USER' })
+        currentUserId = await fixtures.getSignedUserId('BASE_USER')
+      })
+
+      it('should remove the co-owner successfully', async () => {
+        const coOwnerId = await fixtures.insertUser({
+          email: 'coowner@test.com',
+          firstname: 'Co',
+          lastname: 'Owner',
+        })
+
+        const { eventId } = await fixtures.insertEventWithMaintainer({
+          title: 'Test Event',
+          maintainerId: currentUserId,
+        })
+
+        const wishlistId = await fixtures.insertWishlist({
+          eventIds: [eventId],
+          userId: currentUserId,
+          title: 'Public Wishlist',
+          hideItems: false,
+          coOwnerId,
+        })
+
+        const res = await request
+          .post(GRAPHQL_PATH)
+          .send({ query: mutation, variables: { id: wishlistId } })
+          .expect(200)
+
+        expect(res.body.data.removeWishlistCoOwner).toEqual({ __typename: 'VoidOutput', success: true })
+
+        await expectTable(Fixtures.WISHLIST_TABLE).hasNumberOfRows(1).row(0).toMatchObject({
+          id: wishlistId,
+          co_owner_id: null,
+        })
+      })
+
+      it('should return NotFoundRejection when wishlist does not exist', async () => {
+        const res = await request
+          .post(GRAPHQL_PATH)
+          .send({ query: mutation, variables: { id: uuid() } })
+          .expect(200)
+
+        expect(res.body.data.removeWishlistCoOwner.__typename).toBe('NotFoundRejection')
+      })
+
+      it('should return UnauthorizedRejection when user is not the owner', async () => {
+        const otherUserId = await fixtures.insertUser({
+          email: 'other@test.com',
+          firstname: 'Other',
+          lastname: 'User',
+        })
+
+        const coOwnerId = await fixtures.insertUser({
+          email: 'coowner@test.com',
+          firstname: 'Co',
+          lastname: 'Owner',
+        })
+
+        const { eventId } = await fixtures.insertEventWithMaintainer({
+          title: 'Other Event',
+          maintainerId: otherUserId,
+        })
+
+        const wishlistId = await fixtures.insertWishlist({
+          eventIds: [eventId],
+          userId: otherUserId,
+          title: 'Other Wishlist',
+          hideItems: false,
+          coOwnerId,
+        })
+
+        const res = await request
+          .post(GRAPHQL_PATH)
+          .send({ query: mutation, variables: { id: wishlistId } })
+          .expect(200)
+
+        expect(res.body.data.removeWishlistCoOwner.__typename).toBe('UnauthorizedRejection')
+
+        await expectTable(Fixtures.WISHLIST_TABLE).hasNumberOfRows(1).row(0).toMatchObject({
+          id: wishlistId,
+          co_owner_id: coOwnerId,
+        })
+      })
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // removeWishlistLogo
+  // ---------------------------------------------------------------------------
+  describe('Mutation removeWishlistLogo', () => {
+    const mutation = /* GraphQL */ `
+      mutation RemoveWishlistLogo($id: WishlistId!) {
+        removeWishlistLogo(id: $id) {
+          __typename
+          ... on VoidOutput {
+            success
+          }
+          ... on UnauthorizedRejection {
+            message
+          }
+        }
+      }
+    `
+
+    it('should not succeed when not authenticated', async () => {
+      const request = await getRequest()
+      const res = await request
+        .post(GRAPHQL_PATH)
+        .send({ query: mutation, variables: { id: uuid() } })
+        .expect(200)
+
+      expect(res.body.data?.removeWishlistLogo?.__typename).not.toBe('VoidOutput')
+    })
+
+    describe('when user is authenticated', () => {
+      let request: RequestApp
+      let currentUserId: string
+
+      beforeEach(async () => {
+        request = await getRequest({ signedAs: 'BASE_USER' })
+        currentUserId = await fixtures.getSignedUserId('BASE_USER')
+      })
+
+      it('should remove the wishlist logo successfully', async () => {
+        const { eventId } = await fixtures.insertEventWithMaintainer({
+          title: 'Test Event',
+          maintainerId: currentUserId,
+        })
+
+        const wishlistId = await fixtures.insertWishlist({
+          eventIds: [eventId],
+          userId: currentUserId,
+          title: 'My Wishlist',
+        })
+
+        const res = await request
+          .post(GRAPHQL_PATH)
+          .send({ query: mutation, variables: { id: wishlistId } })
+          .expect(200)
+
+        expect(res.body.data.removeWishlistLogo).toEqual({ __typename: 'VoidOutput', success: true })
+
+        await expectTable(Fixtures.WISHLIST_TABLE).hasNumberOfRows(1).row(0).toMatchObject({
+          id: wishlistId,
+          logo_url: null,
+        })
+      })
+
+      it('should return NotFoundRejection when wishlist does not exist', async () => {
+        const res = await request
+          .post(GRAPHQL_PATH)
+          .send({ query: mutation, variables: { id: uuid() } })
+          .expect(200)
+
+        expect(res.body.data.removeWishlistLogo.__typename).toBe('NotFoundRejection')
+      })
+
+      it('should return UnauthorizedRejection when user is not owner/co-owner', async () => {
+        const otherUserId = await fixtures.insertUser({
+          email: 'other@test.com',
+          firstname: 'Other',
+          lastname: 'User',
+        })
+
+        const { eventId } = await fixtures.insertEventWithMaintainer({
+          title: 'Other Event',
+          maintainerId: otherUserId,
+        })
+
+        const wishlistId = await fixtures.insertWishlist({
+          eventIds: [eventId],
+          userId: otherUserId,
+          title: 'Other Wishlist',
+        })
+
+        const res = await request
+          .post(GRAPHQL_PATH)
+          .send({ query: mutation, variables: { id: wishlistId } })
+          .expect(200)
+
+        expect(res.body.data.removeWishlistLogo.__typename).toBe('UnauthorizedRejection')
+      })
+    })
+  })
+})

--- a/apps/api/src/wishlist/infrastructure/resolvers/wishlist-mutation.resolver.ts
+++ b/apps/api/src/wishlist/infrastructure/resolvers/wishlist-mutation.resolver.ts
@@ -1,0 +1,116 @@
+import type { ICurrentUser } from '@wishlist/common'
+
+import { Args, Mutation, Resolver } from '@nestjs/graphql'
+import { GqlCurrentUser } from '@wishlist/api/auth'
+import { ZodPipe } from '@wishlist/api/core'
+import { EventId, WishlistId } from '@wishlist/common'
+
+import {
+  AddWishlistCoOwnerInput,
+  AddWishlistCoOwnerResult,
+  DeleteWishlistResult,
+  LinkWishlistToEventResult,
+  RemoveWishlistCoOwnerResult,
+  RemoveWishlistLogoResult,
+  UnlinkWishlistFromEventResult,
+  UpdateWishlistInput,
+  UpdateWishlistResult,
+} from '../../../gql/generated-types'
+import { AddCoOwnerUseCase } from '../../application/command/add-co-owner.use-case'
+import { DeleteWishlistUseCase } from '../../application/command/delete-wishlist.use-case'
+import { LinkWishlistToEventUseCase } from '../../application/command/link-wishlist-to-event.use-case'
+import { RemoveCoOwnerUseCase } from '../../application/command/remove-co-owner.use-case'
+import { RemoveWishlistLogoUseCase } from '../../application/command/remove-wishlist-logo.use-case'
+import { UnlinkWishlistFromEventUseCase } from '../../application/command/unlink-wishlist-from-event.use-case'
+import { UpdateWishlistUseCase } from '../../application/command/update-wishlist.use-case'
+import {
+  AddWishlistCoOwnerInputSchema,
+  EventIdSchema,
+  UpdateWishlistInputSchema,
+  WishlistIdSchema,
+} from '../wishlist.schema'
+
+@Resolver()
+export class WishlistMutationResolver {
+  constructor(
+    private readonly updateWishlistUseCase: UpdateWishlistUseCase,
+    private readonly deleteWishlistUseCase: DeleteWishlistUseCase,
+    private readonly linkWishlistToEventUseCase: LinkWishlistToEventUseCase,
+    private readonly unlinkWishlistFromEventUseCase: UnlinkWishlistFromEventUseCase,
+    private readonly addCoOwnerUseCase: AddCoOwnerUseCase,
+    private readonly removeCoOwnerUseCase: RemoveCoOwnerUseCase,
+    private readonly removeWishlistLogoUseCase: RemoveWishlistLogoUseCase,
+  ) {}
+
+  @Mutation()
+  async updateWishlist(
+    @Args('id', new ZodPipe(WishlistIdSchema)) wishlistId: WishlistId,
+    @Args('input', new ZodPipe(UpdateWishlistInputSchema)) input: UpdateWishlistInput,
+    @GqlCurrentUser() currentUser: ICurrentUser,
+  ): Promise<UpdateWishlistResult> {
+    await this.updateWishlistUseCase.execute({
+      wishlistId,
+      currentUser,
+      updateWishlist: { title: input.title, description: input.description ?? undefined },
+    })
+
+    return { __typename: 'VoidOutput', success: true }
+  }
+
+  @Mutation()
+  async deleteWishlist(
+    @Args('id', new ZodPipe(WishlistIdSchema)) wishlistId: WishlistId,
+    @GqlCurrentUser() currentUser: ICurrentUser,
+  ): Promise<DeleteWishlistResult> {
+    await this.deleteWishlistUseCase.execute({ wishlistId, currentUser })
+    return { __typename: 'VoidOutput', success: true }
+  }
+
+  @Mutation()
+  async linkWishlistToEvent(
+    @Args('id', new ZodPipe(WishlistIdSchema)) wishlistId: WishlistId,
+    @Args('eventId', new ZodPipe(EventIdSchema)) eventId: EventId,
+    @GqlCurrentUser() currentUser: ICurrentUser,
+  ): Promise<LinkWishlistToEventResult> {
+    await this.linkWishlistToEventUseCase.execute({ wishlistId, currentUser, eventId })
+    return { __typename: 'VoidOutput', success: true }
+  }
+
+  @Mutation()
+  async unlinkWishlistFromEvent(
+    @Args('id', new ZodPipe(WishlistIdSchema)) wishlistId: WishlistId,
+    @Args('eventId', new ZodPipe(EventIdSchema)) eventId: EventId,
+    @GqlCurrentUser() currentUser: ICurrentUser,
+  ): Promise<UnlinkWishlistFromEventResult> {
+    await this.unlinkWishlistFromEventUseCase.execute({ wishlistId, currentUser, eventId })
+    return { __typename: 'VoidOutput', success: true }
+  }
+
+  @Mutation()
+  async addWishlistCoOwner(
+    @Args('id', new ZodPipe(WishlistIdSchema)) wishlistId: WishlistId,
+    @Args('input', new ZodPipe(AddWishlistCoOwnerInputSchema)) input: AddWishlistCoOwnerInput,
+    @GqlCurrentUser() currentUser: ICurrentUser,
+  ): Promise<AddWishlistCoOwnerResult> {
+    await this.addCoOwnerUseCase.execute({ wishlistId, currentUser, coOwnerId: input.userId })
+    return { __typename: 'VoidOutput', success: true }
+  }
+
+  @Mutation()
+  async removeWishlistCoOwner(
+    @Args('id', new ZodPipe(WishlistIdSchema)) wishlistId: WishlistId,
+    @GqlCurrentUser() currentUser: ICurrentUser,
+  ): Promise<RemoveWishlistCoOwnerResult> {
+    await this.removeCoOwnerUseCase.execute({ wishlistId, currentUser })
+    return { __typename: 'VoidOutput', success: true }
+  }
+
+  @Mutation()
+  async removeWishlistLogo(
+    @Args('id', new ZodPipe(WishlistIdSchema)) wishlistId: WishlistId,
+    @GqlCurrentUser() currentUser: ICurrentUser,
+  ): Promise<RemoveWishlistLogoResult> {
+    await this.removeWishlistLogoUseCase.execute({ wishlistId, currentUser })
+    return { __typename: 'VoidOutput', success: true }
+  }
+}

--- a/apps/api/src/wishlist/infrastructure/wishlist.graphql
+++ b/apps/api/src/wishlist/infrastructure/wishlist.graphql
@@ -43,3 +43,112 @@ extend type Query {
   wishlist(id: WishlistId!): GetWishlistByIdResult
   wishlists(filters: PaginationFilters!): GetMyWishlistsResult!
 }
+
+########################################################
+###############   Mutation Inputs   ####################
+########################################################
+
+input UpdateWishlistInput {
+  title: String!
+  description: String
+}
+
+input AddWishlistCoOwnerInput {
+  userId: UserId!
+}
+
+########################################################
+###############   Mutation Result Unions   #############
+########################################################
+
+union UpdateWishlistResult =
+  | VoidOutput
+  | ValidationRejection
+  | UnauthorizedRejection
+  | ForbiddenRejection
+  | NotFoundRejection
+  | InternalErrorRejection
+
+union DeleteWishlistResult =
+  | VoidOutput
+  | ValidationRejection
+  | UnauthorizedRejection
+  | ForbiddenRejection
+  | NotFoundRejection
+  | InternalErrorRejection
+
+union LinkWishlistToEventResult =
+  | VoidOutput
+  | ValidationRejection
+  | UnauthorizedRejection
+  | ForbiddenRejection
+  | NotFoundRejection
+  | InternalErrorRejection
+
+union UnlinkWishlistFromEventResult =
+  | VoidOutput
+  | ValidationRejection
+  | UnauthorizedRejection
+  | ForbiddenRejection
+  | NotFoundRejection
+  | InternalErrorRejection
+
+union AddWishlistCoOwnerResult =
+  | VoidOutput
+  | ValidationRejection
+  | UnauthorizedRejection
+  | ForbiddenRejection
+  | NotFoundRejection
+  | InternalErrorRejection
+
+union RemoveWishlistCoOwnerResult =
+  | VoidOutput
+  | ValidationRejection
+  | UnauthorizedRejection
+  | ForbiddenRejection
+  | NotFoundRejection
+  | InternalErrorRejection
+
+union RemoveWishlistLogoResult =
+  | VoidOutput
+  | ValidationRejection
+  | UnauthorizedRejection
+  | ForbiddenRejection
+  | NotFoundRejection
+  | InternalErrorRejection
+
+extend type Mutation {
+  updateWishlist(id: WishlistId!, input: UpdateWishlistInput!): UpdateWishlistResult!
+  deleteWishlist(id: WishlistId!): DeleteWishlistResult!
+  linkWishlistToEvent(id: WishlistId!, eventId: EventId!): LinkWishlistToEventResult!
+  unlinkWishlistFromEvent(id: WishlistId!, eventId: EventId!): UnlinkWishlistFromEventResult!
+  addWishlistCoOwner(id: WishlistId!, input: AddWishlistCoOwnerInput!): AddWishlistCoOwnerResult!
+  removeWishlistCoOwner(id: WishlistId!): RemoveWishlistCoOwnerResult!
+  removeWishlistLogo(id: WishlistId!): RemoveWishlistLogoResult!
+}
+
+########################################################
+###############   Admin   ##############################
+########################################################
+
+type AdminGetWishlists {
+  data: [Wishlist!]!
+  pagination: Pagination!
+}
+
+input AdminWishlistPaginationFilters {
+  page: Int
+  limit: Int
+  userId: UserId!
+}
+
+union AdminGetWishlistsResult =
+  | AdminGetWishlists
+  | ValidationRejection
+  | UnauthorizedRejection
+  | ForbiddenRejection
+  | InternalErrorRejection
+
+extend type Query {
+  adminWishlists(filters: AdminWishlistPaginationFilters!): AdminGetWishlistsResult!
+}

--- a/apps/api/src/wishlist/infrastructure/wishlist.module.ts
+++ b/apps/api/src/wishlist/infrastructure/wishlist.module.ts
@@ -5,11 +5,20 @@ import { WishlistController } from './controllers/wishlist.controller'
 import { WishlistAdminController } from './controllers/wishlist-admin.controller'
 import { WishlistFieldResolver } from './resolvers/wishlist.field-resolver'
 import { WishlistResolver } from './resolvers/wishlist.resolver'
+import { WishlistAdminResolver } from './resolvers/wishlist-admin.resolver'
+import { WishlistMutationResolver } from './resolvers/wishlist-mutation.resolver'
 import { WishlistDataLoaderFactory } from './wishlist.dataloader'
 
 @Module({
   controllers: [WishlistController, WishlistAdminController],
-  providers: [...handlers, WishlistResolver, WishlistFieldResolver, WishlistDataLoaderFactory],
+  providers: [
+    ...handlers,
+    WishlistResolver,
+    WishlistMutationResolver,
+    WishlistAdminResolver,
+    WishlistFieldResolver,
+    WishlistDataLoaderFactory,
+  ],
   exports: [WishlistDataLoaderFactory],
 })
 export class WishlistModule {}

--- a/apps/api/src/wishlist/infrastructure/wishlist.schema.ts
+++ b/apps/api/src/wishlist/infrastructure/wishlist.schema.ts
@@ -1,0 +1,23 @@
+import { EventId, UserId, WishlistId } from '@wishlist/common'
+import z from 'zod'
+
+import { AddWishlistCoOwnerInput, AdminWishlistPaginationFilters, UpdateWishlistInput } from '../../gql/generated-types'
+
+export const WishlistIdSchema = z.string().transform(val => val as WishlistId)
+export const EventIdSchema = z.string().transform(val => val as EventId)
+export const UserIdSchema = z.string().transform(val => val as UserId)
+
+export const UpdateWishlistInputSchema = z.object({
+  title: z.string().nonempty().max(100),
+  description: z.string().max(2000).optional(),
+}) satisfies z.ZodType<UpdateWishlistInput>
+
+export const AddWishlistCoOwnerInputSchema = z.object({
+  userId: UserIdSchema,
+}) satisfies z.ZodType<AddWishlistCoOwnerInput>
+
+export const AdminWishlistPaginationFiltersSchema = z.object({
+  page: z.number().int().min(1).optional(),
+  limit: z.number().int().min(1).optional(),
+  userId: UserIdSchema,
+}) satisfies z.ZodType<AdminWishlistPaginationFilters>


### PR DESCRIPTION
## Why

Groundwork for migrating the frontend off REST/`api-client` onto GraphQL. The GraphQL API was missing many operations the frontend still hit over REST. This PR closes those gaps (backend only — no frontend changes yet).

## What

Adds GraphQL resolvers, schema, Zod validation, NestJS module wiring and integration tests for the previously REST-only operations. All reuse the **existing CQRS use-cases** — no new business logic, repositories or domain models.

**Event**
- Mutations: `createEvent`, `updateEvent`, `deleteEvent`, `addEventAttendee`, `removeEventAttendee`
- Admin: `adminEvent`, `adminEvents`, `adminUpdateEvent`, `adminDeleteEvent`, `adminDeleteEventAttendee`

**Wishlist**
- Mutations: `updateWishlist`, `deleteWishlist`, `linkWishlistToEvent`, `unlinkWishlistFromEvent`, `addWishlistCoOwner`, `removeWishlistCoOwner`, `removeWishlistLogo`
- Admin: `adminWishlists`

**User**
- Queries: `searchUsers`, `closestFriends` — return the existing `User` type (no `Mini*` types; clients select the fields they need)
- Renamed the admin queries `user` → `adminUser` and `users` → `adminUsers` for clarity (they are `@IsAdmin()`-guarded)

## Notes

- Multipart uploads (user picture, wishlist logo, wishlist-create-with-image) intentionally **stay on REST** — GraphQL handles JSON only here.
- Errors follow the established pattern: use-cases throw Nest exceptions; the global error-transform plugin maps them to typed rejection unions (`ValidationRejection`, `UnauthorizedRejection`, `NotFoundRejection`, `ForbiddenRejection`, `InternalErrorRejection`).

## Verification

- `nx run api:codegen` regenerates `schema.graphql` + `generated-types.ts`
- `yarn typecheck` ✅ (app + spec configs)
- `yarn check` (biome) ✅
- API integration suite: **596 tests passing** (incl. new event/wishlist/user GraphQL resolver specs); unit tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)