### PR TITLE
feat(graphql): expose wrong old password as typed BusinessRuleRejection

### DIFF
--- a/apps/api/schema.graphql
+++ b/apps/api/schema.graphql
@@ -99,6 +99,15 @@ enum AttendeeRole {
   USER
 }
 
+enum BusinessRuleCode {
+  WRONG_OLD_PASSWORD
+}
+
+type BusinessRuleRejection {
+  code: BusinessRuleCode!
+  message: String!
+}
+
 union CancelSecretSantaResult = ForbiddenRejection | InternalErrorRejection | UnauthorizedRejection | VoidOutput
 
 input ChangeUserPasswordInput {
@@ -106,7 +115,7 @@ input ChangeUserPasswordInput {
   oldPassword: String!
 }
 
-union ChangeUserPasswordResult = ForbiddenRejection | InternalErrorRejection | UnauthorizedRejection | ValidationRejection | VoidOutput
+union ChangeUserPasswordResult = BusinessRuleRejection | ForbiddenRejection | InternalErrorRejection | UnauthorizedRejection | ValidationRejection | VoidOutput
 
 type ClosestFriendsOutput {
   users: [User!]!

--- a/apps/api/src/core/common/business-rule.exception.ts
+++ b/apps/api/src/core/common/business-rule.exception.ts
@@ -1,0 +1,24 @@
+import { BadRequestException } from '@nestjs/common'
+
+/**
+ * Codes must stay in sync with the `BusinessRuleCode` enum in core/graphql/base.graphql.
+ */
+export const BUSINESS_RULE_CODES = ['WRONG_OLD_PASSWORD'] as const
+
+export type BusinessRuleCode = (typeof BUSINESS_RULE_CODES)[number]
+
+/**
+ * A domain business-rule violation that clients can act on programmatically.
+ *
+ * Extends BadRequestException so REST controllers keep returning 400 with the
+ * message, while the GraphQL error plugin maps it to a typed
+ * BusinessRuleRejection carrying the code.
+ */
+export class BusinessRuleException extends BadRequestException {
+  constructor(
+    public readonly code: BusinessRuleCode,
+    message: string,
+  ) {
+    super(message)
+  }
+}

--- a/apps/api/src/core/common/index.ts
+++ b/apps/api/src/core/common/index.ts
@@ -1,3 +1,4 @@
+export * from './business-rule.exception'
 export { ValidJsonBody } from './common.decorator'
 export { ParseJsonPipe } from './common.pipe'
 export * from './pagination'

--- a/apps/api/src/core/graphql/base.graphql
+++ b/apps/api/src/core/graphql/base.graphql
@@ -15,6 +15,15 @@ type ValidationRejection {
   errors: [FieldError!]!
 }
 
+enum BusinessRuleCode {
+  WRONG_OLD_PASSWORD
+}
+
+type BusinessRuleRejection {
+  code: BusinessRuleCode!
+  message: String!
+}
+
 type UnauthorizedRejection {
   message: String!
 }

--- a/apps/api/src/core/graphql/graphql-error.plugin.ts
+++ b/apps/api/src/core/graphql/graphql-error.plugin.ts
@@ -1,6 +1,7 @@
 import { ForbiddenException, HttpException, Logger, NotFoundException, UnauthorizedException } from '@nestjs/common'
 import { Plugin } from 'graphql-yoga'
 
+import { BusinessRuleException } from '../common/business-rule.exception'
 import { Rejection } from './rejection.types'
 import { ZodValidationException } from './zod-validation.exception'
 
@@ -16,6 +17,16 @@ function transformException(exception: Error): Rejection {
     return {
       __typename: 'ValidationRejection',
       errors,
+    }
+  }
+
+  // Handle BusinessRuleException (must come before the generic HttpException branch,
+  // BusinessRuleException extends BadRequestException)
+  if (exception instanceof BusinessRuleException) {
+    return {
+      __typename: 'BusinessRuleRejection',
+      code: exception.code,
+      message: exception.message,
     }
   }
 

--- a/apps/api/src/core/graphql/rejection.types.ts
+++ b/apps/api/src/core/graphql/rejection.types.ts
@@ -1,3 +1,5 @@
+import { BusinessRuleCode } from '../common/business-rule.exception'
+
 type FieldError = {
   field: string
   message: string
@@ -6,6 +8,12 @@ type FieldError = {
 export type ValidationRejection = {
   __typename: 'ValidationRejection'
   errors: FieldError[]
+}
+
+export type BusinessRuleRejection = {
+  __typename: 'BusinessRuleRejection'
+  code: BusinessRuleCode
+  message: string
 }
 
 export type UnauthorizedRejection = {
@@ -30,6 +38,7 @@ export type InternalErrorRejection = {
 
 export type Rejection =
   | ValidationRejection
+  | BusinessRuleRejection
   | UnauthorizedRejection
   | ForbiddenRejection
   | NotFoundRejection

--- a/apps/api/src/gql/generated-types.ts
+++ b/apps/api/src/gql/generated-types.ts
@@ -118,6 +118,16 @@ export enum AttendeeRole {
   User = 'USER'
 }
 
+export enum BusinessRuleCode {
+  WrongOldPassword = 'WRONG_OLD_PASSWORD'
+}
+
+export type BusinessRuleRejection = {
+  __typename: 'BusinessRuleRejection';
+  code: BusinessRuleCode;
+  message: Scalars['String']['output'];
+};
+
 export type CancelSecretSantaResult = ForbiddenRejection | InternalErrorRejection | UnauthorizedRejection | VoidOutput;
 
 export type ChangeUserPasswordInput = {
@@ -125,7 +135,7 @@ export type ChangeUserPasswordInput = {
   oldPassword: Scalars['String']['input'];
 };
 
-export type ChangeUserPasswordResult = ForbiddenRejection | InternalErrorRejection | UnauthorizedRejection | ValidationRejection | VoidOutput;
+export type ChangeUserPasswordResult = BusinessRuleRejection | ForbiddenRejection | InternalErrorRejection | UnauthorizedRejection | ValidationRejection | VoidOutput;
 
 export type ClosestFriendsOutput = {
   __typename: 'ClosestFriendsOutput';

--- a/apps/api/src/user/application/command/update-user-password.use-case.ts
+++ b/apps/api/src/user/application/command/update-user-password.use-case.ts
@@ -1,5 +1,6 @@
-import { BadRequestException, Inject, Injectable, Logger } from '@nestjs/common'
+import { Inject, Injectable, Logger } from '@nestjs/common'
 import { PasswordManager } from '@wishlist/api/auth'
+import { BusinessRuleException } from '@wishlist/api/core'
 import { REPOSITORIES } from '@wishlist/api/repositories'
 import { UserId } from '@wishlist/common'
 
@@ -31,7 +32,7 @@ export class UpdateUserPasswordUseCase {
     })
 
     if (!oldPasswordMatch) {
-      throw new BadRequestException("Old password don't match with user password")
+      throw new BusinessRuleException('WRONG_OLD_PASSWORD', "Old password don't match with user password")
     }
 
     const newPasswordHash = await PasswordManager.hash(newPassword)

--- a/apps/api/src/user/infrastructure/resolvers/user.resolver.int-spec.ts
+++ b/apps/api/src/user/infrastructure/resolvers/user.resolver.int-spec.ts
@@ -360,6 +360,10 @@ describe('UserResolver (GraphQL)', () => {
               message
             }
           }
+          ... on BusinessRuleRejection {
+            code
+            message
+          }
           ... on InternalErrorRejection {
             message
           }
@@ -396,8 +400,11 @@ describe('UserResolver (GraphQL)', () => {
 
       const res = await request.post('/graphql').send({ query: mutation, variables: { input } }).expect(200)
 
-      // BadRequestException -> InternalErrorRejection (not a specifically-mapped exception type).
-      expect(res.body.data.changeUserPassword.__typename).toBe('InternalErrorRejection')
+      expect(res.body.data.changeUserPassword).toEqual({
+        __typename: 'BusinessRuleRejection',
+        code: 'WRONG_OLD_PASSWORD',
+        message: "Old password don't match with user password",
+      })
 
       await expectTable(Fixtures.USER_TABLE)
         .row(0)

--- a/apps/api/src/user/infrastructure/user.graphql
+++ b/apps/api/src/user/infrastructure/user.graphql
@@ -145,6 +145,7 @@ union UnlinkCurrentUserSocialResult =
 union ChangeUserPasswordResult =
   | VoidOutput
   | ValidationRejection
+  | BusinessRuleRejection
   | UnauthorizedRejection
   | ForbiddenRejection
   | InternalErrorRejection

--- a/apps/front/src/components/user/UserTabPassword.tsx
+++ b/apps/front/src/components/user/UserTabPassword.tsx
@@ -5,7 +5,7 @@ import { useForm } from 'react-hook-form'
 import { match } from 'ts-pattern'
 import { z } from 'zod'
 
-import { rejectionMessage, rejectionPattern, useChangeUserPasswordMutation } from '../../gql'
+import { BusinessRuleCode, rejectionMessage, rejectionPattern, useChangeUserPasswordMutation } from '../../gql'
 import { useToast } from '../../hooks/useToast'
 import { Card } from '../common/Card'
 import { Subtitle } from '../common/Subtitle'
@@ -50,9 +50,9 @@ export const UserTabPassword = () => {
         addToast({ message: 'Mot de passe mis à jour', variant: 'info' })
         resetForm()
       })
-      // A wrong old password arrives as InternalErrorRejection (BadRequestException
-      // on the API side), not ValidationRejection, so it gets the default message
-      // like the other rejections until the API exposes a typed case for it.
+      .with({ __typename: 'BusinessRuleRejection', code: BusinessRuleCode.WrongOldPassword }, () =>
+        setError('oldPassword', { message: "L'ancien mot de passe est incorrect" }),
+      )
       .with(rejectionPattern, rejection => addToast({ message: rejectionMessage(rejection), variant: 'error' }))
       .exhaustive()
   }

--- a/apps/front/src/components/user/user.graphql
+++ b/apps/front/src/components/user/user.graphql
@@ -104,6 +104,10 @@ mutation ChangeUserPassword($input: ChangeUserPasswordInput!) {
         message
       }
     }
+    ... on BusinessRuleRejection {
+      code
+      message
+    }
   }
 }
 

--- a/apps/front/src/gql/__generated__/graphql.ts
+++ b/apps/front/src/gql/__generated__/graphql.ts
@@ -1591,6 +1591,10 @@ export const ChangeUserPasswordDocument = `
         message
       }
     }
+    ... on BusinessRuleRejection {
+      code
+      message
+    }
   }
 }
     `;

--- a/apps/front/src/gql/__generated__/types.ts
+++ b/apps/front/src/gql/__generated__/types.ts
@@ -113,6 +113,16 @@ export enum AttendeeRole {
   User = 'USER'
 }
 
+export enum BusinessRuleCode {
+  WrongOldPassword = 'WRONG_OLD_PASSWORD'
+}
+
+export type BusinessRuleRejection = {
+  __typename?: 'BusinessRuleRejection';
+  code: BusinessRuleCode;
+  message: Scalars['String']['output'];
+};
+
 export type CancelSecretSantaResult = ForbiddenRejection | InternalErrorRejection | UnauthorizedRejection | VoidOutput;
 
 export type ChangeUserPasswordInput = {
@@ -120,7 +130,7 @@ export type ChangeUserPasswordInput = {
   oldPassword: Scalars['String']['input'];
 };
 
-export type ChangeUserPasswordResult = ForbiddenRejection | InternalErrorRejection | UnauthorizedRejection | ValidationRejection | VoidOutput;
+export type ChangeUserPasswordResult = BusinessRuleRejection | ForbiddenRejection | InternalErrorRejection | UnauthorizedRejection | ValidationRejection | VoidOutput;
 
 export type ClosestFriendsOutput = {
   __typename?: 'ClosestFriendsOutput';
@@ -1609,6 +1619,7 @@ export type ChangeUserPasswordMutationVariables = Exact<{
 
 
 export type ChangeUserPasswordMutation = { __typename?: 'Mutation', changeUserPassword:
+    | { __typename: 'BusinessRuleRejection', code: BusinessRuleCode, message: string }
     | { __typename: 'ForbiddenRejection' }
     | { __typename: 'InternalErrorRejection' }
     | { __typename: 'UnauthorizedRejection' }

--- a/apps/front/src/gql/rejection.ts
+++ b/apps/front/src/gql/rejection.ts
@@ -26,6 +26,7 @@ import { P } from 'ts-pattern'
 
 const REJECTION_TYPENAMES = [
   'ValidationRejection',
+  'BusinessRuleRejection',
   'UnauthorizedRejection',
   'ForbiddenRejection',
   'NotFoundRejection',
@@ -51,6 +52,7 @@ export const rejectionPattern = { __typename: P.string.endsWith('Rejection') } a
 
 const DEFAULT_MESSAGES: Record<RejectionTypename, string> = {
   ValidationRejection: 'Certaines informations saisies sont invalides',
+  BusinessRuleRejection: 'Cette action ne peut pas être effectuée',
   UnauthorizedRejection: 'Vous devez être connecté pour effectuer cette action',
   ForbiddenRejection: "Vous n'avez pas les droits nécessaires pour effectuer cette action",
   NotFoundRejection: "Cette ressource n'existe pas ou a été supprimée",


### PR DESCRIPTION
## What

A wrong old password on the change-password form previously surfaced as `InternalErrorRejection`: the use-case threw a plain `BadRequestException`, which the GraphQL error plugin maps to the generic internal-error case. The frontend could not distinguish it from a real server error and showed "Une erreur s'est produite" instead of a field-level error.

This PR introduces a typed, reusable rejection for domain business-rule violations:

- **`BusinessRuleException(code, message)`** (`apps/api/src/core/common/business-rule.exception.ts`) — extends `BadRequestException`, so REST controllers sharing the use-case keep returning 400 with the same message (verified by the existing controller int-spec, unchanged).
- **`BusinessRuleRejection { code: BusinessRuleCode!, message: String! }`** in `base.graphql`, with a `BusinessRuleCode` enum (`WRONG_OLD_PASSWORD` for now). The enum must stay in sync with `BUSINESS_RULE_CODES` in the exception file (noted in a comment).
- The error plugin maps the exception before the generic `HttpException` branch; `ChangeUserPasswordResult` is the only union extended.
- Frontend: `UserTabPassword.tsx` matches `{ __typename: 'BusinessRuleRejection', code: BusinessRuleCode.WrongOldPassword }` and shows "L'ancien mot de passe est incorrect" on the old-password field. `rejection.ts` helpers gained the new typename with a generic French fallback so unhandled future business-rule rejections degrade gracefully.

## Why not the alternatives

- Mapping `BadRequestException` → `ValidationRejection` would conflate business rules with input validation; `ValidationRejection` is reserved for Zod input failures (see ebdd982), and the plugin has no field name to attach.
- Throwing a Zod-style exception from the use-case would make the application layer depend on the GraphQL layer.

## Reviewer notes

- Generated files (`schema.graphql`, `generated-types.ts`, front `__generated__/*`) come from `nx run api:codegen` + `nx run front:codegen`.
- The resolver int-spec now asserts the full rejection shape (code + message) instead of `InternalErrorRejection`.

## Verification

- `yarn typecheck` ✅ (8 projects)
- `yarn check` ✅
- Unit tests (api, front) ✅
- User-domain integration tests ✅ (130 tests / 6 files, including REST 400 behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)