### PR TITLE
feat(front): redesign landing page with sober editorial style

### DIFF
--- a/apps/front/index.html
+++ b/apps/front/index.html
@@ -33,7 +33,13 @@
 
     <!-- Manifest for PWA -->
     <link rel="manifest" href="/manifest.json" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap" />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400..700;1,9..144,400..700&family=Inter:wght@400;500;600;700&display=swap"
+    />
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons" />
     <link rel="stylesheet" href="/src/styles.scss" />
 

--- a/apps/front/src/components/auth/AuthFormHeader.tsx
+++ b/apps/front/src/components/auth/AuthFormHeader.tsx
@@ -1,0 +1,32 @@
+import type { ReactNode } from 'react'
+
+import { Box, styled, Typography } from '@mui/material'
+
+import { landingTokens } from '../landing/landing.tokens'
+
+const TitleStyled = styled(Typography)(() => ({
+  fontFamily: landingTokens.displayFont,
+  fontWeight: 500,
+  fontSize: '1.9rem',
+  lineHeight: 1.2,
+  letterSpacing: '-0.01em',
+  color: landingTokens.ink,
+}))
+
+const SubtitleStyled = styled(Typography)(({ theme }) => ({
+  color: landingTokens.inkMuted,
+  marginTop: theme.spacing(1),
+  lineHeight: 1.6,
+}))
+
+interface AuthFormHeaderProps {
+  title: string
+  subtitle?: ReactNode
+}
+
+export const AuthFormHeader = ({ title, subtitle }: AuthFormHeaderProps) => (
+  <Box>
+    <TitleStyled variant="h1">{title}</TitleStyled>
+    {subtitle && <SubtitleStyled variant="body2">{subtitle}</SubtitleStyled>}
+  </Box>
+)

--- a/apps/front/src/components/auth/ForgotPasswordPage.tsx
+++ b/apps/front/src/components/auth/ForgotPasswordPage.tsx
@@ -1,5 +1,4 @@
 import { zodResolver } from '@hookform/resolvers/zod'
-import AttachEmailIcon from '@mui/icons-material/AttachEmail'
 import { Box, Button, Stack, styled, TextField, Typography } from '@mui/material'
 import { useState } from 'react'
 import { useForm } from 'react-hook-form'
@@ -9,20 +8,13 @@ import { z } from 'zod'
 import { rejectionMessage, rejectionPattern, useAuthSendResetPasswordEmailMutation } from '../../gql'
 import { useToast } from '../../hooks/useToast'
 import { RouterLink } from '../common/RouterLink'
+import { AuthFormHeader } from './AuthFormHeader'
 
 const schema = z.object({
   email: z.email('Email invalide').max(200, '200 caractères maximum'),
 })
 
 type FormFields = z.infer<typeof schema>
-
-const TitleStyled = styled(Typography)(({ theme }) => ({
-  fontSize: '1.75rem',
-  fontWeight: 600,
-  color: theme.palette.text.primary,
-  textAlign: 'center',
-  marginBottom: 24,
-}))
 
 const ButtonStyled = styled(Button)(() => ({
   paddingTop: 12,
@@ -71,7 +63,7 @@ export const ForgotPasswordPage = () => {
   }
 
   return (
-    <Stack spacing={4} alignItems="center">
+    <Stack spacing={4}>
       {resetCodeSent ? (
         <MessageBoxStyled>
           <Typography variant="body1" gutterBottom>
@@ -84,7 +76,10 @@ export const ForgotPasswordPage = () => {
         </MessageBoxStyled>
       ) : (
         <>
-          <TitleStyled variant="h4">Mot de passe oublié</TitleStyled>
+          <AuthFormHeader
+            title="Mot de passe oublié"
+            subtitle="Indiquez l'email utilisé lors de l'inscription, nous vous enverrons un lien de réinitialisation."
+          />
 
           <Stack component="form" onSubmit={handleSubmit(onSubmit)} spacing={3} width="100%">
             <TextField
@@ -92,7 +87,7 @@ export const ForgotPasswordPage = () => {
               type="email"
               label="Email"
               fullWidth
-              placeholder="Entrer l'email que vous avez utilisé lors de l'inscription"
+              placeholder="votre@email.com"
               autoComplete="email"
               autoFocus
               error={!!formErrors.email}
@@ -106,8 +101,6 @@ export const ForgotPasswordPage = () => {
               size="large"
               color="primary"
               loading={isSubmitting}
-              loadingPosition="start"
-              startIcon={<AttachEmailIcon />}
               disabled={isSubmitting}
             >
               Réinitialisez mon mot de passe

--- a/apps/front/src/components/auth/LoginPage.tsx
+++ b/apps/front/src/components/auth/LoginPage.tsx
@@ -1,5 +1,4 @@
 import { zodResolver } from '@hookform/resolvers/zod'
-import LoginIcon from '@mui/icons-material/Login'
 import { Alert, Button, Divider, Stack, styled, TextField, Typography } from '@mui/material'
 import { useNavigate, useSearch } from '@tanstack/react-router'
 import { useState } from 'react'
@@ -12,6 +11,7 @@ import { setTokens } from '../../core/store/features'
 import { rejectionMessage, rejectionPattern, useAuthLoginMutation, useAuthLoginWithGoogleMutation } from '../../gql'
 import { useToast } from '../../hooks/useToast'
 import { RouterLink } from '../common/RouterLink'
+import { AuthFormHeader } from './AuthFormHeader'
 import { GoogleButton } from './GoogleButton'
 
 const schema = z.object({
@@ -20,13 +20,6 @@ const schema = z.object({
 })
 
 type FormFields = z.infer<typeof schema>
-
-const TitleStyled = styled(Typography)(({ theme }) => ({
-  fontSize: '1.75rem',
-  fontWeight: 600,
-  color: theme.palette.text.primary,
-  textAlign: 'center',
-}))
 
 const ButtonStyled = styled(Button)(() => ({
   paddingTop: 12,
@@ -114,8 +107,8 @@ export const LoginPage = () => {
   const onSubmit = (data: FormFields) => login(data)
 
   return (
-    <Stack spacing={4} alignItems="center">
-      <TitleStyled variant="h4">Connexion</TitleStyled>
+    <Stack spacing={4}>
+      <AuthFormHeader title="Connexion" subtitle="Heureux de vous revoir ! Connectez-vous pour retrouver vos listes." />
 
       <Stack component="form" onSubmit={handleSubmit(onSubmit)} spacing={3} width="100%">
         {formErrors.root && <Alert severity="error">{formErrors.root.message}</Alert>}
@@ -149,8 +142,6 @@ export const LoginPage = () => {
           color="primary"
           fullWidth
           loading={isSubmitting}
-          loadingPosition="start"
-          startIcon={<LoginIcon />}
           disabled={isSubmitting || socialLoading}
         >
           Se connecter

--- a/apps/front/src/components/auth/RegisterPage.tsx
+++ b/apps/front/src/components/auth/RegisterPage.tsx
@@ -1,5 +1,4 @@
 import { zodResolver } from '@hookform/resolvers/zod'
-import PersonAddIcon from '@mui/icons-material/PersonAdd'
 import { Alert, Button, Divider, Stack, styled, TextField, Typography } from '@mui/material'
 import { useNavigate } from '@tanstack/react-router'
 import { useState } from 'react'
@@ -19,6 +18,7 @@ import {
 import { useToast } from '../../hooks/useToast'
 import { zodRequiredString } from '../../utils/validation'
 import { RouterLink } from '../common/RouterLink'
+import { AuthFormHeader } from './AuthFormHeader'
 import { GoogleButton } from './GoogleButton'
 
 const schema = z.object({
@@ -29,13 +29,6 @@ const schema = z.object({
 })
 
 type FormFields = z.infer<typeof schema>
-
-const TitleStyled = styled(Typography)(({ theme }) => ({
-  fontSize: '1.75rem',
-  fontWeight: 600,
-  color: theme.palette.text.primary,
-  textAlign: 'center',
-}))
 
 const SocialButtonsStack = styled(Stack)(() => ({
   width: '100%',
@@ -137,8 +130,11 @@ export const RegisterPage = () => {
   const onSubmit = (data: FormFields) => registerUser(data)
 
   return (
-    <Stack spacing={4} alignItems="center">
-      <TitleStyled variant="h4">Créer un compte</TitleStyled>
+    <Stack spacing={4}>
+      <AuthFormHeader
+        title="Créer un compte"
+        subtitle="Rejoignez vos proches sur Wishlist en moins d'une minute. C'est gratuit."
+      />
 
       <Stack component="form" onSubmit={handleSubmit(onSubmit)} spacing={3} width="100%">
         {formErrors.root && <Alert severity="error">{formErrors.root.message}</Alert>}
@@ -193,8 +189,6 @@ export const RegisterPage = () => {
           size="large"
           fullWidth
           loading={isSubmitting}
-          loadingPosition="start"
-          startIcon={<PersonAddIcon />}
           disabled={isSubmitting || socialLoading}
         >
           Créer mon compte

--- a/apps/front/src/components/auth/RenewForgotPasswordPage.tsx
+++ b/apps/front/src/components/auth/RenewForgotPasswordPage.tsx
@@ -1,5 +1,4 @@
 import { zodResolver } from '@hookform/resolvers/zod'
-import SaveAsIcon from '@mui/icons-material/SaveAs'
 import { Button, Stack, styled, TextField, Typography } from '@mui/material'
 import { useNavigate, useSearch } from '@tanstack/react-router'
 import { useForm } from 'react-hook-form'
@@ -9,6 +8,7 @@ import { z } from 'zod'
 import { rejectionMessage, rejectionPattern, useAuthResetPasswordMutation } from '../../gql'
 import { useToast } from '../../hooks/useToast'
 import { RouterLink } from '../common/RouterLink'
+import { AuthFormHeader } from './AuthFormHeader'
 
 const schema = z
   .object({
@@ -21,14 +21,6 @@ const schema = z
   })
 
 type FormFields = z.infer<typeof schema>
-
-const TitleStyled = styled(Typography)(({ theme }) => ({
-  fontSize: '1.75rem',
-  fontWeight: 600,
-  color: theme.palette.text.primary,
-  textAlign: 'center',
-  marginBottom: 24,
-}))
 
 const ButtonStyled = styled(Button)(() => ({
   paddingTop: 12,
@@ -48,15 +40,6 @@ const ErrorMessageStyled = styled(Typography)(({ theme }) => ({
   color: theme.palette.error.main,
   fontSize: '1.1rem',
   fontWeight: 500,
-}))
-
-const InfoMessageStyled = styled(Typography)(({ theme }) => ({
-  textAlign: 'center',
-  color: theme.palette.text.secondary,
-  backgroundColor: theme.palette.grey[50],
-  padding: theme.spacing(2),
-  borderRadius: theme.shape.borderRadius,
-  border: `1px solid ${theme.palette.grey[200]}`,
 }))
 
 export const RenewForgotPasswordPage = () => {
@@ -104,12 +87,15 @@ export const RenewForgotPasswordPage = () => {
   }
 
   return (
-    <Stack spacing={4} alignItems="center">
-      <TitleStyled variant="h4">Changer de mot de passe</TitleStyled>
-
-      <InfoMessageStyled variant="body1">
-        Vous êtes en train de définir un nouveau mot de passe pour <strong>{email}</strong>
-      </InfoMessageStyled>
+    <Stack spacing={4}>
+      <AuthFormHeader
+        title="Nouveau mot de passe"
+        subtitle={
+          <>
+            Vous définissez un nouveau mot de passe pour <strong>{email}</strong>.
+          </>
+        }
+      />
 
       <Stack component="form" onSubmit={handleSubmit(onSubmit)} spacing={3} width="100%">
         <TextField
@@ -142,8 +128,6 @@ export const RenewForgotPasswordPage = () => {
           size="large"
           color="primary"
           loading={isSubmitting}
-          loadingPosition="start"
-          startIcon={<SaveAsIcon />}
           disabled={isSubmitting}
         >
           Changer mon mot de passe

--- a/apps/front/src/components/common/router/outlet/AnonymousContainerOutlet.tsx
+++ b/apps/front/src/components/common/router/outlet/AnonymousContainerOutlet.tsx
@@ -1,46 +1,178 @@
-import { Box, Container, Stack, styled } from '@mui/material'
+import { RedeemRounded, ShuffleRounded, VisibilityOffRounded } from '@mui/icons-material'
+import { Box, styled, Typography } from '@mui/material'
 import { Outlet, useNavigate } from '@tanstack/react-router'
 
-import { Card } from '../../Card'
+import { landingTokens } from '../../../landing/landing.tokens'
 import { Logo } from '../../Logo'
 
 const Root = styled(Box)(({ theme }) => ({
   minHeight: '100vh',
+  display: 'grid',
+  gridTemplateColumns: '1fr 1fr',
+  [theme.breakpoints.down('md')]: {
+    gridTemplateColumns: '1fr',
+  },
+}))
+
+const BrandPanel = styled(Box)(({ theme }) => ({
+  background: `linear-gradient(175deg, ${theme.palette.primary.main} 0%, ${landingTokens.deepBlue} 85%)`,
+  color: 'white',
+  display: 'flex',
+  flexDirection: 'column',
+  justifyContent: 'space-between',
+  padding: theme.spacing(6, 8),
+  position: 'relative',
+  overflow: 'hidden',
+  '&::before': {
+    content: '""',
+    position: 'absolute',
+    top: '-30%',
+    right: '-20%',
+    width: '70%',
+    height: '80%',
+    background: 'radial-gradient(ellipse at center, rgba(255, 255, 255, 0.07) 0%, transparent 70%)',
+    pointerEvents: 'none',
+  },
+  [theme.breakpoints.down('lg')]: {
+    padding: theme.spacing(5, 6),
+  },
+  [theme.breakpoints.down('md')]: {
+    display: 'none',
+  },
+}))
+
+const LogoContainer = styled(Box)(() => ({
+  cursor: 'pointer',
+  transition: 'opacity 0.2s ease',
+  '&:hover': {
+    opacity: 0.85,
+  },
+}))
+
+const BrandContent = styled(Box)(({ theme }) => ({
+  position: 'relative',
+  maxWidth: 440,
+  paddingBottom: theme.spacing(6),
+}))
+
+const BrandHeadline = styled(Typography)(({ theme }) => ({
+  fontFamily: landingTokens.displayFont,
+  fontWeight: 500,
+  fontSize: 'clamp(2rem, 2.8vw, 2.7rem)',
+  lineHeight: 1.15,
+  letterSpacing: '-0.01em',
+  marginBottom: theme.spacing(5),
+  '& em': {
+    fontStyle: 'italic',
+    color: '#cfe3f3',
+  },
+}))
+
+const BenefitItem = styled(Box)(({ theme }) => ({
   display: 'flex',
   alignItems: 'center',
-  paddingBlock: theme.spacing(4),
-}))
-
-const LogoContainer = styled(Box)({
-  cursor: 'pointer',
-  color: 'primary.main',
-  '&:hover': {
-    opacity: 0.8,
+  gap: theme.spacing(2),
+  '&:not(:last-of-type)': {
+    marginBottom: theme.spacing(2.5),
   },
-})
-
-const OutletContainer = styled(Card)(() => ({
-  borderRadius: 24,
-  padding: 32,
-  boxShadow: '0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05) !important',
 }))
+
+const BenefitIcon = styled(Box)(({ theme }) => ({
+  width: 40,
+  height: 40,
+  borderRadius: theme.spacing(1.25),
+  backgroundColor: 'rgba(255, 255, 255, 0.08)',
+  border: '1px solid rgba(255, 255, 255, 0.15)',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  flexShrink: 0,
+  '& svg': {
+    fontSize: 20,
+    color: 'rgba(255, 255, 255, 0.9)',
+  },
+}))
+
+const BenefitText = styled(Typography)(() => ({
+  color: 'rgba(255, 255, 255, 0.85)',
+  fontSize: '0.95rem',
+  lineHeight: 1.5,
+}))
+
+const BrandFooter = styled(Typography)(() => ({
+  position: 'relative',
+  color: 'rgba(255, 255, 255, 0.45)',
+  fontSize: '0.85rem',
+}))
+
+const FormPanel = styled('main')(({ theme }) => ({
+  backgroundColor: landingTokens.surface,
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  justifyContent: 'center',
+  padding: theme.spacing(8, 3),
+}))
+
+const FormColumn = styled(Box)(() => ({
+  width: '100%',
+  maxWidth: 420,
+}))
+
+const MobileLogo = styled(Box)(({ theme }) => ({
+  display: 'none',
+  cursor: 'pointer',
+  [theme.breakpoints.down('md')]: {
+    display: 'flex',
+    justifyContent: 'center',
+    marginBottom: theme.spacing(5),
+  },
+}))
+
+const benefits = [
+  { icon: <RedeemRounded />, text: 'Créez vos listes de souhaits et partagez-les avec vos proches.' },
+  { icon: <VisibilityOffRounded />, text: 'Réservez les cadeaux en toute discrétion, sans doublon.' },
+  { icon: <ShuffleRounded />, text: 'Organisez un Secret Santa en quelques clics.' },
+]
 
 export const AnonymousContainerOutlet = () => {
   const navigate = useNavigate()
 
   return (
     <Root>
-      <Container component="main" maxWidth="sm">
-        <Stack direction="column" alignItems="center" spacing={4}>
-          <LogoContainer onClick={() => navigate({ to: '/' })}>
-            <Logo height={48} variant="full" />
-          </LogoContainer>
+      <BrandPanel>
+        <LogoContainer onClick={() => navigate({ to: '/' })}>
+          <Logo height={40} variant="full" color="white" />
+        </LogoContainer>
 
-          <OutletContainer>
-            <Outlet />
-          </OutletContainer>
-        </Stack>
-      </Container>
+        <BrandContent>
+          <BrandHeadline>
+            Le bon cadeau,
+            <br />à <em>chaque</em> occasion.
+          </BrandHeadline>
+
+          <Box>
+            {benefits.map(benefit => (
+              <BenefitItem key={benefit.text}>
+                <BenefitIcon>{benefit.icon}</BenefitIcon>
+                <BenefitText>{benefit.text}</BenefitText>
+              </BenefitItem>
+            ))}
+          </Box>
+        </BrandContent>
+
+        <BrandFooter>© {new Date().getFullYear()} Wishlist. Tous droits réservés.</BrandFooter>
+      </BrandPanel>
+
+      <FormPanel>
+        <FormColumn>
+          <MobileLogo onClick={() => navigate({ to: '/' })}>
+            <Logo height={44} variant="full" />
+          </MobileLogo>
+
+          <Outlet />
+        </FormColumn>
+      </FormPanel>
     </Root>
   )
 }

--- a/apps/front/src/components/landing/FAQSection.tsx
+++ b/apps/front/src/components/landing/FAQSection.tsx
@@ -1,330 +1,94 @@
-import { Box, Container, Typography, useMediaQuery, useTheme } from '@mui/material'
+import { AddRounded } from '@mui/icons-material'
+import { Accordion, AccordionDetails, AccordionSummary, Box, Container, Typography } from '@mui/material'
 import { styled } from '@mui/material/styles'
-import { useEffect, useMemo, useRef } from 'react'
+import { useState } from 'react'
+
+import { landingTokens } from './landing.tokens'
 
 const FAQSectionContainer = styled(Box)(({ theme }) => ({
-  padding: theme.spacing(8, 0, 12),
-  backgroundColor: 'white',
-  borderTop: '1px solid #e5e7eb',
-  borderBottom: '1px solid #e5e7eb',
-}))
-
-const FAQTitle = styled(Typography)(({ theme }) => ({
-  textAlign: 'center',
-  marginBottom: theme.spacing(6),
-  fontSize: '2.25rem',
-  fontWeight: 600,
-  color: theme.palette.text.primary,
+  padding: theme.spacing(14, 0),
+  backgroundColor: landingTokens.surface,
   [theme.breakpoints.down('md')]: {
-    fontSize: '1.75rem',
-    marginBottom: theme.spacing(5),
+    padding: theme.spacing(10, 0),
   },
 }))
 
-const FAQContainerWrapper = styled(Box)(({ theme }) => ({
-  position: 'relative',
-  // Masques de fondu sur les côtés
+const FAQLayout = styled(Box)(({ theme }) => ({
+  display: 'grid',
+  gridTemplateColumns: '0.8fr 1.2fr',
+  gap: theme.spacing(10),
+  alignItems: 'start',
+  [theme.breakpoints.down('md')]: {
+    gridTemplateColumns: '1fr',
+    gap: theme.spacing(5),
+  },
+}))
+
+const Kicker = styled(Typography)(({ theme }) => ({
+  color: landingTokens.accent,
+  fontSize: '0.8rem',
+  fontWeight: 600,
+  letterSpacing: '0.18em',
+  textTransform: 'uppercase',
+  marginBottom: theme.spacing(2),
+}))
+
+const SectionTitle = styled(Typography)(({ theme }) => ({
+  fontFamily: landingTokens.displayFont,
+  fontWeight: 500,
+  fontSize: 'clamp(1.9rem, 3.5vw, 2.6rem)',
+  lineHeight: 1.2,
+  letterSpacing: '-0.01em',
+  color: landingTokens.ink,
+  marginBottom: theme.spacing(2),
+}))
+
+const SectionSubtitle = styled(Typography)(() => ({
+  color: landingTokens.inkMuted,
+  fontSize: '1.05rem',
+  lineHeight: 1.7,
+}))
+
+const FAQAccordion = styled(Accordion)(({ theme }) => ({
+  backgroundColor: 'transparent',
+  boxShadow: 'none',
+  borderBottom: `1px solid ${landingTokens.hairline}`,
   '&::before': {
-    content: '""',
-    position: 'absolute',
-    top: 0,
-    left: 0,
-    width: `${FAQ_ANIMATION_CONFIG.FADE_WIDTH}px`,
-    height: '100%',
-    background: 'linear-gradient(to right, white 0%, rgba(255, 255, 255, 0) 100%)',
-    zIndex: 10,
-    pointerEvents: 'none',
-    [theme.breakpoints.down('sm')]: {
-      width: `${FAQ_ANIMATION_CONFIG.FADE_WIDTH_MOBILE}px`,
-    },
-  },
-  '&::after': {
-    content: '""',
-    position: 'absolute',
-    top: 0,
-    right: 0,
-    width: `${FAQ_ANIMATION_CONFIG.FADE_WIDTH}px`,
-    height: '100%',
-    background: 'linear-gradient(to left, white 0%, rgba(255, 255, 255, 0) 100%)',
-    zIndex: 10,
-    pointerEvents: 'none',
-    [theme.breakpoints.down('sm')]: {
-      width: `${FAQ_ANIMATION_CONFIG.FADE_WIDTH_MOBILE}px`,
-    },
-  },
-}))
-
-const FAQContainer = styled(Box)(() => ({
-  overflowX: 'auto',
-  overflowY: 'hidden',
-  position: 'relative',
-  paddingBottom: '16px',
-  scrollbarWidth: 'none',
-  msOverflowStyle: 'none',
-  WebkitOverflowScrolling: 'touch',
-  '&::-webkit-scrollbar': {
     display: 'none',
   },
-  '&:hover': {
-    cursor: 'grab',
+  '&.Mui-expanded': {
+    margin: 0,
   },
-  '&:active': {
-    cursor: 'grabbing',
+  '& .MuiAccordionSummary-root': {
+    padding: theme.spacing(0.5, 0),
+    minHeight: 0,
   },
-}))
-
-const FAQScrollWrapper = styled(Box)(({ theme }) => ({
-  display: 'flex',
-  gap: `${FAQ_ANIMATION_CONFIG.CARD_GAP}px`,
-  [theme.breakpoints.down('md')]: {
-    gap: theme.spacing(3),
+  '& .MuiAccordionSummary-content': {
+    margin: theme.spacing(2, 0),
   },
-  [theme.breakpoints.down('sm')]: {
-    gap: `${FAQ_ANIMATION_CONFIG.CARD_GAP_MOBILE}px`,
+  '& .MuiAccordionSummary-expandIconWrapper': {
+    color: landingTokens.inkMuted,
+    transition: 'transform 0.25s ease',
   },
-}))
-
-const FAQCard = styled(Box)(({ theme }) => ({
-  backgroundColor: '#fafafa',
-  borderRadius: theme.spacing(2),
-  padding: theme.spacing(4),
-  boxShadow: '0 1px 3px rgba(0, 0, 0, 0.1)',
-  border: '1px solid #e5e7eb',
-  transition: 'all 0.3s ease',
-  minWidth: `${FAQ_ANIMATION_CONFIG.CARD_WIDTH}px`,
-  maxWidth: `${FAQ_ANIMATION_CONFIG.CARD_WIDTH}px`,
-  scrollSnapAlign: 'start',
-  flexShrink: 0,
-  [theme.breakpoints.down('md')]: {
-    minWidth: '320px',
-    maxWidth: '320px',
-  },
-  [theme.breakpoints.down('sm')]: {
-    minWidth: `${FAQ_ANIMATION_CONFIG.CARD_WIDTH_MOBILE}px`,
-    maxWidth: `${FAQ_ANIMATION_CONFIG.CARD_WIDTH_MOBILE}px`,
-    padding: theme.spacing(3),
+  '& .MuiAccordionSummary-expandIconWrapper.Mui-expanded': {
+    transform: 'rotate(45deg)',
+    color: theme.palette.primary.main,
   },
 }))
 
-const FAQQuestion = styled(Typography)(({ theme }) => ({
+const Question = styled(Typography)(() => ({
   fontWeight: 600,
-  marginBottom: theme.spacing(2),
-  color: theme.palette.text.primary,
-  fontSize: '1.1rem',
-  [theme.breakpoints.down('sm')]: {
-    fontSize: '1rem',
-    marginBottom: theme.spacing(1.5),
-  },
+  fontSize: '1.05rem',
+  color: landingTokens.ink,
 }))
 
-const FAQAnswer = styled(Typography)(({ theme }) => ({
-  color: theme.palette.text.secondary,
-  lineHeight: 1.6,
-  [theme.breakpoints.down('sm')]: {
-    fontSize: '0.9rem',
-    lineHeight: 1.5,
-  },
+const Answer = styled(AccordionDetails)(({ theme }) => ({
+  padding: theme.spacing(0, 0, 3),
+  color: landingTokens.inkMuted,
+  lineHeight: 1.7,
+  fontSize: '0.95rem',
+  maxWidth: '60ch',
 }))
-
-// Configuration de l'animation FAQ
-const FAQ_ANIMATION_CONFIG = {
-  SCROLL_SPEED: 0.3, // pixels par frame
-  SCROLL_SPEED_MOBILE: 0.2, // pixels par frame sur mobile (plus lent)
-  CARD_WIDTH: 380, // largeur des cartes FAQ
-  CARD_GAP: 32, // espacement entre les cartes
-  PAUSE_AFTER_INTERACTION: 500, // délai avant reprise de l'animation (ms)
-  USER_SCROLL_DETECTION_DELAY: 100, // délai pour détecter la fin du scroll utilisateur (ms)
-  DRAG_SENSITIVITY: 1, // multiplicateur de sensibilité pour le drag
-  INITIAL_DELAY: 3000, // délai initial avant démarrage de l'animation (ms)
-  FADE_WIDTH: 80, // largeur du fondu sur les côtés (px)
-  FADE_WIDTH_MOBILE: 20, // largeur du fondu sur les côtés sur mobile (px)
-  CARD_WIDTH_MOBILE: 260, // largeur des cartes FAQ sur mobile
-  CARD_GAP_MOBILE: 16, // espacement entre les cartes sur mobile
-} as const
-
-const InfiniteScrollFAQ = ({ faqs }: { faqs: Array<{ question: string; answer: string }> }) => {
-  const containerRef = useRef<HTMLDivElement>(null)
-  const wrapperRef = useRef<HTMLDivElement>(null)
-  const animationRef = useRef<number>(0)
-  const isUserScrollingRef = useRef(false)
-  const isHoveringRef = useRef(false)
-  const lastUserScrollTime = useRef(Date.now() - FAQ_ANIMATION_CONFIG.INITIAL_DELAY)
-  const isDraggingRef = useRef(false)
-  const startXRef = useRef(0)
-  const scrollLeftRef = useRef(0)
-  const scrollAccumulator = useRef(0)
-
-  const theme = useTheme()
-  const isMobile = useMediaQuery(theme.breakpoints.down('sm'))
-
-  const scrollSpeed = useMemo(
-    () => (isMobile ? FAQ_ANIMATION_CONFIG.SCROLL_SPEED_MOBILE : FAQ_ANIMATION_CONFIG.SCROLL_SPEED),
-    [isMobile],
-  )
-
-  const cardWidth = useMemo(
-    () =>
-      (isMobile ? FAQ_ANIMATION_CONFIG.CARD_WIDTH_MOBILE : FAQ_ANIMATION_CONFIG.CARD_WIDTH) +
-      (isMobile ? FAQ_ANIMATION_CONFIG.CARD_GAP_MOBILE : FAQ_ANIMATION_CONFIG.CARD_GAP),
-    [isMobile],
-  )
-
-  useEffect(() => {
-    const container = containerRef.current
-    const wrapper = wrapperRef.current
-    if (!container || !wrapper) return
-
-    const totalWidth = cardWidth * faqs.length
-
-    const animate = () => {
-      const currentTime = Date.now()
-
-      // Si l'utilisateur a scrollé récemment ou hover, attendre avant de reprendre l'animation
-      if (
-        currentTime - lastUserScrollTime.current < FAQ_ANIMATION_CONFIG.PAUSE_AFTER_INTERACTION ||
-        isDraggingRef.current ||
-        isHoveringRef.current
-      ) {
-        animationRef.current = requestAnimationFrame(animate)
-        return
-      }
-
-      if (!isUserScrollingRef.current && !isDraggingRef.current && !isHoveringRef.current) {
-        // Accumuler les petites valeurs de scroll pour gérer les vitesses très lentes
-        scrollAccumulator.current += scrollSpeed
-
-        // N'appliquer le scroll que quand on a au moins 1 pixel à déplacer
-        if (scrollAccumulator.current >= 1) {
-          const scrollAmount = Math.floor(scrollAccumulator.current)
-          container.scrollLeft += scrollAmount
-          scrollAccumulator.current -= scrollAmount
-        }
-      }
-
-      animationRef.current = requestAnimationFrame(animate)
-    }
-
-    // Détecter le scroll utilisateur (wheel, touch)
-    const handleWheel = () => {
-      isUserScrollingRef.current = true
-      lastUserScrollTime.current = Date.now()
-      setTimeout(() => {
-        isUserScrollingRef.current = false
-      }, FAQ_ANIMATION_CONFIG.USER_SCROLL_DETECTION_DELAY)
-    }
-
-    // Gérer le scroll infini sans interférer avec l'animation
-    const handleScroll = () => {
-      const { scrollLeft, scrollWidth, clientWidth } = container
-
-      if (scrollLeft <= 0) {
-        container.scrollLeft = totalWidth - 1
-      } else if (scrollLeft >= scrollWidth - clientWidth - 1) {
-        container.scrollLeft = totalWidth + 1
-      }
-    }
-
-    // Gestionnaires pour le drag scroll
-    const handleMouseDown = (e: MouseEvent) => {
-      isDraggingRef.current = true
-      startXRef.current = e.pageX - container.offsetLeft
-      scrollLeftRef.current = container.scrollLeft
-      lastUserScrollTime.current = Date.now()
-      container.style.cursor = 'grabbing'
-      container.style.userSelect = 'none'
-    }
-
-    const handleMouseUp = () => {
-      isDraggingRef.current = false
-      container.style.cursor = 'grab'
-      container.style.userSelect = 'auto'
-    }
-
-    const handleMouseMove = (e: MouseEvent) => {
-      if (!isDraggingRef.current) return
-      e.preventDefault()
-      const x = e.pageX - container.offsetLeft
-      const walk = (x - startXRef.current) * FAQ_ANIMATION_CONFIG.DRAG_SENSITIVITY
-      container.scrollLeft = scrollLeftRef.current - walk
-      lastUserScrollTime.current = Date.now()
-    }
-
-    // Gestionnaires pour le hover
-    const handleMouseEnter = () => {
-      isHoveringRef.current = true
-      lastUserScrollTime.current = Date.now()
-    }
-
-    const handleMouseLeaveContainer = () => {
-      isHoveringRef.current = false
-      // Arrêter le drag si on sort du container
-      if (isDraggingRef.current) {
-        isDraggingRef.current = false
-        container.style.cursor = 'grab'
-        container.style.userSelect = 'auto'
-      }
-    }
-
-    container.addEventListener('scroll', handleScroll, { passive: true })
-    container.addEventListener('wheel', handleWheel, { passive: true })
-    container.addEventListener('touchstart', handleWheel, { passive: true })
-    container.addEventListener('mouseenter', handleMouseEnter, { passive: true })
-    container.addEventListener('mouseleave', handleMouseLeaveContainer, { passive: true })
-    container.addEventListener('mousedown', handleMouseDown)
-    container.addEventListener('mouseup', handleMouseUp)
-    container.addEventListener('mousemove', handleMouseMove)
-
-    // Positionner au milieu au démarrage
-    container.scrollLeft = totalWidth
-
-    // Démarrer l'animation immédiatement
-    animationRef.current = requestAnimationFrame(animate)
-
-    return () => {
-      if (animationRef.current) {
-        cancelAnimationFrame(animationRef.current)
-      }
-      container.removeEventListener('scroll', handleScroll)
-      container.removeEventListener('wheel', handleWheel)
-      container.removeEventListener('touchstart', handleWheel)
-      container.removeEventListener('mouseenter', handleMouseEnter)
-      container.removeEventListener('mouseleave', handleMouseLeaveContainer)
-      container.removeEventListener('mousedown', handleMouseDown)
-      container.removeEventListener('mouseup', handleMouseUp)
-      container.removeEventListener('mousemove', handleMouseMove)
-    }
-  }, [faqs.length, cardWidth, scrollSpeed])
-
-  return (
-    <FAQContainerWrapper>
-      <FAQContainer ref={containerRef}>
-        <FAQScrollWrapper ref={wrapperRef}>
-          {/* Première série */}
-          {faqs.map((faq, index) => (
-            <FAQCard key={`first-${index}`}>
-              <FAQQuestion>{faq.question}</FAQQuestion>
-              <FAQAnswer>{faq.answer}</FAQAnswer>
-            </FAQCard>
-          ))}
-          {/* Série dupliquée pour l'effet infini */}
-          {faqs.map((faq, index) => (
-            <FAQCard key={`second-${index}`}>
-              <FAQQuestion>{faq.question}</FAQQuestion>
-              <FAQAnswer>{faq.answer}</FAQAnswer>
-            </FAQCard>
-          ))}
-          {/* Troisième série pour un scroll plus fluide */}
-          {faqs.map((faq, index) => (
-            <FAQCard key={`third-${index}`}>
-              <FAQQuestion>{faq.question}</FAQQuestion>
-              <FAQAnswer>{faq.answer}</FAQAnswer>
-            </FAQCard>
-          ))}
-        </FAQScrollWrapper>
-      </FAQContainer>
-    </FAQContainerWrapper>
-  )
-}
 
 const DEFAULT_FAQS = [
   {
@@ -363,11 +127,37 @@ interface FAQSectionProps {
 }
 
 export const FAQSection = ({ faqs = DEFAULT_FAQS }: FAQSectionProps) => {
+  const [expanded, setExpanded] = useState<number | false>(0)
+
   return (
     <FAQSectionContainer id="faq">
-      <Container maxWidth="xl" sx={{ px: { xs: 2, sm: 3, md: 4 } }}>
-        <FAQTitle>Questions fréquentes</FAQTitle>
-        <InfiniteScrollFAQ faqs={faqs} />
+      <Container maxWidth="lg">
+        <FAQLayout>
+          <Box>
+            <Kicker>FAQ</Kicker>
+            <SectionTitle>Questions fréquentes</SectionTitle>
+            <SectionSubtitle>
+              Une autre question ? Créez un compte gratuitement et découvrez Wishlist par vous-même.
+            </SectionSubtitle>
+          </Box>
+
+          <Box>
+            {faqs.map((faq, index) => (
+              <FAQAccordion
+                key={faq.question}
+                disableGutters
+                square
+                expanded={expanded === index}
+                onChange={(_, isExpanded) => setExpanded(isExpanded ? index : false)}
+              >
+                <AccordionSummary expandIcon={<AddRounded />}>
+                  <Question>{faq.question}</Question>
+                </AccordionSummary>
+                <Answer>{faq.answer}</Answer>
+              </FAQAccordion>
+            ))}
+          </Box>
+        </FAQLayout>
       </Container>
     </FAQSectionContainer>
   )

--- a/apps/front/src/components/landing/FeaturesGrid.tsx
+++ b/apps/front/src/components/landing/FeaturesGrid.tsx
@@ -1,345 +1,174 @@
-import { Box, Button, Chip, Container, Fade, Typography } from '@mui/material'
+import type { SvgIconComponent } from '@mui/icons-material'
+
+import {
+  CalendarMonthRounded,
+  Diversity3Rounded,
+  LockOutlined,
+  RedeemRounded,
+  ShuffleRounded,
+  TaskAltRounded,
+} from '@mui/icons-material'
+import { Box, Container, Typography } from '@mui/material'
 import { styled } from '@mui/material/styles'
-import { useState } from 'react'
+
+import { landingTokens } from './landing.tokens'
 
 const FeaturesContainer = styled(Box)(({ theme }) => ({
-  padding: theme.spacing(12, 0),
-  backgroundColor: '#fafafa',
-  position: 'relative',
+  padding: theme.spacing(14, 0),
+  backgroundColor: landingTokens.surface,
+  [theme.breakpoints.down('md')]: {
+    padding: theme.spacing(10, 0),
+  },
+}))
+
+const SectionHeader = styled(Box)(({ theme }) => ({
+  maxWidth: 560,
+  marginBottom: theme.spacing(8),
+  [theme.breakpoints.down('md')]: {
+    marginBottom: theme.spacing(6),
+  },
+}))
+
+const Kicker = styled(Typography)(({ theme }) => ({
+  color: landingTokens.accent,
+  fontSize: '0.8rem',
+  fontWeight: 600,
+  letterSpacing: '0.18em',
+  textTransform: 'uppercase',
+  marginBottom: theme.spacing(2),
 }))
 
 const SectionTitle = styled(Typography)(({ theme }) => ({
-  textAlign: 'center',
-  marginBottom: theme.spacing(3),
-  fontSize: '3rem',
-  fontWeight: 700,
-  color: theme.palette.text.primary,
-  [theme.breakpoints.down('md')]: {
-    fontSize: '2.5rem',
-  },
-  [theme.breakpoints.down('sm')]: {
-    fontSize: '2rem',
-  },
+  fontFamily: landingTokens.displayFont,
+  fontWeight: 500,
+  fontSize: 'clamp(1.9rem, 3.5vw, 2.6rem)',
+  lineHeight: 1.2,
+  letterSpacing: '-0.01em',
+  color: landingTokens.ink,
+  marginBottom: theme.spacing(2),
 }))
 
-const SectionSubtitle = styled(Typography)(({ theme }) => ({
-  textAlign: 'center',
-  fontSize: '1.25rem',
-  color: theme.palette.text.secondary,
-  maxWidth: '600px',
-  margin: `0 auto ${theme.spacing(10)}`,
-  [theme.breakpoints.down('md')]: {
-    fontSize: '1.1rem',
-    margin: `0 auto ${theme.spacing(8)}`,
-  },
+const SectionSubtitle = styled(Typography)(() => ({
+  color: landingTokens.inkMuted,
+  fontSize: '1.05rem',
+  lineHeight: 1.7,
 }))
 
 const FeaturesGrid = styled(Box)(({ theme }) => ({
   display: 'grid',
   gridTemplateColumns: 'repeat(3, 1fr)',
-  gap: theme.spacing(4),
+  gap: theme.spacing(3),
   [theme.breakpoints.down('md')]: {
     gridTemplateColumns: 'repeat(2, 1fr)',
-    gap: theme.spacing(3),
   },
   [theme.breakpoints.down('sm')]: {
     gridTemplateColumns: '1fr',
-    gap: theme.spacing(3),
   },
 }))
 
 const FeatureCard = styled(Box)(({ theme }) => ({
-  backgroundColor: 'white',
+  backgroundColor: landingTokens.paper,
+  border: `1px solid ${landingTokens.hairline}`,
   borderRadius: theme.spacing(2),
   padding: theme.spacing(4),
-  boxShadow: '0 2px 20px rgba(0, 0, 0, 0.06)',
-  transition: 'all 0.3s ease',
-  border: '1px solid rgba(0, 0, 0, 0.05)',
-  position: 'relative',
+  transition: 'border-color 0.25s ease, transform 0.25s ease, box-shadow 0.25s ease',
   '&:hover': {
-    transform: 'translateY(-4px)',
-    boxShadow: '0 8px 40px rgba(0, 0, 0, 0.12)',
+    borderColor: theme.palette.primary.main,
+    transform: 'translateY(-3px)',
+    boxShadow: '0 16px 32px -20px rgba(28, 43, 54, 0.25)',
   },
 }))
 
 const FeatureIconWrapper = styled(Box)(({ theme }) => ({
-  width: 64,
-  height: 64,
+  width: 46,
+  height: 46,
   borderRadius: theme.spacing(1.5),
+  backgroundColor: landingTokens.blueTint,
+  color: theme.palette.primary.main,
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
   marginBottom: theme.spacing(3),
-  fontSize: '2rem',
 }))
 
 const FeatureTitle = styled(Typography)(({ theme }) => ({
   fontWeight: 600,
-  fontSize: '1.25rem',
-  color: theme.palette.text.primary,
-  marginBottom: theme.spacing(2),
+  fontSize: '1.1rem',
+  color: landingTokens.ink,
+  marginBottom: theme.spacing(1),
 }))
 
-const FeatureDescription = styled(Typography)(({ theme }) => ({
-  color: theme.palette.text.secondary,
-  lineHeight: 1.6,
+const FeatureDescription = styled(Typography)(() => ({
+  color: landingTokens.inkMuted,
+  lineHeight: 1.65,
   fontSize: '0.95rem',
 }))
 
-const BadgeChip = styled(Chip)(({ theme }) => ({
-  position: 'absolute',
-  top: theme.spacing(2),
-  right: theme.spacing(2),
-  fontSize: '0.75rem',
-  height: 24,
-  fontWeight: 600,
-}))
-
-const PopularBadge = styled(BadgeChip)(() => ({
-  backgroundColor: '#fef3c7',
-  color: '#d97706',
-  border: '1px solid #fcd34d',
-}))
-
-const NewBadge = styled(BadgeChip)(() => ({
-  backgroundColor: '#dcfce7',
-  color: '#16a34a',
-  border: '1px solid #86efac',
-}))
-
-const EssentialBadge = styled(BadgeChip)(() => ({
-  backgroundColor: '#fce7f3',
-  color: '#be185d',
-  border: '1px solid #f9a8d4',
-}))
-
-const ProBadge = styled(BadgeChip)(() => ({
-  backgroundColor: '#e0e7ff',
-  color: '#4338ca',
-  border: '1px solid #a5b4fc',
-}))
-
-const ComingSoonBadge = styled(BadgeChip)(() => ({
-  backgroundColor: '#f3e8ff',
-  color: '#7c3aed',
-  border: '1px solid #c4b5fd',
-}))
-
-const ShowMoreButton = styled(Button)(({ theme }) => ({
-  marginTop: theme.spacing(6),
-  padding: theme.spacing(1.5, 4),
-  borderRadius: theme.spacing(3),
-  fontSize: '1rem',
-  fontWeight: 600,
-  textTransform: 'none',
-  background: 'linear-gradient(135deg, #3b82f6 0%, #1d4ed8 100%)',
-  color: 'white',
-  boxShadow: '0 4px 20px rgba(59, 130, 246, 0.25)',
-  transition: 'all 0.3s ease',
-  '&:hover': {
-    background: 'linear-gradient(135deg, #2563eb 0%, #1e40af 100%)',
-    transform: 'translateY(-2px)',
-    boxShadow: '0 6px 30px rgba(59, 130, 246, 0.35)',
-  },
-  '&:active': {
-    transform: 'translateY(0)',
-  },
-}))
-
-const ShowMoreContainer = styled(Box)(() => ({
-  display: 'flex',
-  justifyContent: 'center',
-  width: '100%',
-}))
-
 interface Feature {
-  icon: string
+  icon: SvgIconComponent
   title: string
   description: string
-  iconBg: string
-  badge?: 'Populaire' | 'Nouveau' | 'Essentiel' | 'Pro' | 'Bientôt'
-  priority?: number // pour l'ordre d'affichage
 }
 
 const features: Feature[] = [
   {
-    icon: '🎁',
-    title: 'Listes de souhaits intelligentes',
-    description: 'Créez et organisez vos souhaits par priorités',
-    iconBg: 'linear-gradient(135deg, #3b82f6 0%, #1d4ed8 100%)',
-    badge: 'Populaire',
-    priority: 1,
+    icon: RedeemRounded,
+    title: 'Listes de souhaits',
+    description: 'Ajoutez vos envies en quelques secondes, avec un lien, une photo et un niveau de priorité.',
   },
   {
-    icon: '📅',
-    title: "Gestion d'événements",
-    description: 'Organisez anniversaires, mariages, Noël et tous vos moments spéciaux.',
-    iconBg: 'linear-gradient(135deg, #8b5cf6 0%, #7c3aed 100%)',
-    priority: 2,
+    icon: CalendarMonthRounded,
+    title: 'Événements',
+    description: 'Anniversaires, Noël, mariages, naissances : réunissez vos proches autour d’une même date.',
   },
   {
-    icon: '👨‍👩‍👧‍👦',
-    title: 'Partage familial',
-    description: 'Invitez famille et amis à consulter vos listes et partager les leurs.',
-    iconBg: 'linear-gradient(135deg, #f97316 0%, #ea580c 100%)',
-    badge: 'Essentiel',
-    priority: 3,
+    icon: Diversity3Rounded,
+    title: 'Partage en famille',
+    description: 'Invitez famille et amis par email ou par lien. Chacun consulte les listes des autres.',
   },
   {
-    icon: '🎅🏻',
+    icon: TaskAltRounded,
+    title: 'Réservations discrètes',
+    description: 'Réservez un cadeau pour éviter les doublons — la personne concernée n’en saura rien.',
+  },
+  {
+    icon: ShuffleRounded,
     title: 'Secret Santa',
-    description: 'Organisez un Secret Santa avec vos proches pour vos Noël',
-    iconBg: 'linear-gradient(135deg, #22c55e 0%, #ef4444 100%)',
-    badge: 'Nouveau',
-    priority: 4,
+    description: 'Tirage au sort automatique avec exclusions et budget. Chacun reçoit son tirage par email.',
   },
   {
-    icon: '🐣',
-    title: 'Listes de proches et enfants',
-    description: 'Gérez la liste de vos proches et enfants',
-    iconBg: 'linear-gradient(135deg, #fbbf24 0%, #f59e0b 100%)',
-    badge: 'Populaire',
-    priority: 5,
-  },
-  {
-    icon: '🔒',
-    title: 'Confidentialité garantie',
-    description: 'Contrôlez qui peut voir vos listes avec des paramètres de confidentialité avancés.',
-    iconBg: 'linear-gradient(135deg, #10b981 0%, #059669 100%)',
-    priority: 6,
-  },
-  {
-    icon: '🔔',
-    title: 'Notifications intelligentes',
-    description: 'Recevez des rappels pour les événements importants de vos proches.',
-    iconBg: 'linear-gradient(135deg, #3b82f6 0%, #1e40af 100%)',
-  },
-  {
-    icon: '💝',
-    title: 'Favoris et recommandations',
-    description: 'Découvrez des idées cadeaux basées sur les goûts de vos proches.',
-    iconBg: 'linear-gradient(135deg, #ec4899 0%, #be185d 100%)',
-  },
-  {
-    icon: '🔗',
-    title: 'Listes partagée',
-    description: 'Partagez vos listes sur différents événements',
-    iconBg: 'linear-gradient(135deg, #8b5cf6 0%, #6d28d9 100%)',
-  },
-  {
-    icon: '⚡',
-    title: 'Synchronisation temps réel',
-    description: 'Mises à jour instantanées pour tous les membres de la famille.',
-    iconBg: 'linear-gradient(135deg, #06b6d4 0%, #0891b2 100%)',
+    icon: LockOutlined,
+    title: 'Confidentialité',
+    description: 'Vos listes ne sont visibles que par les personnes que vous invitez, rien de plus.',
   },
 ]
 
-const getBadgeComponent = (badge: Feature['badge']) => {
-  switch (badge) {
-    case 'Populaire':
-      return <PopularBadge label="Populaire" size="small" />
-    case 'Nouveau':
-      return <NewBadge label="Nouveau" size="small" />
-    case 'Essentiel':
-      return <EssentialBadge label="Essentiel" size="small" />
-    case 'Pro':
-      return <ProBadge label="Pro" size="small" />
-    case 'Bientôt':
-      return <ComingSoonBadge label="Bientôt" size="small" />
-    default:
-      return null
-  }
-}
-
 export const FeaturesGridSection = () => {
-  const [showAll, setShowAll] = useState(false)
-
-  // Nombre de features à afficher initialement
-  const INITIAL_FEATURES_COUNT = 6
-
-  // Séparer les features prioritaires et les autres
-  const sortedFeatures = [...features].sort((a, b) => {
-    if (a.priority && b.priority) return a.priority - b.priority
-    if (a.priority) return -1
-    if (b.priority) return 1
-    return 0
-  })
-
-  const displayedFeatures = showAll ? sortedFeatures : sortedFeatures.slice(0, INITIAL_FEATURES_COUNT)
-  const hasMoreFeatures = sortedFeatures.length > INITIAL_FEATURES_COUNT
-
-  const handleToggle = () => {
-    if (showAll) {
-      // Smooth scroll vers le haut de la section quand on réduit
-      const featuresSection = document.getElementById('features')
-      if (featuresSection) {
-        featuresSection.scrollIntoView({ behavior: 'smooth', block: 'start' })
-      }
-    }
-    setShowAll(!showAll)
-  }
-
   return (
     <FeaturesContainer id="features">
       <Container maxWidth="lg">
-        <SectionTitle>
-          Tout ce dont vous avez besoin pour{' '}
-          <span
-            style={{
-              background: 'linear-gradient(135deg, #3d7ea8 0%, #60a5fa 100%)',
-              backgroundClip: 'text',
-              WebkitBackgroundClip: 'text',
-              WebkitTextFillColor: 'transparent',
-            }}
-          >
-            des moments parfaits
-          </span>
-        </SectionTitle>
-
-        <SectionSubtitle>
-          Découvrez toutes les fonctionnalités qui rendent WishList unique pour organiser vos événements et partager vos
-          souhaits en toute simplicité.
-        </SectionSubtitle>
+        <SectionHeader>
+          <Kicker>Fonctionnalités</Kicker>
+          <SectionTitle>Tout pour bien offrir, rien de superflu.</SectionTitle>
+          <SectionSubtitle>
+            Des outils simples pour organiser vos événements et partager vos souhaits, pensés pour toute la famille.
+          </SectionSubtitle>
+        </SectionHeader>
 
         <FeaturesGrid>
-          {displayedFeatures.map((feature, index) => (
-            <Fade
-              key={index}
-              in={true}
-              timeout={showAll && index >= INITIAL_FEATURES_COUNT ? 800 + (index - INITIAL_FEATURES_COUNT) * 100 : 0}
-            >
-              <FeatureCard>
-                {feature.badge && getBadgeComponent(feature.badge)}
-
-                <FeatureIconWrapper style={{ background: feature.iconBg }}>{feature.icon}</FeatureIconWrapper>
-
+          {features.map(feature => {
+            const Icon = feature.icon
+            return (
+              <FeatureCard key={feature.title}>
+                <FeatureIconWrapper>
+                  <Icon fontSize="small" />
+                </FeatureIconWrapper>
                 <FeatureTitle>{feature.title}</FeatureTitle>
                 <FeatureDescription>{feature.description}</FeatureDescription>
               </FeatureCard>
-            </Fade>
-          ))}
+            )
+          })}
         </FeaturesGrid>
-
-        {hasMoreFeatures && (
-          <ShowMoreContainer>
-            <ShowMoreButton
-              onClick={handleToggle}
-              endIcon={
-                <span
-                  style={{
-                    fontSize: '1.2rem',
-                    transition: 'transform 0.3s ease',
-                    transform: showAll ? 'rotate(180deg)' : 'rotate(0deg)',
-                  }}
-                >
-                  ↓
-                </span>
-              }
-            >
-              {showAll ? 'Voir moins' : `Voir ${sortedFeatures.length - INITIAL_FEATURES_COUNT} autres fonctionnalités`}
-            </ShowMoreButton>
-          </ShowMoreContainer>
-        )}
       </Container>
     </FeaturesContainer>
   )

--- a/apps/front/src/components/landing/FooterSection.tsx
+++ b/apps/front/src/components/landing/FooterSection.tsx
@@ -1,21 +1,34 @@
-import { Box, Stack, Typography } from '@mui/material'
+import { Container, Stack, Typography } from '@mui/material'
 import { styled } from '@mui/material/styles'
 import { Link } from '@tanstack/react-router'
 
-const FooterContainer = styled(Box)(({ theme }) => ({
-  backgroundColor: theme.palette.primary.dark,
-  color: 'white',
-  padding: theme.spacing(2, 0),
-  gap: theme.spacing(2),
+import { landingTokens } from './landing.tokens'
+
+const FooterContainer = styled('footer')(({ theme }) => ({
+  backgroundColor: landingTokens.deepBlue,
+  padding: theme.spacing(2.5, 0),
+}))
+
+const FooterContent = styled(Container)(({ theme }) => ({
   display: 'flex',
-  flexDirection: 'column',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+  gap: theme.spacing(2),
+  [theme.breakpoints.down('sm')]: {
+    flexDirection: 'column',
+    gap: theme.spacing(1.5),
+  },
+}))
+
+const Copyright = styled(Typography)(() => ({
+  color: 'rgba(255, 255, 255, 0.55)',
+  fontSize: '0.85rem',
 }))
 
 const FooterLinkItem = styled(Typography)(() => ({
-  color: '#d1d5db',
-  textDecoration: 'none',
-  cursor: 'pointer',
-  transition: 'color 0.3s ease',
+  color: 'rgba(255, 255, 255, 0.65)',
+  fontSize: '0.85rem',
+  transition: 'color 0.2s ease',
   '&:hover': {
     color: 'white',
   },
@@ -28,17 +41,18 @@ const FooterLinkItem = styled(Typography)(() => ({
 export const FooterSection = () => {
   return (
     <FooterContainer>
-      <Stack direction="row" spacing={3} justifyContent="center" alignItems="center">
-        <FooterLinkItem variant="body2">
-          <Link to="/privacy">Confidentialité</Link>
-        </FooterLinkItem>
-        <FooterLinkItem variant="body2">
-          <Link to="/terms">Conditions</Link>
-        </FooterLinkItem>
-      </Stack>
-      <Typography variant="body2" color="grey.400" textAlign="center">
-        © {new Date().getFullYear()} Wishlist. Tous droits réservés.
-      </Typography>
+      <FooterContent maxWidth="lg">
+        <Copyright>© {new Date().getFullYear()} Wishlist. Tous droits réservés.</Copyright>
+
+        <Stack direction="row" spacing={3}>
+          <FooterLinkItem>
+            <Link to="/privacy">Confidentialité</Link>
+          </FooterLinkItem>
+          <FooterLinkItem>
+            <Link to="/terms">Conditions</Link>
+          </FooterLinkItem>
+        </Stack>
+      </FooterContent>
     </FooterContainer>
   )
 }

--- a/apps/front/src/components/landing/GetStartedSection.tsx
+++ b/apps/front/src/components/landing/GetStartedSection.tsx
@@ -5,164 +5,92 @@ import { Box, Button, Container, Typography } from '@mui/material'
 import { styled } from '@mui/material/styles'
 import { Link } from '@tanstack/react-router'
 
+import { landingTokens } from './landing.tokens'
+
 const CTAContainer = styled(Box)(({ theme }) => ({
-  background: `linear-gradient(10deg, ${theme.palette.primary.dark} 0%, ${theme.palette.primary.main} 30%, ${theme.palette.primary.light} 60%, ${theme.palette.primary.dark} 100%)`,
-  padding: theme.spacing(12, 0),
+  background: `linear-gradient(175deg, ${theme.palette.primary.main} 0%, ${landingTokens.deepBlue} 75%)`,
+  padding: theme.spacing(14, 0),
   position: 'relative',
   overflow: 'hidden',
   '&::before': {
     content: '""',
     position: 'absolute',
-    top: 0,
-    left: 0,
-    right: 0,
-    bottom: 0,
-    background:
-      'url("data:image/svg+xml,%3Csvg width="40" height="40" viewBox="0 0 40 40" xmlns="http://www.w3.org/2000/svg"%3E%3Cg fill="none" fill-rule="evenodd"%3E%3Cg fill="%23ffffff" fill-opacity="0.03"%3E%3Cpath d="M20 20c0-16.569-13.431-30-30-30s-30 13.431-30 30 13.431 30 30 30 30-13.431 30-30z"/%3E%3C/g%3E%3C/g%3E%3C/svg%3E")',
+    top: '-40%',
+    right: '-10%',
+    width: '50%',
+    height: '120%',
+    background: 'radial-gradient(ellipse at center, rgba(255, 255, 255, 0.07) 0%, transparent 70%)',
+    pointerEvents: 'none',
+  },
+  [theme.breakpoints.down('md')]: {
+    padding: theme.spacing(10, 0),
   },
 }))
 
 const ContentWrapper = styled(Container)(() => ({
   position: 'relative',
-  zIndex: 1,
   textAlign: 'center',
-  color: 'white',
 }))
 
 const CTATitle = styled(Typography)(({ theme }) => ({
-  fontSize: '2.5rem',
-  fontWeight: 700,
-  marginBottom: theme.spacing(3),
-  background: 'linear-gradient(135deg, #ffffff 0%, #e0f2fe 100%)',
-  backgroundClip: 'text',
-  WebkitBackgroundClip: 'text',
-  WebkitTextFillColor: 'transparent',
-  [theme.breakpoints.down('md')]: {
-    fontSize: '2rem',
-  },
-  [theme.breakpoints.down('sm')]: {
-    fontSize: '1.75rem',
+  fontFamily: landingTokens.displayFont,
+  fontWeight: 500,
+  fontSize: 'clamp(2rem, 4vw, 3rem)',
+  lineHeight: 1.15,
+  letterSpacing: '-0.01em',
+  color: '#ffffff',
+  marginBottom: theme.spacing(2.5),
+  '& em': {
+    fontStyle: 'italic',
+    color: '#cfe3f3',
   },
 }))
 
 const CTASubtitle = styled(Typography)(({ theme }) => ({
-  fontSize: '1.2rem',
-  color: 'rgba(255, 255, 255, 0.9)',
-  maxWidth: '600px',
-  margin: `0 auto ${theme.spacing(8)}`,
-  lineHeight: 1.6,
-  [theme.breakpoints.down('md')]: {
-    fontSize: '1.1rem',
-    margin: `0 auto ${theme.spacing(6)}`,
-  },
-}))
-
-const ButtonGroup = styled(Box)(() => ({
-  display: 'flex',
-  justifyContent: 'center',
+  fontSize: '1.1rem',
+  color: 'rgba(255, 255, 255, 0.85)',
+  maxWidth: 520,
+  margin: `0 auto ${theme.spacing(6)}`,
+  lineHeight: 1.7,
 }))
 
 const PrimaryButton = styled(Button)<ButtonProps & LinkProps>(({ theme }) => ({
-  backgroundColor: 'white',
+  backgroundColor: '#ffffff',
   color: theme.palette.primary.main,
   fontWeight: 600,
-  fontSize: '1.1rem',
-  padding: theme.spacing(2, 5),
-  borderRadius: theme.spacing(1),
-  boxShadow: '0 4px 20px rgba(0, 0, 0, 0.1)',
-  transition: 'all 0.3s ease',
-  minWidth: 220,
+  fontSize: '1.05rem',
+  padding: theme.spacing(1.75, 5),
+  boxShadow: '0 16px 32px -16px rgba(0, 0, 0, 0.4)',
   '&:hover': {
-    backgroundColor: '#f8fafc',
-    transform: 'translateY(-2px)',
-    boxShadow: '0 8px 30px rgba(0, 0, 0, 0.15)',
+    backgroundColor: landingTokens.paper,
+    transform: 'translateY(-1px)',
+    boxShadow: '0 20px 36px -16px rgba(0, 0, 0, 0.45)',
   },
 }))
 
-const FloatingCard = styled(Box)(({ theme }) => ({
-  position: 'absolute',
-  backgroundColor: 'rgba(255, 255, 255, 0.1)',
-  borderRadius: theme.spacing(2),
-  padding: theme.spacing(2),
-  backdropFilter: 'blur(10px)',
-  border: '1px solid rgba(255, 255, 255, 0.2)',
-  [theme.breakpoints.down('md')]: {
-    display: 'none',
-  },
-}))
-
-const FloatingCard1 = styled(FloatingCard)(() => ({
-  top: '20%',
-  left: '10%',
-  transform: 'rotate(-5deg)',
-}))
-
-const FloatingCard2 = styled(FloatingCard)(() => ({
-  top: '60%',
-  right: '10%',
-  transform: 'rotate(5deg)',
-}))
-
-const FloatingCard3 = styled(FloatingCard)(() => ({
-  bottom: '20%',
-  left: '15%',
-  transform: 'rotate(-3deg)',
-}))
-
-const FloatingCard4 = styled(FloatingCard)(() => ({
-  top: '40%',
-  right: '15%',
-  transform: 'rotate(-7deg)',
-}))
-
-const CardIcon = styled(Box)(() => ({
-  fontSize: '2rem',
-  marginBottom: '8px',
-  textAlign: 'center',
-}))
-
-const CardText = styled(Typography)(() => ({
-  fontSize: '0.9rem',
-  color: 'rgba(255, 255, 255, 0.9)',
-  textAlign: 'center',
-  fontWeight: 500,
+const TrustCaption = styled(Typography)(({ theme }) => ({
+  marginTop: theme.spacing(2.5),
+  fontSize: '0.85rem',
+  color: 'rgba(255, 255, 255, 0.7)',
 }))
 
 export const GetStartedSection = () => {
   return (
     <CTAContainer>
-      <FloatingCard1>
-        <CardIcon>🎂</CardIcon>
-        <CardText>Anniversaires</CardText>
-      </FloatingCard1>
-
-      <FloatingCard2>
-        <CardIcon>🎄</CardIcon>
-        <CardText>Noël</CardText>
-      </FloatingCard2>
-
-      <FloatingCard3>
-        <CardIcon>💍</CardIcon>
-        <CardText>Mariages</CardText>
-      </FloatingCard3>
-
-      <FloatingCard4>
-        <CardIcon>👶</CardIcon>
-        <CardText>Naissance</CardText>
-      </FloatingCard4>
-
       <ContentWrapper maxWidth="md">
-        <CTATitle>Prêt à créer vos premières listes ?</CTATitle>
+        <CTATitle>
+          Prêt pour votre <em>prochain</em> événement ?
+        </CTATitle>
 
         <CTASubtitle>
-          Rejoignez des milliers de familles qui utilisent déjà WishList pour organiser leurs moments les plus précieux.
+          Rejoignez les familles qui utilisent déjà Wishlist pour organiser leurs moments les plus précieux.
         </CTASubtitle>
 
-        <ButtonGroup>
-          <PrimaryButton variant="contained" size="large" component={Link} to="/register">
-            Commencer gratuitement
-          </PrimaryButton>
-        </ButtonGroup>
+        <PrimaryButton variant="contained" size="large" component={Link} to="/register">
+          Commencer gratuitement
+        </PrimaryButton>
+
+        <TrustCaption>Inscription en moins d’une minute · 100 % gratuit</TrustCaption>
       </ContentWrapper>
     </CTAContainer>
   )

--- a/apps/front/src/components/landing/HeroSection.tsx
+++ b/apps/front/src/components/landing/HeroSection.tsx
@@ -1,153 +1,115 @@
 import type { ButtonProps } from '@mui/material'
 import type { LinkProps } from '@tanstack/react-router'
 
+import { CalendarMonthRounded, RedeemRounded, ShuffleRounded } from '@mui/icons-material'
 import { Box, Button, Container, Typography } from '@mui/material'
 import { keyframes, styled } from '@mui/material/styles'
 import { Link } from '@tanstack/react-router'
 
-import { Logo } from '../common/Logo'
+import { landingTokens } from './landing.tokens'
 
-// Animations
-const twinkle = keyframes`
-  0%, 100% { 
-    opacity: 0.2;
-    transform: scale(0.8);
-    filter: brightness(0.8);
+const fadeUp = keyframes`
+  from {
+    opacity: 0;
+    transform: translateY(16px);
   }
-  50% { 
+  to {
     opacity: 1;
-    transform: scale(1.5);
-    filter: brightness(1.5);
-  }
-`
-
-const shimmer = keyframes`
-  0% { 
-    opacity: 0.4;
-    filter: brightness(1);
-  }
-  50% { 
-    opacity: 1;
-    filter: brightness(2);
-  }
-  100% { 
-    opacity: 0.4;
-    filter: brightness(1);
-  }
-`
-
-const colorShift = keyframes`
-  0%, 100% {
-    filter: hue-rotate(0deg) brightness(1) saturate(1);
-  }
-  25% {
-    filter: hue-rotate(-3deg) brightness(1.05) saturate(1.1);
-  }
-  50% {
-    filter: hue-rotate(3deg) brightness(0.95) saturate(0.95);
-  }
-  75% {
-    filter: hue-rotate(-2deg) brightness(1.02) saturate(1.05);
+    transform: translateY(0);
   }
 `
 
 const HeroContainer = styled(Box)(() => ({
-  background: 'linear-gradient(135deg, #1a3a52 0%, #255376 50%, #1a3a52 100%)',
-  minHeight: '100vh',
+  backgroundColor: landingTokens.paper,
+  backgroundImage: `radial-gradient(ellipse 60% 50% at 85% 10%, ${landingTokens.blueTint} 0%, transparent 70%)`,
   position: 'relative',
   overflow: 'hidden',
-  display: 'flex',
-  alignItems: 'center',
-  animation: `${colorShift} 10s ease-in-out infinite`,
-}))
-
-// Container for all stars
-const StarsContainer = styled(Box)(() => ({
-  position: 'absolute',
-  top: 0,
-  left: 0,
-  right: 0,
-  bottom: 0,
-  pointerEvents: 'none',
-  zIndex: 0,
-}))
-
-// Animated Star Points
-const StarPoint = styled(Box)(() => ({
-  position: 'absolute',
-  width: '2px',
-  height: '2px',
-  backgroundColor: '#ffffff',
-  borderRadius: '50%',
-  pointerEvents: 'none',
-  boxShadow: '0 0 10px rgba(255, 255, 255, 1), 0 0 20px rgba(147, 197, 253, 0.8)',
-  animation: `${twinkle} 1.5s ease-in-out infinite`,
-}))
-
-const BiggerStar = styled(Box)(() => ({
-  position: 'absolute',
-  width: '3px',
-  height: '3px',
-  backgroundColor: '#ffffff',
-  borderRadius: '50%',
-  pointerEvents: 'none',
-  boxShadow: '0 0 15px rgba(255, 255, 255, 1), 0 0 30px rgba(147, 197, 253, 1)',
-  animation: `${shimmer} 1s ease-in-out infinite`,
 }))
 
 const ContentWrapper = styled(Container)(({ theme }) => ({
-  position: 'relative',
-  zIndex: 1,
   display: 'grid',
-  gridTemplateColumns: '1fr 400px',
-  gap: theme.spacing(8),
+  gridTemplateColumns: '1.05fr 0.95fr',
+  gap: theme.spacing(10),
   alignItems: 'center',
   paddingTop: theme.spacing(12),
+  paddingBottom: theme.spacing(14),
   [theme.breakpoints.down('md')]: {
     gridTemplateColumns: '1fr',
-    gap: theme.spacing(4),
-    textAlign: 'center',
-    paddingTop: theme.spacing(14),
+    gap: theme.spacing(8),
+    paddingTop: theme.spacing(8),
+    paddingBottom: theme.spacing(10),
   },
 }))
 
-const MainContent = styled(Box)(() => ({
-  color: 'white',
+const MainContent = styled(Box)(({ theme }) => ({
+  '& > *': {
+    animation: `${fadeUp} 0.7s ease both`,
+  },
+  '& > *:nth-of-type(2)': { animationDelay: '0.1s' },
+  '& > *:nth-of-type(3)': { animationDelay: '0.2s' },
+  '& > *:nth-of-type(4)': { animationDelay: '0.3s' },
+  '& > *:nth-of-type(5)': { animationDelay: '0.4s' },
+  '@media (prefers-reduced-motion: reduce)': {
+    '& > *': { animation: 'none' },
+  },
+  [theme.breakpoints.down('md')]: {
+    textAlign: 'center',
+  },
 }))
 
-const GradientTitle = styled(Typography)(({ theme }) => ({
-  background: 'linear-gradient(135deg, #ffffff 0%, #e0f2fe 100%)',
-  backgroundClip: 'text',
-  WebkitBackgroundClip: 'text',
-  WebkitTextFillColor: 'transparent',
-  fontSize: '3.5rem',
-  fontWeight: 700,
-  lineHeight: 1.2,
+const Kicker = styled(Box)(({ theme }) => ({
+  display: 'flex',
+  alignItems: 'center',
+  gap: theme.spacing(1.5),
   marginBottom: theme.spacing(3),
   [theme.breakpoints.down('md')]: {
-    fontSize: '2.5rem',
+    justifyContent: 'center',
   },
-  [theme.breakpoints.down('sm')]: {
-    fontSize: '2rem',
+}))
+
+const KickerRule = styled(Box)(() => ({
+  width: 28,
+  height: 1,
+  backgroundColor: landingTokens.accent,
+}))
+
+const KickerText = styled(Typography)(() => ({
+  color: landingTokens.accent,
+  fontSize: '0.8rem',
+  fontWeight: 600,
+  letterSpacing: '0.18em',
+  textTransform: 'uppercase',
+}))
+
+const HeroTitle = styled(Typography)(({ theme }) => ({
+  fontFamily: landingTokens.displayFont,
+  fontWeight: 500,
+  fontSize: 'clamp(2.5rem, 5vw, 4rem)',
+  lineHeight: 1.12,
+  letterSpacing: '-0.02em',
+  color: landingTokens.ink,
+  marginBottom: theme.spacing(3),
+  '& em': {
+    fontStyle: 'italic',
+    color: theme.palette.primary.main,
   },
 }))
 
 const Subtitle = styled(Typography)(({ theme }) => ({
-  color: 'rgba(255, 255, 255, 0.9)',
-  fontSize: '1.25rem',
-  lineHeight: 1.6,
-  marginBottom: theme.spacing(4),
-  maxWidth: '500px',
+  color: landingTokens.inkMuted,
+  fontSize: '1.15rem',
+  lineHeight: 1.7,
+  marginBottom: theme.spacing(5),
+  maxWidth: 480,
   [theme.breakpoints.down('md')]: {
-    fontSize: '1.1rem',
-    maxWidth: 'none',
+    margin: `0 auto ${theme.spacing(5)}`,
   },
 }))
 
 const ButtonGroup = styled(Box)(({ theme }) => ({
   display: 'flex',
   gap: theme.spacing(2),
-  marginBottom: theme.spacing(6),
+  marginBottom: theme.spacing(3),
   [theme.breakpoints.down('md')]: {
     justifyContent: 'center',
   },
@@ -157,283 +119,276 @@ const ButtonGroup = styled(Box)(({ theme }) => ({
 }))
 
 const PrimaryButton = styled(Button)<ButtonProps & LinkProps>(({ theme }) => ({
-  backgroundColor: 'white',
-  color: theme.palette.primary.main,
   fontWeight: 600,
-  fontSize: '1.1rem',
+  fontSize: '1.05rem',
   padding: theme.spacing(1.5, 4),
-  borderRadius: theme.spacing(1),
-  boxShadow: '0 4px 20px rgba(0, 0, 0, 0.1)',
-  transition: 'all 0.3s ease',
+  boxShadow: '0 8px 24px -8px rgba(37, 83, 118, 0.5)',
   '&:hover': {
-    backgroundColor: '#f8fafc',
-    transform: 'translateY(-2px)',
-    boxShadow: '0 8px 30px rgba(0, 0, 0, 0.15)',
+    boxShadow: '0 12px 28px -8px rgba(37, 83, 118, 0.55)',
+    transform: 'translateY(-1px)',
   },
 }))
 
 const SecondaryButton = styled(Button)<ButtonProps & LinkProps>(({ theme }) => ({
-  borderColor: 'white',
-  color: 'white',
   fontWeight: 600,
-  fontSize: '1.1rem',
+  fontSize: '1.05rem',
   padding: theme.spacing(1.5, 4),
-  borderRadius: theme.spacing(1),
-  transition: 'all 0.3s ease',
+  color: landingTokens.ink,
+  borderColor: landingTokens.hairline,
+  backgroundColor: landingTokens.surface,
   '&:hover': {
-    backgroundColor: 'rgba(255, 255, 255, 0.1)',
-    borderColor: 'white',
-    transform: 'translateY(-2px)',
+    borderColor: landingTokens.ink,
+    backgroundColor: landingTokens.surface,
   },
 }))
 
-const FeaturesSidebar = styled(Box)(({ theme }) => ({
-  backgroundColor: 'rgba(255, 255, 255, 0.95)',
-  borderRadius: theme.spacing(2),
-  padding: theme.spacing(4),
-  boxShadow: '0 20px 40px rgba(0, 0, 0, 0.1)',
-  backdropFilter: 'blur(10px)',
+const TrustLine = styled(Typography)(() => ({
+  color: landingTokens.inkMuted,
+  fontSize: '0.85rem',
+}))
+
+// --- Product mock ---------------------------------------------------------
+
+const MockArea = styled(Box)(({ theme }) => ({
+  position: 'relative',
+  animation: `${fadeUp} 0.7s ease 0.25s both`,
+  '@media (prefers-reduced-motion: reduce)': {
+    animation: 'none',
+  },
   [theme.breakpoints.down('md')]: {
+    maxWidth: 440,
     margin: '0 auto',
-    maxWidth: '400px',
-    marginBottom: theme.spacing(6),
+    width: '100%',
   },
 }))
 
-const FeatureItem = styled(Box)(({ theme }) => ({
+const BackCard = styled(Box)(({ theme }) => ({
+  position: 'absolute',
+  inset: theme.spacing(3, -2, -3, 2),
+  backgroundColor: landingTokens.surface,
+  border: `1px solid ${landingTokens.hairline}`,
+  borderRadius: theme.spacing(2.5),
+  transform: 'rotate(3deg)',
+  opacity: 0.7,
+}))
+
+const MainCard = styled(Box)(({ theme }) => ({
+  position: 'relative',
+  backgroundColor: landingTokens.surface,
+  border: `1px solid ${landingTokens.hairline}`,
+  borderRadius: theme.spacing(2.5),
+  padding: theme.spacing(3.5),
+  boxShadow: '0 32px 64px -32px rgba(28, 43, 54, 0.3)',
+}))
+
+const CardHeader = styled(Box)(({ theme }) => ({
   display: 'flex',
   alignItems: 'center',
   gap: theme.spacing(2),
-  marginBottom: theme.spacing(3),
-  '&:last-child': {
-    marginBottom: 0,
-  },
+  paddingBottom: theme.spacing(2.5),
+  borderBottom: `1px solid ${landingTokens.hairline}`,
 }))
 
-const FeatureIcon = styled(Box)(({ theme }) => ({
-  width: 48,
-  height: 48,
-  borderRadius: theme.spacing(1),
+const IconChip = styled(Box)(({ theme }) => ({
+  width: 44,
+  height: 44,
+  borderRadius: theme.spacing(1.5),
+  backgroundColor: landingTokens.blueTint,
+  color: theme.palette.primary.main,
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
-  fontSize: '1.5rem',
-  fontWeight: 600,
-  color: 'white',
+  flexShrink: 0,
 }))
 
-const FeatureContent = styled(Box)(() => ({
+const CardHeaderText = styled(Box)(() => ({
   flex: 1,
+  minWidth: 0,
 }))
 
-const FeatureTitle = styled(Typography)(({ theme }) => ({
+const EventTitle = styled(Typography)(() => ({
   fontWeight: 600,
-  color: theme.palette.text.primary,
-  marginBottom: theme.spacing(0.5),
+  color: landingTokens.ink,
+  fontSize: '1.05rem',
+  lineHeight: 1.3,
 }))
 
-const FeatureDescription = styled(Typography)(({ theme }) => ({
-  fontSize: '0.9rem',
-  color: theme.palette.text.secondary,
-  lineHeight: 1.4,
+const EventMeta = styled(Typography)(() => ({
+  color: landingTokens.inkMuted,
+  fontSize: '0.85rem',
 }))
 
-const NavBar = styled(Box)(({ theme }) => ({
-  position: 'absolute',
-  top: 0,
-  left: 0,
-  right: 0,
-  zIndex: 10,
+const AvatarRow = styled(Box)(() => ({
+  display: 'flex',
+  '& > *:not(:first-of-type)': {
+    marginLeft: -8,
+  },
+}))
+
+const InitialAvatar = styled(Box, {
+  shouldForwardProp: prop => prop !== 'bg' && prop !== 'fg',
+})<{ bg: string; fg: string }>(({ bg, fg }) => ({
+  width: 30,
+  height: 30,
+  borderRadius: '50%',
+  backgroundColor: bg,
+  color: fg,
+  border: `2px solid ${landingTokens.surface}`,
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  fontSize: '0.7rem',
+  fontWeight: 600,
+}))
+
+const ItemRow = styled(Box)(({ theme }) => ({
+  display: 'flex',
+  alignItems: 'center',
+  gap: theme.spacing(1.75),
   padding: theme.spacing(2, 0),
-  backdropFilter: 'blur(10px)',
-  borderBottom: '1px solid rgba(255, 255, 255, 0.1)',
-  transition: 'padding 0.3s ease',
+  '&:not(:last-of-type)': {
+    borderBottom: `1px solid ${landingTokens.hairline}`,
+  },
 }))
 
-const NavContent = styled(Container)(() => ({
+const ItemIcon = styled(Box)(({ theme }) => ({
+  width: 34,
+  height: 34,
+  borderRadius: theme.spacing(1),
+  backgroundColor: landingTokens.paper,
+  color: landingTokens.inkMuted,
   display: 'flex',
-  justifyContent: 'space-between',
   alignItems: 'center',
+  justifyContent: 'center',
+  flexShrink: 0,
 }))
 
-const NavRightGroup = styled(Box)(({ theme }) => ({
+const ItemName = styled(Typography)(() => ({
+  flex: 1,
+  fontWeight: 500,
+  fontSize: '0.95rem',
+  color: landingTokens.ink,
+}))
+
+const StatusChip = styled(Box, {
+  shouldForwardProp: prop => prop !== 'reserved',
+})<{ reserved?: boolean }>(({ reserved }) => ({
+  padding: '3px 12px',
+  borderRadius: 999,
+  fontSize: '0.75rem',
+  fontWeight: 600,
+  whiteSpace: 'nowrap',
+  ...(reserved
+    ? { backgroundColor: '#e7f2eb', color: '#2f7a52' }
+    : { border: `1px solid ${landingTokens.hairline}`, color: landingTokens.inkMuted }),
+}))
+
+const FloatingBadge = styled(Box)(({ theme }) => ({
+  position: 'absolute',
+  top: theme.spacing(-2.5),
+  right: theme.spacing(-1.5),
   display: 'flex',
   alignItems: 'center',
-  gap: theme.spacing(4),
-}))
-
-const NavLinks = styled(Box)(({ theme }) => ({
-  display: 'flex',
-  gap: theme.spacing(4),
-  [theme.breakpoints.down('md')]: {
-    display: 'none',
+  gap: theme.spacing(1),
+  backgroundColor: landingTokens.surface,
+  border: `1px solid ${landingTokens.hairline}`,
+  borderRadius: 999,
+  padding: theme.spacing(1, 2),
+  boxShadow: '0 12px 24px -12px rgba(28, 43, 54, 0.25)',
+  transform: 'rotate(2deg)',
+  zIndex: 1,
+  [theme.breakpoints.down('sm')]: {
+    right: theme.spacing(0.5),
   },
 }))
 
-const NavLink = styled(Typography)(() => ({
-  color: 'rgba(255, 255, 255, 0.9)',
-  textDecoration: 'none',
-  fontWeight: 500,
-  transition: 'color 0.3s ease',
-  cursor: 'pointer',
-  '&:hover': {
-    color: 'white',
-  },
+const FloatingBadgeText = styled(Typography)(() => ({
+  fontSize: '0.8rem',
+  fontWeight: 600,
+  color: landingTokens.ink,
 }))
 
-const handleSmoothScroll = (elementId: string) => {
-  const element = document.getElementById(elementId)
-  if (element) {
-    element.scrollIntoView({
-      behavior: 'smooth',
-      block: 'start',
-    })
-  }
-}
-
-const LoginButton = styled(Button)<ButtonProps & LinkProps>(() => ({
-  color: 'white',
-  borderColor: 'rgba(255, 255, 255, 0.3)',
-  fontWeight: 500,
-  transition: 'all 0.3s ease',
-  '&:hover': {
-    borderColor: 'white',
-    backgroundColor: 'rgba(255, 255, 255, 0.1)',
-  },
-}))
-
-const features = [
-  {
-    icon: '📅',
-    title: 'Événements organisés',
-    description: 'Créez des événements pour toutes vos célébrations et invitez vos proches facilement.',
-    bgColor: '#f59e0b',
-  },
-  {
-    icon: '👨‍👩‍👧‍👦',
-    title: 'Partage en famille',
-    description: 'Partagez vos listes de souhaits avec famille et amis pour des surprises réussies.',
-    bgColor: '#10b981',
-  },
-  {
-    icon: '✨',
-    title: 'Expérience magique',
-    description: 'Interface intuitive et design élégant pour une expérience utilisateur exceptionnelle.',
-    bgColor: '#8b5cf6',
-  },
+const mockItems = [
+  { name: 'Machine à expresso', reserved: true },
+  { name: 'Plaid en laine mérinos', reserved: true },
+  { name: 'Coffret de thés verts', reserved: false },
 ]
 
-const navItems = [
-  { label: 'Fonctionnalités', targetId: 'features' },
-  { label: 'FAQ', targetId: 'faq' },
+const mockAvatars = [
+  { initials: 'CL', bg: '#edf2f6', fg: '#255376' },
+  { initials: 'MA', bg: '#f3eee4', fg: '#a87b2d' },
+  { initials: 'JD', bg: '#e7f2eb', fg: '#2f7a52' },
 ]
 
 export const HeroSection = () => {
-  // Generate star positions
-  const smallStars = Array.from({ length: 70 }, (_, i) => ({
-    id: i,
-    top: Math.random() * 100,
-    left: Math.random() * 100,
-    delay: Math.random() * 1.5,
-  }))
-
-  const bigStars = Array.from({ length: 25 }, (_, i) => ({
-    id: i,
-    top: Math.random() * 100,
-    left: Math.random() * 100,
-    delay: Math.random() * 1,
-  }))
-
   return (
     <HeroContainer>
-      <StarsContainer id="stars">
-        {/* Small twinkling stars */}
-        {smallStars.map(star => (
-          <StarPoint
-            key={`small-${star.id}`}
-            sx={{
-              top: `${star.top}%`,
-              left: `${star.left}%`,
-              animationDelay: `${star.delay}s`,
-            }}
-          />
-        ))}
-
-        {/* Bigger shimmering stars */}
-        {bigStars.map(star => (
-          <BiggerStar
-            key={`big-${star.id}`}
-            sx={{
-              top: `${star.top}%`,
-              left: `${star.left}%`,
-              animationDelay: `${star.delay}s`,
-            }}
-          />
-        ))}
-      </StarsContainer>
-
-      <NavBar>
-        <NavContent maxWidth="lg">
-          <Logo variant="full" color="white" />
-          <NavRightGroup>
-            <NavLinks>
-              {navItems.map(item => (
-                <NavLink key={item.label} onClick={() => handleSmoothScroll(item.targetId)}>
-                  {item.label}
-                </NavLink>
-              ))}
-            </NavLinks>
-            <LoginButton variant="outlined" component={Link} to="/login">
-              Connexion
-            </LoginButton>
-          </NavRightGroup>
-        </NavContent>
-      </NavBar>
-
       <ContentWrapper maxWidth="lg">
         <MainContent>
-          <GradientTitle variant="h1">
-            Organisez vos
-            <br />
-            <span
-              style={{
-                background: 'linear-gradient(135deg, #60a5fa 0%, #93c5fd 50%, #dbeafe 100%)',
-                backgroundClip: 'text',
-                WebkitBackgroundClip: 'text',
-                WebkitTextFillColor: 'transparent',
-                textShadow: '0 0 30px rgba(147, 197, 253, 0.8)',
-              }}
-            >
-              moments magiques
-            </span>
-          </GradientTitle>
+          <Kicker>
+            <KickerRule />
+            <KickerText>Listes de souhaits partagées</KickerText>
+          </Kicker>
+
+          <HeroTitle variant="h1">
+            Le bon cadeau,
+            <br />à <em>chaque</em> occasion.
+          </HeroTitle>
 
           <Subtitle>
-            Partagez vos souhaits avec vos proches et découvrez leurs envies. Parfait pour les anniversaires, Noël,
-            mariages et plus encore.
+            Créez vos listes de souhaits, partagez-les avec vos proches et réservez les cadeaux en toute discrétion.
+            Anniversaires, Noël, mariages — tout au même endroit.
           </Subtitle>
 
           <ButtonGroup>
             <PrimaryButton variant="contained" size="large" component={Link} to="/register">
-              Créer ma première liste
+              Créer ma liste gratuitement
             </PrimaryButton>
             <SecondaryButton variant="outlined" size="large" component={Link} to="/login">
-              Découvrir
+              Se connecter
             </SecondaryButton>
           </ButtonGroup>
+
+          <TrustLine>Gratuit · Réservations discrètes · Secret Santa intégré</TrustLine>
         </MainContent>
 
-        <FeaturesSidebar>
-          {features.map((feature, index) => (
-            <FeatureItem key={index}>
-              <FeatureIcon style={{ backgroundColor: feature.bgColor }}>{feature.icon}</FeatureIcon>
-              <FeatureContent>
-                <FeatureTitle>{feature.title}</FeatureTitle>
-                <FeatureDescription>{feature.description}</FeatureDescription>
-              </FeatureContent>
-            </FeatureItem>
-          ))}
-        </FeaturesSidebar>
+        <MockArea aria-hidden="true">
+          <BackCard />
+          <FloatingBadge>
+            <ShuffleRounded sx={{ fontSize: 18, color: 'primary.main' }} />
+            <FloatingBadgeText>Secret Santa · tirage effectué</FloatingBadgeText>
+          </FloatingBadge>
+          <MainCard>
+            <CardHeader>
+              <IconChip>
+                <CalendarMonthRounded fontSize="small" />
+              </IconChip>
+              <CardHeaderText>
+                <EventTitle>Noël en famille</EventTitle>
+                <EventMeta>25 décembre · 8 participants</EventMeta>
+              </CardHeaderText>
+              <AvatarRow>
+                {mockAvatars.map(avatar => (
+                  <InitialAvatar key={avatar.initials} bg={avatar.bg} fg={avatar.fg}>
+                    {avatar.initials}
+                  </InitialAvatar>
+                ))}
+              </AvatarRow>
+            </CardHeader>
+
+            <Box>
+              {mockItems.map(item => (
+                <ItemRow key={item.name}>
+                  <ItemIcon>
+                    <RedeemRounded sx={{ fontSize: 18 }} />
+                  </ItemIcon>
+                  <ItemName>{item.name}</ItemName>
+                  <StatusChip reserved={item.reserved}>{item.reserved ? 'Réservé' : 'Disponible'}</StatusChip>
+                </ItemRow>
+              ))}
+            </Box>
+          </MainCard>
+        </MockArea>
       </ContentWrapper>
     </HeroContainer>
   )

--- a/apps/front/src/components/landing/HowItWorksSection.tsx
+++ b/apps/front/src/components/landing/HowItWorksSection.tsx
@@ -1,0 +1,118 @@
+import { Box, Container, Typography } from '@mui/material'
+import { styled } from '@mui/material/styles'
+
+import { landingTokens } from './landing.tokens'
+
+const SectionContainer = styled(Box)(({ theme }) => ({
+  padding: theme.spacing(14, 0),
+  backgroundColor: landingTokens.paper,
+  [theme.breakpoints.down('md')]: {
+    padding: theme.spacing(10, 0),
+  },
+}))
+
+const SectionHeader = styled(Box)(({ theme }) => ({
+  textAlign: 'center',
+  maxWidth: 560,
+  margin: `0 auto ${theme.spacing(8)}`,
+  [theme.breakpoints.down('md')]: {
+    marginBottom: theme.spacing(6),
+  },
+}))
+
+const Kicker = styled(Typography)(({ theme }) => ({
+  color: landingTokens.accent,
+  fontSize: '0.8rem',
+  fontWeight: 600,
+  letterSpacing: '0.18em',
+  textTransform: 'uppercase',
+  marginBottom: theme.spacing(2),
+}))
+
+const SectionTitle = styled(Typography)(() => ({
+  fontFamily: landingTokens.displayFont,
+  fontWeight: 500,
+  fontSize: 'clamp(1.9rem, 3.5vw, 2.6rem)',
+  lineHeight: 1.2,
+  letterSpacing: '-0.01em',
+  color: landingTokens.ink,
+}))
+
+const StepsGrid = styled(Box)(({ theme }) => ({
+  display: 'grid',
+  gridTemplateColumns: 'repeat(3, 1fr)',
+  gap: theme.spacing(6),
+  [theme.breakpoints.down('md')]: {
+    gridTemplateColumns: '1fr',
+    gap: theme.spacing(5),
+    maxWidth: 480,
+    margin: '0 auto',
+  },
+}))
+
+const Step = styled(Box)(({ theme }) => ({
+  borderTop: `1px solid ${landingTokens.hairline}`,
+  paddingTop: theme.spacing(3),
+}))
+
+const StepNumber = styled(Typography)(({ theme }) => ({
+  fontFamily: landingTokens.displayFont,
+  fontStyle: 'italic',
+  fontSize: '1.5rem',
+  color: landingTokens.accent,
+  marginBottom: theme.spacing(1.5),
+}))
+
+const StepTitle = styled(Typography)(({ theme }) => ({
+  fontWeight: 600,
+  fontSize: '1.15rem',
+  color: landingTokens.ink,
+  marginBottom: theme.spacing(1),
+}))
+
+const StepDescription = styled(Typography)(() => ({
+  color: landingTokens.inkMuted,
+  lineHeight: 1.7,
+  fontSize: '0.95rem',
+}))
+
+const steps = [
+  {
+    number: '01',
+    title: 'Créez votre événement',
+    description: 'Choisissez l’occasion et la date, puis invitez vos proches par email ou en partageant un lien.',
+  },
+  {
+    number: '02',
+    title: 'Partagez vos listes',
+    description: 'Chacun renseigne ses envies : un lien, une photo, une priorité. Tout le monde sait quoi offrir.',
+  },
+  {
+    number: '03',
+    title: 'Réservez en toute discrétion',
+    description: 'Les invités réservent les cadeaux entre eux pour éviter les doublons. La surprise reste entière.',
+  },
+]
+
+export const HowItWorksSection = () => {
+  return (
+    <SectionContainer id="how-it-works">
+      <Container maxWidth="lg">
+        <SectionHeader>
+          <Kicker>Comment ça marche</Kicker>
+          <SectionTitle>Trois étapes, zéro doublon.</SectionTitle>
+        </SectionHeader>
+
+        <StepsGrid>
+          {steps.map(step => (
+            <Step key={step.number}>
+              <StepNumber>{step.number}</StepNumber>
+              <StepTitle>{step.title}</StepTitle>
+              <StepDescription>{step.description}</StepDescription>
+            </Step>
+          ))}
+        </StepsGrid>
+      </Container>
+    </SectionContainer>
+  )
+}

--- a/apps/front/src/components/landing/LandingNav.tsx
+++ b/apps/front/src/components/landing/LandingNav.tsx
@@ -1,0 +1,104 @@
+import type { ButtonProps } from '@mui/material'
+import type { LinkProps } from '@tanstack/react-router'
+
+import { Box, Button, Container, Typography } from '@mui/material'
+import { styled } from '@mui/material/styles'
+import { Link } from '@tanstack/react-router'
+
+import { Logo } from '../common/Logo'
+import { landingTokens } from './landing.tokens'
+
+const NavBar = styled('nav')(() => ({
+  position: 'sticky',
+  top: 0,
+  zIndex: 20,
+  backgroundColor: 'rgba(250, 248, 244, 0.85)',
+  backdropFilter: 'blur(12px)',
+  WebkitBackdropFilter: 'blur(12px)',
+  borderBottom: `1px solid ${landingTokens.hairline}`,
+}))
+
+const NavContent = styled(Container)(({ theme }) => ({
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+  paddingTop: theme.spacing(1.75),
+  paddingBottom: theme.spacing(1.75),
+}))
+
+const NavLinks = styled(Box)(({ theme }) => ({
+  display: 'flex',
+  gap: theme.spacing(4),
+  [theme.breakpoints.down('md')]: {
+    display: 'none',
+  },
+}))
+
+const NavLink = styled(Typography)(() => ({
+  color: landingTokens.inkMuted,
+  fontWeight: 500,
+  fontSize: '0.95rem',
+  cursor: 'pointer',
+  transition: 'color 0.2s ease',
+  '&:hover': {
+    color: landingTokens.ink,
+  },
+}))
+
+const NavActions = styled(Box)(({ theme }) => ({
+  display: 'flex',
+  alignItems: 'center',
+  gap: theme.spacing(1.5),
+}))
+
+const LoginButton = styled(Button)<ButtonProps & LinkProps>(({ theme }) => ({
+  color: landingTokens.ink,
+  fontWeight: 500,
+  [theme.breakpoints.down('sm')]: {
+    display: 'none',
+  },
+}))
+
+const RegisterButton = styled(Button)<ButtonProps & LinkProps>(({ theme }) => ({
+  fontWeight: 600,
+  paddingLeft: theme.spacing(2.5),
+  paddingRight: theme.spacing(2.5),
+}))
+
+const navItems = [
+  { label: 'Fonctionnalités', targetId: 'features' },
+  { label: 'Comment ça marche', targetId: 'how-it-works' },
+  { label: 'FAQ', targetId: 'faq' },
+]
+
+const handleSmoothScroll = (elementId: string) => {
+  const element = document.getElementById(elementId)
+  if (element) {
+    element.scrollIntoView({ behavior: 'smooth', block: 'start' })
+  }
+}
+
+export const LandingNav = () => {
+  return (
+    <NavBar>
+      <NavContent maxWidth="lg">
+        <Logo variant="full" height={36} />
+        <NavLinks>
+          {navItems.map(item => (
+            <NavLink key={item.targetId} onClick={() => handleSmoothScroll(item.targetId)}>
+              {item.label}
+            </NavLink>
+          ))}
+        </NavLinks>
+        <NavActions>
+          <LoginButton variant="text" component={Link} to="/login">
+            Se connecter
+          </LoginButton>
+          <RegisterButton variant="contained" disableElevation component={Link} to="/register">
+            Commencer
+          </RegisterButton>
+        </NavActions>
+      </NavContent>
+    </NavBar>
+  )
+}

--- a/apps/front/src/components/landing/LandingPage.tsx
+++ b/apps/front/src/components/landing/LandingPage.tsx
@@ -5,14 +5,18 @@ import { FeaturesGridSection } from './FeaturesGrid'
 import { FooterSection } from './FooterSection'
 import { GetStartedSection } from './GetStartedSection'
 import { HeroSection } from './HeroSection'
+import { HowItWorksSection } from './HowItWorksSection'
+import { LandingNav } from './LandingNav'
 
 export const LandingPage = () => {
   return (
     <Box>
+      <LandingNav />
       <HeroSection />
       <FeaturesGridSection />
-      <GetStartedSection />
+      <HowItWorksSection />
       <FAQSection />
+      <GetStartedSection />
       <FooterSection />
     </Box>
   )

--- a/apps/front/src/components/landing/landing.tokens.ts
+++ b/apps/front/src/components/landing/landing.tokens.ts
@@ -1,0 +1,16 @@
+/**
+ * Design tokens specific to the public landing page.
+ * The landing uses an editorial look (serif display font, warm paper background)
+ * that intentionally differs from the in-app MUI theme.
+ */
+export const landingTokens = {
+  displayFont: '"Fraunces", Georgia, "Times New Roman", serif',
+  paper: '#faf8f4',
+  surface: '#ffffff',
+  ink: '#1c2b36',
+  inkMuted: '#5c6b76',
+  hairline: '#e8e3da',
+  accent: '#a87b2d',
+  blueTint: '#edf2f6',
+  deepBlue: '#1b3d58',
+} as const


### PR DESCRIPTION
## Summary

Refonte complète de la landing page (mode déconnecté) vers un style **éditorial, sobre et professionnel** :

- **Hero** : fond papier clair, titres en serif Fraunces avec accent italique, et un mock produit (carte d'événement avec réservations `Réservé/Disponible` et badge Secret Santa) à la place des étoiles scintillantes et de la sidebar emoji
- **Nav** : nouvelle barre sticky translucide avec blur (`LandingNav`)
- **Fonctionnalités** : 10 features → 6, icônes MUI sur pastille unique au lieu d'emojis sur dégradés arc-en-ciel, suppression des 5 badges colorés et du bouton « voir plus »
- **Comment ça marche** : nouvelle section 3 étapes numérotées (`HowItWorksSection`)
- **FAQ** : le carrousel infini auto-scroll (~300 lignes d'animation JS) est remplacé par un accordéon deux colonnes
- **CTA + footer** : un seul bloc bleu profond continu — le dégradé du CTA se termine sur la couleur unie du footer, réduit à une ligne (copyright + liens légaux)
- **Tokens** : palette et serif de la landing centralisés dans `landing.tokens.ts`
- **Fonts** : chargement de Fraunces et Inter dans `index.html` (Inter était déclarée dans le thème mais jamais chargée)

Premier commit d'une série : d'autres pages seront reprises dans des commits suivants sur cette branche.

## Test plan

- [x] `nx run front:typecheck` ✅
- [x] `biome check` ✅
- [x] Vérification visuelle desktop (1280px) et mobile (375px) de toutes les sections via preview
- [ ] Revue visuelle sur l'environnement de déploiement

🤖 Generated with [Claude Code](https://claude.com/claude-code)