### PR TITLE
feat(front): replace list spinners with MUI card skeletons

### DIFF
--- a/apps/front/src/components/event/EventCardSkeleton.tsx
+++ b/apps/front/src/components/event/EventCardSkeleton.tsx
@@ -1,0 +1,53 @@
+import { Skeleton, styled } from '@mui/material'
+
+import { Card } from '../common/Card'
+
+const EventCardContent = styled(Card)(({ theme }) => ({
+  display: 'flex',
+  flexDirection: 'column',
+  minHeight: '100px',
+  border: `1px solid ${theme.palette.divider}`,
+  padding: 16,
+}))
+
+const EventHeader = styled('div')({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '16px',
+  marginBottom: '12px',
+})
+
+const EventTextContent = styled('div')({
+  display: 'flex',
+  flexDirection: 'column',
+  flex: 1,
+  minWidth: 0,
+})
+
+const EventInfos = styled('div')(({ theme }) => ({
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+  marginTop: 'auto',
+  paddingTop: '12px',
+  borderTop: `1px solid ${theme.palette.divider}`,
+}))
+
+export const EventCardSkeleton = () => {
+  return (
+    <EventCardContent>
+      <EventHeader>
+        <Skeleton animation="wave" variant="circular" width={29} height={29} />
+        <EventTextContent>
+          <Skeleton animation="wave" variant="text" width="60%" sx={{ fontSize: '1rem' }} />
+          <Skeleton animation="wave" variant="text" width="30%" sx={{ fontSize: '0.8rem' }} />
+        </EventTextContent>
+      </EventHeader>
+
+      <EventInfos>
+        <Skeleton animation="wave" variant="text" width={90} sx={{ fontSize: '0.8rem' }} />
+        <Skeleton animation="wave" variant="text" width={60} sx={{ fontSize: '0.8rem' }} />
+      </EventInfos>
+    </EventCardContent>
+  )
+}

--- a/apps/front/src/components/event/EventHeaderSkeleton.tsx
+++ b/apps/front/src/components/event/EventHeaderSkeleton.tsx
@@ -1,0 +1,63 @@
+import { Box, Container, Skeleton, Stack, styled } from '@mui/material'
+
+const HeaderContent = styled(Box)(({ theme }) => ({
+  display: 'flex',
+  paddingBottom: theme.spacing(2),
+  borderBottom: `1px solid ${theme.palette.divider}`,
+  flexDirection: 'row',
+  alignItems: 'center',
+  gap: theme.spacing(3),
+
+  [theme.breakpoints.down('sm')]: {
+    flexDirection: 'column',
+    gap: theme.spacing(2),
+  },
+}))
+
+const LeftSection = styled(Stack)(({ theme }) => ({
+  flexDirection: 'row',
+  gap: theme.spacing(3),
+  alignItems: 'center',
+  flex: 1,
+  width: '100%',
+}))
+
+const TitleContainer = styled(Stack)(({ theme }) => ({
+  gap: theme.spacing(1),
+  flex: 1,
+  minWidth: 0,
+}))
+
+const MetadataStack = styled(Stack)(({ theme }) => ({
+  flexDirection: 'row',
+  gap: theme.spacing(3),
+  flexWrap: 'wrap',
+  alignItems: 'center',
+
+  [theme.breakpoints.down('lg')]: {
+    flexDirection: 'column',
+    gap: theme.spacing(1),
+    alignItems: 'flex-start',
+  },
+}))
+
+export const EventHeaderSkeleton = () => {
+  return (
+    <Container maxWidth="lg">
+      <HeaderContent>
+        <LeftSection>
+          <Skeleton animation="wave" variant="circular" width={48} height={48} />
+
+          <TitleContainer>
+            <Skeleton animation="wave" variant="text" width="40%" sx={{ fontSize: '1.5rem' }} />
+
+            <MetadataStack>
+              <Skeleton animation="wave" variant="text" width={180} sx={{ fontSize: '0.875rem' }} />
+              <Skeleton animation="wave" variant="text" width={120} sx={{ fontSize: '0.875rem' }} />
+            </MetadataStack>
+          </TitleContainer>
+        </LeftSection>
+      </HeaderContent>
+    </Container>
+  )
+}

--- a/apps/front/src/components/event/EventListPage.tsx
+++ b/apps/front/src/components/event/EventListPage.tsx
@@ -4,11 +4,13 @@ import { useNavigate, useSearch } from '@tanstack/react-router'
 
 import { isRejection, rejectionMessage, useEventListPageGetEventsQuery } from '../../gql'
 import { FabAutoGrow } from '../common/FabAutoGrow'
-import { Loader } from '../common/Loader'
 import { Pagination } from '../common/Pagination'
 import { Title } from '../common/Title'
 import { EmptyEventsState } from './EmptyEventsState'
 import { EventCard } from './EventCard'
+import { EventCardSkeleton } from './EventCardSkeleton'
+
+const SKELETON_KEYS = ['s1', 's2', 's3', 's4'] as const
 
 export const EventListPage = () => {
   const { page: currentPage } = useSearch({ from: '/_authenticated/_with-layout/events/' })
@@ -28,10 +30,21 @@ export const EventListPage = () => {
 
   return (
     <Box>
-      {totalElements > 0 && <Title>Évènements</Title>}
+      {(loading || totalElements > 0) && <Title>Évènements</Title>}
 
-      <Loader loading={loading}>
-        {queryRejection && <Alert severity="error">{rejectionMessage(queryRejection)}</Alert>}
+      {queryRejection && <Alert severity="error">{rejectionMessage(queryRejection)}</Alert>}
+
+      {loading && (
+        <Grid container spacing={3} aria-busy>
+          {SKELETON_KEYS.map(key => (
+            <Grid key={key} size={{ xs: 12, lg: 6 }}>
+              <EventCardSkeleton />
+            </Grid>
+          ))}
+        </Grid>
+      )}
+
+      {!loading && (
         <Grid container spacing={3}>
           {events.map(event => (
             <Grid key={event.id} size={{ xs: 12, lg: 6 }}>
@@ -39,7 +52,7 @@ export const EventListPage = () => {
             </Grid>
           ))}
         </Grid>
-      </Loader>
+      )}
 
       {totalElements > 0 && (
         <>

--- a/apps/front/src/components/event/EventPage.tsx
+++ b/apps/front/src/components/event/EventPage.tsx
@@ -8,10 +8,10 @@ import { useSelector } from 'react-redux'
 import { AttendeeRole, isRejection, rejectionMessage, useEventPageGetEventQuery } from '../../gql'
 import { useSecretSantaSuggestion } from '../../hooks'
 import { Description } from '../common/Description'
-import { Loader } from '../common/Loader'
 import { SEO } from '../SEO'
 import { EventAttendeesDialog } from './EventAttendeesDialog'
 import { EventHeader } from './EventHeader'
+import { EventHeaderSkeleton } from './EventHeaderSkeleton'
 import { EventNotFound } from './EventNotFound'
 import { EventWishlists } from './EventWishlists'
 import { MySecretSantaDraw } from './MySecretSantaDraw'
@@ -50,45 +50,52 @@ export const EventPage = ({ eventId }: EventPageProps) => {
         canonical={`/events/${eventId}`}
       />
       <Box>
-        <Loader loading={loading}>
-          {queryRejection && <Alert severity="error">{rejectionMessage(queryRejection)}</Alert>}
-          {!event && !queryRejection && <EventNotFound />}
-          {event && (
-            <>
-              <EventHeader
-                icon={event.icon ?? undefined}
-                title={event.title}
-                eventId={event.id}
-                eventDate={event.eventDate}
-                attendees={attendees}
-                currentUserCanEdit={currentUserCanEdit}
-                openAttendeesDialog={() => setOpenAttendeesDialog(true)}
-              />
+        {loading && (
+          <>
+            <EventHeaderSkeleton />
+            <Container maxWidth="lg">
+              <Stack gap="20px" sx={{ paddingTop: 3 }}>
+                <EventWishlists loading />
+              </Stack>
+            </Container>
+          </>
+        )}
 
-              <Container maxWidth="lg">
-                <Stack gap="20px" sx={{ paddingTop: 3 }}>
-                  {shouldShowSuggestion && (
-                    <SecretSantaSuggestionCard eventId={event.id} onDismiss={dismissSuggestion} />
-                  )}
+        {!loading && queryRejection && <Alert severity="error">{rejectionMessage(queryRejection)}</Alert>}
+        {!loading && !event && !queryRejection && <EventNotFound />}
+        {!loading && event && (
+          <>
+            <EventHeader
+              icon={event.icon ?? undefined}
+              title={event.title}
+              eventId={event.id}
+              eventDate={event.eventDate}
+              attendees={attendees}
+              currentUserCanEdit={currentUserCanEdit}
+              openAttendeesDialog={() => setOpenAttendeesDialog(true)}
+            />
 
-                  <MySecretSantaDraw eventId={event.id} />
+            <Container maxWidth="lg">
+              <Stack gap="20px" sx={{ paddingTop: 3 }}>
+                {shouldShowSuggestion && <SecretSantaSuggestionCard eventId={event.id} onDismiss={dismissSuggestion} />}
 
-                  {event.description && <Description text={event.description} allowMarkdown />}
+                <MySecretSantaDraw eventId={event.id} />
 
-                  <EventWishlists eventId={event.id} wishlists={event.wishlists} />
-                </Stack>
-              </Container>
+                {event.description && <Description text={event.description} allowMarkdown />}
 
-              <EventAttendeesDialog
-                open={openAttendeesDialog}
-                handleClose={() => setOpenAttendeesDialog(false)}
-                currentUserCanEdit={currentUserCanEdit}
-                eventId={event.id}
-                attendees={attendees}
-              />
-            </>
-          )}
-        </Loader>
+                <EventWishlists eventId={event.id} wishlists={event.wishlists} />
+              </Stack>
+            </Container>
+
+            <EventAttendeesDialog
+              open={openAttendeesDialog}
+              handleClose={() => setOpenAttendeesDialog(false)}
+              currentUserCanEdit={currentUserCanEdit}
+              eventId={event.id}
+              attendees={attendees}
+            />
+          </>
+        )}
       </Box>
     </>
   )

--- a/apps/front/src/components/event/EventWishlists.tsx
+++ b/apps/front/src/components/event/EventWishlists.tsx
@@ -8,15 +8,30 @@ import { useNavigate } from '@tanstack/react-router'
 import { FabAutoGrow } from '../common/FabAutoGrow'
 import { EmptyListsState } from '../wishlist/EmptyListsState'
 import { WishlistCardWithOwner } from '../wishlist/WishlistCardWithOwner'
+import { WishlistCardWithOwnerSkeleton } from '../wishlist/WishlistCardWithOwnerSkeleton'
 
-export type EventWishlistsProps = {
-  eventId: EventId
-  wishlists: EventWishlist[]
-}
+const SKELETON_KEYS = ['s1', 's2', 's3', 's4', 's5', 's6'] as const
 
-export const EventWishlists = ({ eventId, wishlists }: EventWishlistsProps) => {
+export type EventWishlistsProps = { loading: true } | { loading?: false; eventId: EventId; wishlists: EventWishlist[] }
+
+export const EventWishlists = (props: EventWishlistsProps) => {
   const navigate = useNavigate()
 
+  if (props.loading) {
+    return (
+      <Box className="wishlists">
+        <Grid container spacing={3} aria-busy>
+          {SKELETON_KEYS.map(key => (
+            <Grid key={key} size={{ xs: 12, md: 6, xl: 4 }}>
+              <WishlistCardWithOwnerSkeleton />
+            </Grid>
+          ))}
+        </Grid>
+      </Box>
+    )
+  }
+
+  const { eventId, wishlists } = props
   const handleAddList = () => navigate({ to: '/wishlists/new', search: { fromEvent: eventId } })
 
   return (

--- a/apps/front/src/components/item/ItemCardSkeleton.tsx
+++ b/apps/front/src/components/item/ItemCardSkeleton.tsx
@@ -1,0 +1,58 @@
+import { Box, Skeleton, styled } from '@mui/material'
+
+import { Card } from '../common/Card'
+
+const ItemCardStyled = styled(Card)(({ theme }) => ({
+  position: 'relative',
+  display: 'flex',
+  flexDirection: 'column',
+  height: '100%',
+  overflow: 'hidden',
+  border: `1px solid ${theme.palette.divider}`,
+  padding: 0,
+}))
+
+const ItemImageContainer = styled(Box)({
+  height: '240px',
+  width: '100%',
+  overflow: 'hidden',
+})
+
+const ItemContent = styled(Box)({
+  display: 'flex',
+  flexDirection: 'column',
+  flexGrow: 1,
+  padding: '16px',
+  gap: '4px',
+  alignItems: 'center',
+})
+
+const ItemFooter = styled(Box)(({ theme }) => ({
+  display: 'flex',
+  flexDirection: 'row',
+  alignItems: 'center',
+  justifyContent: 'center',
+  padding: '8px 16px',
+  borderTop: `1px solid ${theme.palette.divider}`,
+  marginTop: 'auto',
+}))
+
+export const ItemCardSkeleton = () => {
+  return (
+    <ItemCardStyled>
+      <ItemImageContainer>
+        <Skeleton animation="wave" variant="rectangular" width="100%" height="100%" />
+      </ItemImageContainer>
+
+      <ItemContent>
+        <Skeleton animation="wave" variant="text" width="70%" sx={{ fontSize: '1.1rem' }} />
+        <Skeleton animation="wave" variant="text" width="90%" sx={{ fontSize: '0.9rem' }} />
+        <Skeleton animation="wave" variant="text" width="50%" sx={{ fontSize: '0.9rem' }} />
+      </ItemContent>
+
+      <ItemFooter>
+        <Skeleton animation="wave" variant="text" width={120} sx={{ fontSize: '0.75rem' }} />
+      </ItemFooter>
+    </ItemCardStyled>
+  )
+}

--- a/apps/front/src/components/wishlist/WishlistCardWithEventsSkeleton.tsx
+++ b/apps/front/src/components/wishlist/WishlistCardWithEventsSkeleton.tsx
@@ -1,0 +1,65 @@
+import { Skeleton, styled } from '@mui/material'
+
+import { Card } from '../common/Card'
+
+const WishlistCardContent = styled(Card)(({ theme }) => ({
+  display: 'flex',
+  flexDirection: 'column',
+  minHeight: '100px',
+  height: '100%',
+  border: `1px solid ${theme.palette.divider}`,
+  padding: 16,
+}))
+
+const WishlistHeader = styled('div')({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  gap: '12px',
+  marginBottom: '16px',
+})
+
+const WishlistTitleContainer = styled('div')({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  flex: 1,
+  minWidth: 0,
+})
+
+const WishlistEvents = styled('div')(({ theme }) => ({
+  marginTop: 'auto',
+  paddingTop: '12px',
+  borderTop: `1px solid ${theme.palette.divider}`,
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  justifyContent: 'center',
+  gap: '6px',
+}))
+
+const EventItem = styled('div')({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '6px',
+})
+
+export const WishlistCardWithEventsSkeleton = () => {
+  return (
+    <WishlistCardContent>
+      <WishlistHeader>
+        <Skeleton animation="wave" variant="circular" width={32} height={32} />
+        <WishlistTitleContainer>
+          <Skeleton animation="wave" variant="text" width="55%" sx={{ fontSize: '1rem' }} />
+        </WishlistTitleContainer>
+      </WishlistHeader>
+
+      <WishlistEvents>
+        <EventItem>
+          <Skeleton animation="wave" variant="circular" width={19} height={19} />
+          <Skeleton animation="wave" variant="text" width={160} sx={{ fontSize: '0.8rem' }} />
+        </EventItem>
+      </WishlistEvents>
+    </WishlistCardContent>
+  )
+}

--- a/apps/front/src/components/wishlist/WishlistCardWithOwnerSkeleton.tsx
+++ b/apps/front/src/components/wishlist/WishlistCardWithOwnerSkeleton.tsx
@@ -1,0 +1,35 @@
+import { Skeleton, styled } from '@mui/material'
+
+import { Card } from '../common/Card'
+
+const WishlistCardContent = styled(Card)(({ theme }) => ({
+  display: 'flex',
+  flexDirection: 'row',
+  alignItems: 'center',
+  height: '5.5rem',
+  padding: 12,
+  gap: '16px',
+  border: `1px solid ${theme.palette.divider}`,
+  overflow: 'hidden',
+}))
+
+const ContentContainer = styled('div')({
+  flex: 1,
+  display: 'flex',
+  flexDirection: 'column',
+  justifyContent: 'center',
+  minWidth: 0,
+  gap: '4px',
+})
+
+export const WishlistCardWithOwnerSkeleton = () => {
+  return (
+    <WishlistCardContent>
+      <Skeleton animation="wave" variant="circular" width={65} height={65} />
+      <ContentContainer>
+        <Skeleton animation="wave" variant="text" width="70%" sx={{ fontSize: '1rem' }} />
+        <Skeleton animation="wave" variant="text" width="40%" sx={{ fontSize: '0.85rem' }} />
+      </ContentContainer>
+    </WishlistCardContent>
+  )
+}

--- a/apps/front/src/components/wishlist/WishlistHeaderSkeleton.tsx
+++ b/apps/front/src/components/wishlist/WishlistHeaderSkeleton.tsx
@@ -1,0 +1,46 @@
+import { Box, Container, Skeleton, Stack, styled } from '@mui/material'
+
+const HeaderContent = styled(Box)(({ theme }) => ({
+  display: 'flex',
+  paddingBottom: theme.spacing(2),
+  borderBottom: `1px solid ${theme.palette.divider}`,
+  flexDirection: 'row',
+  alignItems: 'center',
+  gap: theme.spacing(3),
+
+  [theme.breakpoints.down('md')]: {
+    flexDirection: 'column',
+    gap: theme.spacing(2),
+  },
+}))
+
+const LeftSection = styled(Stack)(({ theme }) => ({
+  flexDirection: 'row',
+  gap: theme.spacing(3),
+  alignItems: 'center',
+  flex: 1,
+  width: '100%',
+}))
+
+const TitleContainer = styled(Stack)(({ theme }) => ({
+  gap: theme.spacing(1),
+  flex: 1,
+  minWidth: 0,
+}))
+
+export const WishlistHeaderSkeleton = () => {
+  return (
+    <Container maxWidth="lg">
+      <HeaderContent>
+        <LeftSection>
+          <Skeleton animation="wave" variant="circular" width={75} height={75} />
+
+          <TitleContainer>
+            <Skeleton animation="wave" variant="text" width="45%" sx={{ fontSize: '1.5rem' }} />
+            <Skeleton animation="wave" variant="text" width={160} sx={{ fontSize: '0.875rem' }} />
+          </TitleContainer>
+        </LeftSection>
+      </HeaderContent>
+    </Container>
+  )
+}

--- a/apps/front/src/components/wishlist/WishlistItems.tsx
+++ b/apps/front/src/components/wishlist/WishlistItems.tsx
@@ -11,15 +11,16 @@ import { useSelector } from 'react-redux'
 
 import { FabAutoGrow } from '../common/FabAutoGrow'
 import { ItemCard } from '../item/ItemCard'
+import { ItemCardSkeleton } from '../item/ItemCardSkeleton'
 import { ItemFormDialog } from '../item/ItemFormDialog'
 import { EmptyItemsState } from './EmptyItemsState'
 import { applyFilter, applySort } from './WishlistFilterAndSortItems'
 
-export type WishlistTabItemsProps = {
-  wishlist: DetailedWishlist
-  hasImportableItems: boolean
-  onImportItems: () => void
-}
+const SKELETON_KEYS = ['s1', 's2', 's3', 's4', 's5', 's6', 's7', 's8'] as const
+
+export type WishlistTabItemsProps =
+  | { loading: true }
+  | { loading?: false; wishlist: DetailedWishlist; hasImportableItems: boolean; onImportItems: () => void }
 
 // Image modal component
 const ImageModal = ({
@@ -113,7 +114,33 @@ const ImageModal = ({
 
 const mapState = (state: RootState) => state.auth.user?.id
 
-export const WishlistItems = ({ wishlist, hasImportableItems, onImportItems }: WishlistTabItemsProps) => {
+export const WishlistItems = (props: WishlistTabItemsProps) => {
+  if (props.loading) {
+    return (
+      <Box className="items">
+        <Grid container spacing={3} aria-busy>
+          {SKELETON_KEYS.map(key => (
+            <Grid key={key} size={{ xs: 12, sm: 6, lg: 4, xl: 3 }}>
+              <ItemCardSkeleton />
+            </Grid>
+          ))}
+        </Grid>
+      </Box>
+    )
+  }
+
+  return <WishlistItemsLoaded {...props} />
+}
+
+const WishlistItemsLoaded = ({
+  wishlist,
+  hasImportableItems,
+  onImportItems,
+}: {
+  wishlist: DetailedWishlist
+  hasImportableItems: boolean
+  onImportItems: () => void
+}) => {
   const currentUserId = useSelector(mapState)
   const {
     displayAddItemFormDialog: openItemFormDialog,

--- a/apps/front/src/components/wishlist/WishlistListPage.tsx
+++ b/apps/front/src/components/wishlist/WishlistListPage.tsx
@@ -4,11 +4,13 @@ import { useNavigate, useSearch } from '@tanstack/react-router'
 
 import { isRejection, rejectionMessage, useWishlistListPageQuery } from '../../gql'
 import { FabAutoGrow } from '../common/FabAutoGrow'
-import { Loader } from '../common/Loader'
 import { Pagination } from '../common/Pagination'
 import { Title } from '../common/Title'
 import { EmptyListsState } from './EmptyListsState'
 import { WishlistCardWithEvents } from './WishlistCardWithEvents'
+import { WishlistCardWithEventsSkeleton } from './WishlistCardWithEventsSkeleton'
+
+const SKELETON_KEYS = ['s1', 's2', 's3', 's4'] as const
 
 export const WishlistListPage = () => {
   const { page: currentPage } = useSearch({ from: '/_authenticated/_with-layout/wishlists/' })
@@ -27,10 +29,21 @@ export const WishlistListPage = () => {
 
   return (
     <Box>
-      {totalElements > 0 && <Title>Mes listes</Title>}
+      {(loading || totalElements > 0) && <Title>Mes listes</Title>}
 
-      <Loader loading={loading}>
-        {queryRejection && <Alert severity="error">{rejectionMessage(queryRejection)}</Alert>}
+      {queryRejection && <Alert severity="error">{rejectionMessage(queryRejection)}</Alert>}
+
+      {loading && (
+        <Grid container spacing={3} aria-busy>
+          {SKELETON_KEYS.map(key => (
+            <Grid key={key} size={{ xs: 12, lg: 6 }}>
+              <WishlistCardWithEventsSkeleton />
+            </Grid>
+          ))}
+        </Grid>
+      )}
+
+      {!loading && (
         <Grid container spacing={3}>
           {(wishlists?.data ?? []).map(wishlist => (
             <Grid key={wishlist.id} size={{ xs: 12, lg: 6 }}>
@@ -38,7 +51,7 @@ export const WishlistListPage = () => {
             </Grid>
           ))}
         </Grid>
-      </Loader>
+      )}
 
       {totalElements > 0 && (
         <>

--- a/apps/front/src/components/wishlist/WishlistPage.tsx
+++ b/apps/front/src/components/wishlist/WishlistPage.tsx
@@ -10,11 +10,11 @@ import { useSelector } from 'react-redux'
 import { isRejection, rejectionMessage, useImportableItemsQuery, useWishlistPageQuery } from '../../gql'
 import { useFeatureFlag } from '../../hooks/useFeatureFlag'
 import { Description } from '../common/Description'
-import { Loader } from '../common/Loader'
 import { ImportItemsDialog } from '../item/ImportItemsDialog'
 import { SEO } from '../SEO'
 import { WishlistEventsDialog } from './WishlistEventsDialog'
 import { WishlistHeader } from './WishlistHeader'
+import { WishlistHeaderSkeleton } from './WishlistHeaderSkeleton'
 import { WishlistItems } from './WishlistItems'
 import { WishlistNotFound } from './WishlistNotFound'
 
@@ -86,57 +86,66 @@ export const WishlistPage = ({ wishlistId }: WishlistPageProps) => {
         canonical={`/wishlists/${wishlistId}`}
       />
       <Box>
-        <Loader loading={loading}>
-          {queryRejection && <Alert severity="error">{rejectionMessage(queryRejection)}</Alert>}
-          {!wishlist && !queryRejection && <WishlistNotFound />}
+        {loading && (
+          <>
+            <WishlistHeaderSkeleton />
+            <Container maxWidth="lg">
+              <Stack gap="20px" sx={{ paddingTop: 3 }}>
+                <WishlistItems loading />
+              </Stack>
+            </Container>
+          </>
+        )}
 
-          {wishlist && (
-            <>
-              <WishlistHeader
-                wishlist={wishlist}
-                currentUserCanEdit={currentUserCanEdit}
-                isPublic={isPublic}
-                hasImportableItems={importableItems.length > 0}
-                sort={sort}
-                filter={filter}
-                onSortChange={setSort}
-                onFilterChange={setFilter}
-                onOpenEventDialog={() => setShowEventDialog(true)}
-                onOpenImportDialog={() => setShowImportDialog(true)}
-              />
+        {!loading && queryRejection && <Alert severity="error">{rejectionMessage(queryRejection)}</Alert>}
+        {!loading && !wishlist && !queryRejection && <WishlistNotFound />}
 
-              <Container maxWidth="lg">
-                <Stack gap="20px" sx={{ paddingTop: 3 }}>
-                  {wishlist.description && <Description text={wishlist.description} allowMarkdown />}
+        {!loading && wishlist && (
+          <>
+            <WishlistHeader
+              wishlist={wishlist}
+              currentUserCanEdit={currentUserCanEdit}
+              isPublic={isPublic}
+              hasImportableItems={importableItems.length > 0}
+              sort={sort}
+              filter={filter}
+              onSortChange={setSort}
+              onFilterChange={setFilter}
+              onOpenEventDialog={() => setShowEventDialog(true)}
+              onOpenImportDialog={() => setShowImportDialog(true)}
+            />
 
-                  <WishlistItems
-                    wishlist={wishlist}
-                    hasImportableItems={importableItems.length > 0}
-                    onImportItems={() => setShowImportDialog(true)}
-                  />
-                </Stack>
-              </Container>
+            <Container maxWidth="lg">
+              <Stack gap="20px" sx={{ paddingTop: 3 }}>
+                {wishlist.description && <Description text={wishlist.description} allowMarkdown />}
 
-              <WishlistEventsDialog
-                open={showEventDialog}
-                handleClose={() => setShowEventDialog(false)}
-                wishlistId={wishlist.id}
-                events={wishlist.events}
-                currentUserCanEdit={currentUserCanEdit}
-              />
-
-              {currentUserCanEdit && importableItems.length > 0 && (
-                <ImportItemsDialog
-                  open={showImportDialog && importItemsEnabled}
-                  wishlistId={wishlist.id}
-                  importableItems={importableItems}
-                  onClose={() => setShowImportDialog(false)}
-                  onComplete={() => setShowImportDialog(false)}
+                <WishlistItems
+                  wishlist={wishlist}
+                  hasImportableItems={importableItems.length > 0}
+                  onImportItems={() => setShowImportDialog(true)}
                 />
-              )}
-            </>
-          )}
-        </Loader>
+              </Stack>
+            </Container>
+
+            <WishlistEventsDialog
+              open={showEventDialog}
+              handleClose={() => setShowEventDialog(false)}
+              wishlistId={wishlist.id}
+              events={wishlist.events}
+              currentUserCanEdit={currentUserCanEdit}
+            />
+
+            {currentUserCanEdit && importableItems.length > 0 && (
+              <ImportItemsDialog
+                open={showImportDialog && importItemsEnabled}
+                wishlistId={wishlist.id}
+                importableItems={importableItems}
+                onClose={() => setShowImportDialog(false)}
+                onComplete={() => setShowImportDialog(false)}
+              />
+            )}
+          </>
+        )}
       </Box>
     </>
   )


### PR DESCRIPTION
## Summary
- Replace full-page `Loader` spinners with MUI `Skeleton` placeholders that match event, wishlist, and item cards.
- Add dedicated `*Skeleton` components (including detail headers) so list and detail pages keep their layout while data loads.
- Keep empty states, pagination, and FABs hidden until loading finishes.

## Test plan
- [ ] Open `/events` with a slow network (DevTools Slow 3G) and confirm event card skeletons, then real `EventCard`s.
- [ ] Open `/wishlists` the same way and confirm wishlist card skeletons.
- [ ] Open an event detail page and confirm header + wishlist card skeletons, then real content.
- [ ] Open a wishlist detail page and confirm header + item card skeletons, then real items.
- [ ] Confirm empty states still appear when there is no data (not during loading).


Made with [Cursor](https://cursor.com)