### PR TITLE
feat(event): add creator, admin and participant attendee roles

### DIFF
--- a/apps/api/drizzle/migrations/0009_rename-attendee-roles.sql
+++ b/apps/api/drizzle/migrations/0009_rename-attendee-roles.sql
@@ -1,0 +1,5 @@
+UPDATE "event_attendee" SET "role" = 'creator' WHERE "role" = 'maintainer';
+--> statement-breakpoint
+UPDATE "event_attendee" SET "role" = 'participant' WHERE "role" = 'user';
+--> statement-breakpoint
+ALTER TABLE "event_attendee" ALTER COLUMN "role" SET DEFAULT 'participant';

--- a/apps/api/drizzle/migrations/meta/0009_snapshot.json
+++ b/apps/api/drizzle/migrations/meta/0009_snapshot.json
@@ -1,0 +1,983 @@
+{
+  "id": "caac5370-b2da-4b91-9823-278d6defa043",
+  "prevId": "43eb5672-7995-4e25-8d1f-1096ffed1ddc",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.event": {
+      "name": "event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_date": {
+          "name": "event_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_attendee": {
+      "name": "event_attendee",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "temp_user_email": {
+          "name": "temp_user_email",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'participant'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_attendee_event_id_event_id_fk": {
+          "name": "event_attendee_event_id_event_id_fk",
+          "tableFrom": "event_attendee",
+          "tableTo": "event",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_attendee_user_id_user_id_fk": {
+          "name": "event_attendee_user_id_user_id_fk",
+          "tableFrom": "event_attendee",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "event_attendee_event_id_user_id_temp_user_email_key": {
+          "name": "event_attendee_event_id_user_id_temp_user_email_key",
+          "nullsNotDistinct": false,
+          "columns": ["event_id", "user_id", "temp_user_email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "chk_user": {
+          "name": "chk_user",
+          "value": "((user_id IS NOT NULL) AND (temp_user_email IS NULL)) OR ((user_id IS NULL) AND (temp_user_email IS NOT NULL))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.event_wishlist": {
+      "name": "event_wishlist",
+      "schema": "",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wishlist_id": {
+          "name": "wishlist_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_wishlist_wishlist_id_wishlist_id_fk": {
+          "name": "event_wishlist_wishlist_id_wishlist_id_fk",
+          "tableFrom": "event_wishlist",
+          "tableTo": "wishlist",
+          "columnsFrom": ["wishlist_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_wishlist_event_id_event_id_fk": {
+          "name": "event_wishlist_event_id_event_id_fk",
+          "tableFrom": "event_wishlist",
+          "tableTo": "event",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "event_wishlist_event_id_wishlist_id_pk": {
+          "name": "event_wishlist_event_id_wishlist_id_pk",
+          "columns": ["event_id", "wishlist_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.item": {
+      "name": "item",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "wishlist_id": {
+          "name": "wishlist_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "picture_url": {
+          "name": "picture_url",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_suggested": {
+          "name": "is_suggested",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "import_source_id": {
+          "name": "import_source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "taker_id": {
+          "name": "taker_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "taken_at": {
+          "name": "taken_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "item_wishlist_id_wishlist_id_fk": {
+          "name": "item_wishlist_id_wishlist_id_fk",
+          "tableFrom": "item",
+          "tableTo": "wishlist",
+          "columnsFrom": ["wishlist_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "item_taker_id_user_id_fk": {
+          "name": "item_taker_id_user_id_fk",
+          "tableFrom": "item",
+          "tableTo": "user",
+          "columnsFrom": ["taker_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "item_import_source_id_item_id_fk": {
+          "name": "item_import_source_id_item_id_fk",
+          "tableFrom": "item",
+          "tableTo": "item",
+          "columnsFrom": ["import_source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_import_source_id": {
+          "name": "chk_import_source_id",
+          "value": "import_source_id IS DISTINCT FROM id"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.secret_santa": {
+      "name": "secret_santa",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "budget": {
+          "name": "budget",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "secret_santa_event_id_event_id_fk": {
+          "name": "secret_santa_event_id_event_id_fk",
+          "tableFrom": "secret_santa",
+          "tableTo": "event",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "secret_santa_event_id_unique": {
+          "name": "secret_santa_event_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["event_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.secret_santa_user": {
+      "name": "secret_santa_user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "secret_santa_id": {
+          "name": "secret_santa_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attendee_id": {
+          "name": "attendee_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "draw_user_id": {
+          "name": "draw_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exclusions": {
+          "name": "exclusions",
+          "type": "uuid[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "secret_santa_user_secret_santa_id_attendee_id_key": {
+          "name": "secret_santa_user_secret_santa_id_attendee_id_key",
+          "columns": [
+            {
+              "expression": "secret_santa_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attendee_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "secret_santa_user_secret_santa_id_secret_santa_id_fk": {
+          "name": "secret_santa_user_secret_santa_id_secret_santa_id_fk",
+          "tableFrom": "secret_santa_user",
+          "tableTo": "secret_santa",
+          "columnsFrom": ["secret_santa_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "secret_santa_user_attendee_id_event_attendee_id_fk": {
+          "name": "secret_santa_user_attendee_id_event_attendee_id_fk",
+          "tableFrom": "secret_santa_user",
+          "tableTo": "event_attendee",
+          "columnsFrom": ["attendee_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "birthday": {
+          "name": "birthday",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password_enc": {
+          "name": "password_enc",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "authorities": {
+          "name": "authorities",
+          "type": "varchar(100)[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"ROLE_USER\"}'"
+        },
+        "last_ip": {
+          "name": "last_ip",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_connected_at": {
+          "name": "last_connected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "picture_url": {
+          "name": "picture_url",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_email_unique_idx": {
+          "name": "user_email_unique_idx",
+          "columns": [
+            {
+              "expression": "lower((email)::text)",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_email_change_verification": {
+      "name": "user_email_change_verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "new_email": {
+          "name": "new_email",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expired_at": {
+          "name": "expired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_email_change_verification_user_id_fkey": {
+          "name": "user_email_change_verification_user_id_fkey",
+          "tableFrom": "user_email_change_verification",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_email_setting": {
+      "name": "user_email_setting",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "daily_new_item_notification": {
+          "name": "daily_new_item_notification",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_email_setting_user_id_fkey": {
+          "name": "user_email_setting_user_id_fkey",
+          "tableFrom": "user_email_setting",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_setting_user_id_key": {
+          "name": "user_email_setting_user_id_key",
+          "nullsNotDistinct": false,
+          "columns": ["user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_password_verification": {
+      "name": "user_password_verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expired_at": {
+          "name": "expired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_password_verification_user_id_fkey": {
+          "name": "user_password_verification_user_id_fkey",
+          "tableFrom": "user_password_verification",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_social": {
+      "name": "user_social",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "social_id": {
+          "name": "social_id",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "social_type": {
+          "name": "social_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "picture_url": {
+          "name": "picture_url",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_social_user_id_fkey": {
+          "name": "user_social_user_id_fkey",
+          "tableFrom": "user_social",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_social_user_id_social_type_key": {
+          "name": "user_social_user_id_social_type_key",
+          "nullsNotDistinct": false,
+          "columns": ["user_id", "social_type"]
+        },
+        "user_social_social_id_social_type_key": {
+          "name": "user_social_social_id_social_type_key",
+          "nullsNotDistinct": false,
+          "columns": ["social_id", "social_type"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wishlist": {
+      "name": "wishlist",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "co_owner_id": {
+          "name": "co_owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hide_items": {
+          "name": "hide_items",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "wishlist_owner_id_user_id_fk": {
+          "name": "wishlist_owner_id_user_id_fk",
+          "tableFrom": "wishlist",
+          "tableTo": "user",
+          "columnsFrom": ["owner_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wishlist_co_owner_id_user_id_fk": {
+          "name": "wishlist_co_owner_id_user_id_fk",
+          "tableFrom": "wishlist",
+          "tableTo": "user",
+          "columnsFrom": ["co_owner_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_co_owner": {
+          "name": "chk_co_owner",
+          "value": "co_owner_id IS DISTINCT FROM owner_id"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/drizzle/migrations/meta/_journal.json
+++ b/apps/api/drizzle/migrations/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1765270495345,
       "tag": "0008_remove-circular-dep",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1787386061230,
+      "tag": "0009_rename-attendee-roles",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/drizzle/schema.ts
+++ b/apps/api/drizzle/schema.ts
@@ -58,7 +58,7 @@ export const eventAttendee = pgTable(
     eventId: eventId('event_id').notNull(),
     userId: userId('user_id'),
     tempUserEmail: varchar('temp_user_email', { length: 200 }),
-    role: varchar({ length: 50 }).default('user').notNull(),
+    role: varchar({ length: 50 }).default('participant').notNull(),
   },
   table => [
     foreignKey({ columns: [table.eventId], foreignColumns: [event.id] }).onDelete('cascade'),

--- a/apps/api/drizzle/seed.ts
+++ b/apps/api/drizzle/seed.ts
@@ -143,12 +143,12 @@ async function main() {
 
     eventsValues.push(event)
 
-    const maintainer = getRandomUser()
+    const creator = getRandomUser()
     eventAttendeesValues.push({
       id: faker.string.uuid(),
       eventId: event.id,
-      userId: maintainer.id,
-      role: 'maintainer',
+      userId: creator.id,
+      role: 'creator',
     })
 
     const numberOfAttendees = faker.number.int({ min: 0, max: 10 })
@@ -161,16 +161,16 @@ async function main() {
           id: faker.string.uuid(),
           eventId: event.id,
           tempUserEmail: faker.internet.email(),
-          role: 'user',
+          role: 'participant',
         })
       } else {
-        const attendee = getRandomUserWithExclusion(maintainer.id)
+        const attendee = getRandomUserWithExclusion(creator.id)
 
         eventAttendeesValues.push({
           id: faker.string.uuid(),
           eventId: event.id,
           userId: attendee.id,
-          role: 'user',
+          role: 'participant',
         })
       }
     }

--- a/apps/api/schema.graphql
+++ b/apps/api/schema.graphql
@@ -95,8 +95,9 @@ input AdminWishlistPaginationFilters {
 scalar AttendeeId
 
 enum AttendeeRole {
-  MAINTAINER
-  USER
+  ADMIN
+  CREATOR
+  PARTICIPANT
 }
 
 enum BusinessRuleCode {
@@ -358,6 +359,7 @@ type Mutation {
   unlinkCurrentUserSocial(socialId: UserSocialId!): UnlinkCurrentUserSocialResult!
   unlinkWishlistFromEvent(eventId: EventId!, id: WishlistId!): UnlinkWishlistFromEventResult!
   updateEvent(id: EventId!, input: UpdateEventInput!): UpdateEventResult!
+  updateEventAttendeeRole(attendeeId: AttendeeId!, eventId: EventId!, role: AttendeeRole!): UpdateEventAttendeeRoleResult!
   updateItem(input: UpdateItemInput!, itemId: ItemId!): UpdateItemResult!
   updateSecretSanta(id: SecretSantaId!, input: UpdateSecretSantaInput!): UpdateSecretSantaResult!
   updateSecretSantaUser(id: SecretSantaId!, input: UpdateSecretSantaUserInput!, secretSantaUserId: SecretSantaUserId!): UpdateSecretSantaUserResult!
@@ -506,6 +508,8 @@ type UnauthorizedRejection {
 union UnlinkCurrentUserSocialResult = ForbiddenRejection | InternalErrorRejection | UnauthorizedRejection | ValidationRejection | VoidOutput
 
 union UnlinkWishlistFromEventResult = ForbiddenRejection | InternalErrorRejection | NotFoundRejection | UnauthorizedRejection | ValidationRejection | VoidOutput
+
+union UpdateEventAttendeeRoleResult = ForbiddenRejection | InternalErrorRejection | NotFoundRejection | UnauthorizedRejection | ValidationRejection | VoidOutput
 
 input UpdateEventInput {
   description: String

--- a/apps/api/src/event/application/command/add-attendee.use-case.ts
+++ b/apps/api/src/event/application/command/add-attendee.use-case.ts
@@ -37,7 +37,7 @@ export class AddAttendeeUseCase {
     const event = await this.eventRepository.findByIdOrFail(eventId)
 
     if (!event.canEdit(currentUser)) {
-      throw new UnauthorizedException('Only maintainers of the event can add an attendee')
+      throw new UnauthorizedException('Only creators and admins of the event can add an attendee')
     }
 
     const attendeeAlreadyExists = event.attendees.some(attendee => attendee.getEmail() === input.newAttendee.email)
@@ -47,7 +47,11 @@ export class AddAttendeeUseCase {
     }
 
     const user = await this.userRepository.findByEmail(input.newAttendee.email)
-    const role = input.newAttendee.role ?? AttendeeRole.USER
+    const role = input.newAttendee.role ?? AttendeeRole.PARTICIPANT
+
+    if (role === AttendeeRole.CREATOR) {
+      throw new BadRequestException('Cannot assign the creator role to an attendee')
+    }
     const attendeeId = this.attendeeRepository.newId()
 
     const newAttendee = user

--- a/apps/api/src/event/application/command/create-event.use-case.ts
+++ b/apps/api/src/event/application/command/create-event.use-case.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable, Logger } from '@nestjs/common'
+import { BadRequestException, Inject, Injectable, Logger } from '@nestjs/common'
 import { EventBus } from '@nestjs/cqrs'
 import { REPOSITORIES } from '@wishlist/api/repositories'
 import { type UserRepository } from '@wishlist/api/user'
@@ -52,7 +52,7 @@ export class CreateEventUseCase {
     const eventId = this.eventRepository.newId()
     const attendees: EventAttendee[] = []
 
-    // Add the current user as maintainer attendee
+    // Add the current user as creator attendee
     const currentUser = await this.userRepository.findByIdOrFail(input.currentUser.id)
 
     attendees.push(
@@ -60,14 +60,19 @@ export class CreateEventUseCase {
         id: this.attendeeRepository.newId(),
         eventId,
         user: currentUser,
-        role: AttendeeRole.MAINTAINER,
+        role: AttendeeRole.CREATOR,
       }),
     )
 
     for (const attendee of input.newEvent.attendees ?? []) {
       const user = existingUsers.find(u => u.email === attendee.email)
       const id = this.attendeeRepository.newId()
-      const role = attendee.role ?? AttendeeRole.USER
+      const role = attendee.role ?? AttendeeRole.PARTICIPANT
+
+      if (role === AttendeeRole.CREATOR) {
+        throw new BadRequestException('Cannot assign the creator role to an invited attendee')
+      }
+
       const newAttendee = user
         ? EventAttendee.createFromExistingUser({ id, eventId, user, role })
         : EventAttendee.createFromNonExistingUser({

--- a/apps/api/src/event/application/command/delete-attendee.use-case.ts
+++ b/apps/api/src/event/application/command/delete-attendee.use-case.ts
@@ -33,7 +33,7 @@ export class DeleteAttendeeUseCase {
     const event = await this.eventRepository.findByIdOrFail(eventId)
 
     if (!event.canEdit(currentUser)) {
-      throw new UnauthorizedException('Only maintainers of the event can delete an attendee')
+      throw new UnauthorizedException('Only creators and admins of the event can delete an attendee')
     }
 
     const attendee = event.attendees.find(a => a.id === attendeeId)
@@ -44,6 +44,10 @@ export class DeleteAttendeeUseCase {
 
     if (attendee.user?.id === currentUser.id) {
       throw new ConflictException('You cannot delete yourself from the event')
+    }
+
+    if (attendee.isCreator()) {
+      throw new ConflictException('You cannot delete the creator of the event')
     }
 
     const attendeeUserId = attendee.user?.id

--- a/apps/api/src/event/application/command/delete-event.use-case.ts
+++ b/apps/api/src/event/application/command/delete-event.use-case.ts
@@ -29,7 +29,7 @@ export class DeleteEventUseCase {
     const event = await this.eventRepository.findByIdOrFail(eventId)
 
     if (!event.canEdit(currentUser)) {
-      throw new UnauthorizedException('Only maintainers of the event can delete it')
+      throw new UnauthorizedException('Only creators and admins of the event can delete it')
     }
 
     const wishlists = await this.wishlistRepository.findByEvent(event.id)

--- a/apps/api/src/event/application/command/update-attendee-role.use-case.ts
+++ b/apps/api/src/event/application/command/update-attendee-role.use-case.ts
@@ -1,0 +1,70 @@
+import {
+  BadRequestException,
+  ConflictException,
+  Inject,
+  Injectable,
+  Logger,
+  NotFoundException,
+  UnauthorizedException,
+} from '@nestjs/common'
+import { REPOSITORIES } from '@wishlist/api/repositories'
+import { type AttendeeId, AttendeeRole, type EventId, type ICurrentUser } from '@wishlist/common'
+
+import { type EventAttendeeRepository, type EventRepository } from '../../domain'
+
+export type UpdateAttendeeRoleInput = {
+  currentUser: ICurrentUser
+  eventId: EventId
+  attendeeId: AttendeeId
+  role: AttendeeRole
+}
+
+@Injectable()
+export class UpdateAttendeeRoleUseCase {
+  private readonly logger = new Logger(UpdateAttendeeRoleUseCase.name)
+
+  constructor(
+    @Inject(REPOSITORIES.EVENT)
+    private readonly eventRepository: EventRepository,
+    @Inject(REPOSITORIES.EVENT_ATTENDEE)
+    private readonly attendeeRepository: EventAttendeeRepository,
+  ) {}
+
+  async execute(input: UpdateAttendeeRoleInput): Promise<void> {
+    this.logger.log('Update attendee role request received', { input })
+    const { attendeeId, currentUser, eventId, role } = input
+
+    const event = await this.eventRepository.findByIdOrFail(eventId)
+
+    if (!event.canEdit(currentUser)) {
+      throw new UnauthorizedException('Only creators and admins of the event can update an attendee role')
+    }
+
+    const attendee = event.attendees.find(a => a.id === attendeeId)
+
+    if (!attendee) {
+      throw new NotFoundException('Attendee not found')
+    }
+
+    if (attendee.user?.id === currentUser.id) {
+      throw new ConflictException('You cannot change your own role')
+    }
+
+    if (attendee.isCreator()) {
+      throw new ConflictException('You cannot change the creator role')
+    }
+
+    if (role === AttendeeRole.CREATOR) {
+      throw new BadRequestException('Cannot assign the creator role to an attendee')
+    }
+
+    if (role !== AttendeeRole.ADMIN && role !== AttendeeRole.PARTICIPANT) {
+      throw new BadRequestException('Role must be admin or participant')
+    }
+
+    const updatedAttendee = attendee.updateRole(role)
+
+    this.logger.log('Saving attendee role...', { attendeeId, eventId, role })
+    await this.attendeeRepository.save(updatedAttendee)
+  }
+}

--- a/apps/api/src/event/application/command/update-event.use-case.ts
+++ b/apps/api/src/event/application/command/update-event.use-case.ts
@@ -26,7 +26,7 @@ export class UpdateEventUseCase {
     const event = await this.eventRepository.findByIdOrFail(input.eventId)
 
     if (!event.canEdit(input.currentUser)) {
-      throw new UnauthorizedException('Only maintainers of the event can update it')
+      throw new UnauthorizedException('Only creators and admins of the event can update it')
     }
 
     const updatedEvent = event.update({

--- a/apps/api/src/event/application/index.ts
+++ b/apps/api/src/event/application/index.ts
@@ -2,6 +2,7 @@ import { AddAttendeeUseCase } from './command/add-attendee.use-case'
 import { CreateEventUseCase } from './command/create-event.use-case'
 import { DeleteAttendeeUseCase } from './command/delete-attendee.use-case'
 import { DeleteEventUseCase } from './command/delete-event.use-case'
+import { UpdateAttendeeRoleUseCase } from './command/update-attendee-role.use-case'
 import { UpdateEventUseCase } from './command/update-event.use-case'
 import { AttendeeAddedHandler } from './event/attendee-added.handler'
 import { GetEventAttendeesByIdsUseCase } from './query/get-event-attendees-by-ids.use-case'
@@ -18,6 +19,7 @@ export const handlers = [
   UpdateEventUseCase,
   AddAttendeeUseCase,
   DeleteAttendeeUseCase,
+  UpdateAttendeeRoleUseCase,
   // Queries
   GetEventByIdUseCase,
   GetEventsByIdsUseCase,

--- a/apps/api/src/event/domain/model/event-attendee.model.ts
+++ b/apps/api/src/event/domain/model/event-attendee.model.ts
@@ -1,5 +1,6 @@
 import type { User } from '@wishlist/api/user'
-import type { AttendeeId, AttendeeRole, EventId } from '@wishlist/common'
+
+import { type AttendeeId, AttendeeRole, type EventId } from '@wishlist/common'
 
 export type EventAttendeeProps = {
   id: AttendeeId
@@ -85,6 +86,17 @@ export class EventAttendee {
       ...this,
       user,
       pendingEmail: undefined,
+    })
+  }
+
+  isCreator(): boolean {
+    return this.role === AttendeeRole.CREATOR
+  }
+
+  updateRole(role: AttendeeRole): EventAttendee {
+    return new EventAttendee({
+      ...this,
+      role,
     })
   }
 }

--- a/apps/api/src/event/domain/model/event.model.ts
+++ b/apps/api/src/event/domain/model/event.model.ts
@@ -80,14 +80,14 @@ export class Event {
   canEdit(currentUser: ICurrentUser): boolean {
     return this.canAccessByRole({
       currentUser,
-      acceptedRoles: [AttendeeRole.MAINTAINER],
+      acceptedRoles: [AttendeeRole.CREATOR, AttendeeRole.ADMIN],
     })
   }
 
   canView(currentUser: ICurrentUser): boolean {
     return this.canAccessByRole({
       currentUser,
-      acceptedRoles: [AttendeeRole.MAINTAINER, AttendeeRole.USER],
+      acceptedRoles: [AttendeeRole.CREATOR, AttendeeRole.ADMIN, AttendeeRole.PARTICIPANT],
     })
   }
 

--- a/apps/api/src/event/infrastructure/controllers/event-attendee.controller.int-spec.ts
+++ b/apps/api/src/event/infrastructure/controllers/event-attendee.controller.int-spec.ts
@@ -598,10 +598,7 @@ describe('EventAttendeeController', () => {
         {
           body: {},
           case: 'empty body',
-          message: [
-            'role must be one of the following values: creator, admin, participant',
-            'role should not be empty',
-          ],
+          message: ['role should not be empty'],
         },
         {
           body: { role: 'invalid-role' },

--- a/apps/api/src/event/infrastructure/controllers/event-attendee.controller.int-spec.ts
+++ b/apps/api/src/event/infrastructure/controllers/event-attendee.controller.int-spec.ts
@@ -21,7 +21,7 @@ describe('EventAttendeeController', () => {
         .post(path(uuid()))
         .send({
           email: 'test@example.com',
-          role: AttendeeRole.USER,
+          role: AttendeeRole.PARTICIPANT,
         })
         .expect(401)
     })
@@ -44,7 +44,7 @@ describe('EventAttendeeController', () => {
         {
           body: { email: 'test@example.com', role: 'invalid-role' },
           case: 'invalid role',
-          message: ['role must be one of the following values: maintainer, user'],
+          message: ['role must be one of the following values: creator, admin, participant'],
         },
       ])('should return 400 when invalid input: $case', async ({ body, message }) => {
         const { eventId } = await fixtures.insertEventWithMaintainer({
@@ -76,14 +76,14 @@ describe('EventAttendeeController', () => {
           .post(path(eventId))
           .send({
             email: 'new-attendee@example.com',
-            role: AttendeeRole.USER,
+            role: AttendeeRole.PARTICIPANT,
           })
           .expect(201)
           .expect(({ body }) => {
             expect(body).toEqual({
               id: expect.toBeString(),
               pending_email: 'new-attendee@example.com',
-              role: AttendeeRole.USER,
+              role: AttendeeRole.PARTICIPANT,
             })
           })
 
@@ -96,7 +96,7 @@ describe('EventAttendeeController', () => {
             id: createdId,
             event_id: eventId,
             temp_user_email: 'new-attendee@example.com',
-            role: AttendeeRole.USER,
+            role: AttendeeRole.PARTICIPANT,
           })
 
         await expectMail()
@@ -124,13 +124,13 @@ describe('EventAttendeeController', () => {
           .post(path(eventId))
           .send({
             email: 'other@example.com',
-            role: AttendeeRole.USER,
+            role: AttendeeRole.PARTICIPANT,
           })
           .expect(201)
           .expect(({ body }) => {
             expect(body).toEqual({
               id: expect.toBeString(),
-              role: AttendeeRole.USER,
+              role: AttendeeRole.PARTICIPANT,
               user: {
                 id: otherUserId,
                 email: 'other@example.com',
@@ -149,7 +149,7 @@ describe('EventAttendeeController', () => {
             id: createdId,
             event_id: eventId,
             user_id: otherUserId,
-            role: AttendeeRole.USER,
+            role: AttendeeRole.PARTICIPANT,
           })
 
         await expectMail()
@@ -167,7 +167,7 @@ describe('EventAttendeeController', () => {
           .post(path(nonExistentEventId))
           .send({
             email: 'test@example.com',
-            role: AttendeeRole.USER,
+            role: AttendeeRole.PARTICIPANT,
           })
           .expect(404)
           .expect(({ body }) =>
@@ -197,13 +197,13 @@ describe('EventAttendeeController', () => {
           .post(path(eventId))
           .send({
             email: 'test@example.com',
-            role: AttendeeRole.USER,
+            role: AttendeeRole.PARTICIPANT,
           })
           .expect(401)
           .expect(({ body }) =>
             expect(body).toMatchObject({
               error: 'Unauthorized',
-              message: 'Only maintainers of the event can add an attendee',
+              message: 'Only creators and admins of the event can add an attendee',
             }),
           )
 
@@ -227,7 +227,7 @@ describe('EventAttendeeController', () => {
           .post(path(eventId))
           .send({
             email: existingEmail,
-            role: AttendeeRole.USER,
+            role: AttendeeRole.PARTICIPANT,
           })
           .expect(400)
           .expect(({ body }) =>
@@ -238,6 +238,54 @@ describe('EventAttendeeController', () => {
           )
 
         await expectTable(Fixtures.EVENT_ATTENDEE_TABLE).hasNumberOfRows(2) // maintainer + existing attendee
+      })
+
+      it('should return 400 when assigning creator role', async () => {
+        const { eventId } = await fixtures.insertEventWithMaintainer({
+          title: 'Test Event',
+          description: 'Test Description',
+          maintainerId: currentUserId,
+        })
+
+        await request
+          .post(path(eventId))
+          .send({
+            email: 'new-attendee@example.com',
+            role: AttendeeRole.CREATOR,
+          })
+          .expect(400)
+          .expect(({ body }) =>
+            expect(body).toMatchObject({
+              error: 'Bad Request',
+              message: 'Cannot assign the creator role to an attendee',
+            }),
+          )
+
+        await expectTable(Fixtures.EVENT_ATTENDEE_TABLE).hasNumberOfRows(1)
+      })
+
+      it('should add attendee when user is admin of the event', async () => {
+        const creatorId = await fixtures.insertUser({
+          email: 'creator@example.com',
+          firstname: 'Creator',
+          lastname: 'User',
+        })
+        const { eventId } = await fixtures.insertEventWithCreator({
+          title: 'Test Event',
+          description: 'Test Description',
+          creatorId,
+        })
+        await fixtures.insertAdminAttendee({ eventId, userId: currentUserId })
+
+        await request
+          .post(path(eventId))
+          .send({
+            email: 'new-attendee@example.com',
+            role: AttendeeRole.PARTICIPANT,
+          })
+          .expect(201)
+
+        await expectTable(Fixtures.EVENT_ATTENDEE_TABLE).hasNumberOfRows(3)
       })
     })
   })
@@ -307,7 +355,7 @@ describe('EventAttendeeController', () => {
           .expect(({ body }) =>
             expect(body).toMatchObject({
               error: 'Unauthorized',
-              message: 'Only maintainers of the event can delete an attendee',
+              message: 'Only creators and admins of the event can delete an attendee',
             }),
           )
 
@@ -494,6 +542,258 @@ describe('EventAttendeeController', () => {
         await expectTable(Fixtures.EVENT_ATTENDEE_TABLE).hasNumberOfRows(2) // 1 attendee for eventId1 and 1 for eventId2
         await expectTable(Fixtures.EVENT_WISHLIST_TABLE).hasNumberOfRows(1) // linked to eventId2
         await expectTable(Fixtures.WISHLIST_TABLE).hasNumberOfRows(1) // wishlist still exists
+      })
+
+      it('should return 409 when trying to delete the creator', async () => {
+        const creatorId = await fixtures.insertUser({
+          email: 'creator@example.com',
+          firstname: 'Creator',
+          lastname: 'User',
+        })
+        const { eventId, attendeeId: creatorAttendeeId } = await fixtures.insertEventWithCreator({
+          title: 'Test Event',
+          description: 'Test Description',
+          creatorId,
+        })
+        await fixtures.insertAdminAttendee({ eventId, userId: currentUserId })
+
+        await request
+          .delete(path({ eventId, attendeeId: creatorAttendeeId }))
+          .expect(409)
+          .expect(({ body }) =>
+            expect(body).toMatchObject({
+              error: 'Conflict',
+              message: 'You cannot delete the creator of the event',
+            }),
+          )
+
+        await expectTable(Fixtures.EVENT_ATTENDEE_TABLE).hasNumberOfRows(2)
+      })
+    })
+  })
+
+  describe('PUT /event/:eventId/attendee/:attendeeId', () => {
+    const path = (params: { eventId: string; attendeeId: string }) =>
+      `/event/${params.eventId}/attendee/${params.attendeeId}`
+
+    it('should return unauthorized if not authenticated', async () => {
+      const request = await getRequest()
+
+      await request
+        .put(path({ eventId: uuid(), attendeeId: uuid() }))
+        .send({ role: AttendeeRole.ADMIN })
+        .expect(401)
+    })
+
+    describe('when user is authenticated', () => {
+      let request: RequestApp
+      let currentUserId: string
+
+      beforeEach(async () => {
+        request = await getRequest({ signedAs: 'BASE_USER' })
+        currentUserId = await fixtures.getSignedUserId('BASE_USER')
+      })
+
+      it.each([
+        {
+          body: {},
+          case: 'empty body',
+          message: [
+            'role must be one of the following values: creator, admin, participant',
+            'role should not be empty',
+          ],
+        },
+        {
+          body: { role: 'invalid-role' },
+          case: 'invalid role',
+          message: ['role must be one of the following values: creator, admin, participant'],
+        },
+      ])('should return 400 when invalid input: $case', async ({ body, message }) => {
+        const { eventId, attendeeId } = await fixtures.insertEventWithMaintainer({
+          title: 'Test Event',
+          description: 'Test Description',
+          maintainerId: currentUserId,
+        })
+
+        await request
+          .put(path({ eventId, attendeeId }))
+          .send(body)
+          .expect(400)
+          .expect(({ body }) =>
+            expect(body).toMatchObject({
+              error: 'Bad Request',
+              message: expect.arrayContaining(message),
+            }),
+          )
+      })
+
+      it('should update attendee role from participant to admin', async () => {
+        const { eventId } = await fixtures.insertEventWithMaintainer({
+          title: 'Test Event',
+          description: 'Test Description',
+          maintainerId: currentUserId,
+        })
+        const otherUserId = await fixtures.insertUser({
+          email: 'attendee@example.com',
+          firstname: 'Attendee',
+          lastname: 'User',
+        })
+        const attendeeId = await fixtures.insertActiveAttendee({
+          eventId,
+          userId: otherUserId,
+          role: AttendeeRole.PARTICIPANT,
+        })
+
+        await request.put(path({ eventId, attendeeId })).send({ role: AttendeeRole.ADMIN }).expect(200)
+
+        await expectTable(Fixtures.EVENT_ATTENDEE_TABLE).hasNumberOfRows(2).row(1).toMatchObject({
+          id: attendeeId,
+          role: AttendeeRole.ADMIN,
+        })
+      })
+
+      it('should update attendee role when current user is admin', async () => {
+        const creatorId = await fixtures.insertUser({
+          email: 'creator@example.com',
+          firstname: 'Creator',
+          lastname: 'User',
+        })
+        const { eventId } = await fixtures.insertEventWithCreator({
+          title: 'Test Event',
+          description: 'Test Description',
+          creatorId,
+        })
+        await fixtures.insertAdminAttendee({ eventId, userId: currentUserId })
+        const otherUserId = await fixtures.insertUser({
+          email: 'attendee@example.com',
+          firstname: 'Attendee',
+          lastname: 'User',
+        })
+        const attendeeId = await fixtures.insertActiveAttendee({
+          eventId,
+          userId: otherUserId,
+          role: AttendeeRole.PARTICIPANT,
+        })
+
+        await request.put(path({ eventId, attendeeId })).send({ role: AttendeeRole.ADMIN }).expect(200)
+
+        await expectTable(Fixtures.EVENT_ATTENDEE_TABLE).hasNumberOfRows(3).row(2).toMatchObject({
+          id: attendeeId,
+          role: AttendeeRole.ADMIN,
+        })
+      })
+
+      it('should return 401 when user is not creator or admin of event', async () => {
+        const otherUserId = await fixtures.insertUser({
+          email: 'other@example.com',
+          firstname: 'Other',
+          lastname: 'User',
+        })
+        const { eventId } = await fixtures.insertEventWithMaintainer({
+          title: 'Test Event',
+          description: 'Test Description',
+          maintainerId: otherUserId,
+        })
+        const attendeeId = await fixtures.insertPendingAttendee({
+          eventId,
+          tempUserEmail: 'attendee@example.com',
+        })
+
+        await request
+          .put(path({ eventId, attendeeId }))
+          .send({ role: AttendeeRole.ADMIN })
+          .expect(401)
+          .expect(({ body }) =>
+            expect(body).toMatchObject({
+              error: 'Unauthorized',
+              message: 'Only creators and admins of the event can update an attendee role',
+            }),
+          )
+      })
+
+      it('should return 409 when trying to change own role', async () => {
+        const { eventId, attendeeId } = await fixtures.insertEventWithMaintainer({
+          title: 'Test Event',
+          description: 'Test Description',
+          maintainerId: currentUserId,
+        })
+
+        await request
+          .put(path({ eventId, attendeeId }))
+          .send({ role: AttendeeRole.ADMIN })
+          .expect(409)
+          .expect(({ body }) =>
+            expect(body).toMatchObject({
+              error: 'Conflict',
+              message: 'You cannot change your own role',
+            }),
+          )
+      })
+
+      it('should return 409 when trying to change the creator role', async () => {
+        const creatorId = await fixtures.insertUser({
+          email: 'creator@example.com',
+          firstname: 'Creator',
+          lastname: 'User',
+        })
+        const { eventId, attendeeId: creatorAttendeeId } = await fixtures.insertEventWithCreator({
+          title: 'Test Event',
+          description: 'Test Description',
+          creatorId,
+        })
+        await fixtures.insertAdminAttendee({ eventId, userId: currentUserId })
+
+        await request
+          .put(path({ eventId, attendeeId: creatorAttendeeId }))
+          .send({ role: AttendeeRole.ADMIN })
+          .expect(409)
+          .expect(({ body }) =>
+            expect(body).toMatchObject({
+              error: 'Conflict',
+              message: 'You cannot change the creator role',
+            }),
+          )
+      })
+
+      it('should return 400 when assigning creator role', async () => {
+        const { eventId } = await fixtures.insertEventWithMaintainer({
+          title: 'Test Event',
+          description: 'Test Description',
+          maintainerId: currentUserId,
+        })
+        const otherUserId = await fixtures.insertUser({
+          email: 'attendee@example.com',
+          firstname: 'Attendee',
+          lastname: 'User',
+        })
+        const attendeeId = await fixtures.insertActiveAttendee({
+          eventId,
+          userId: otherUserId,
+        })
+
+        await request
+          .put(path({ eventId, attendeeId }))
+          .send({ role: AttendeeRole.CREATOR })
+          .expect(400)
+          .expect(({ body }) =>
+            expect(body).toMatchObject({
+              error: 'Bad Request',
+              message: 'Cannot assign the creator role to an attendee',
+            }),
+          )
+      })
+
+      it('should return 404 when attendee does not exist', async () => {
+        const { eventId } = await fixtures.insertEventWithMaintainer({
+          title: 'Test Event',
+          description: 'Test Description',
+          maintainerId: currentUserId,
+        })
+
+        await request
+          .put(path({ eventId, attendeeId: uuid() }))
+          .send({ role: AttendeeRole.ADMIN })
+          .expect(404)
       })
     })
   })

--- a/apps/api/src/event/infrastructure/controllers/event-attendee.controller.ts
+++ b/apps/api/src/event/infrastructure/controllers/event-attendee.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Delete, Param, Post } from '@nestjs/common'
+import { Body, Controller, Delete, Param, Post, Put } from '@nestjs/common'
 import { ApiTags } from '@nestjs/swagger'
 import { CurrentUser } from '@wishlist/api/auth'
 import {
@@ -7,10 +7,12 @@ import {
   type AttendeeId,
   type EventId,
   type ICurrentUser,
+  UpdateEventAttendeeRoleInputDto,
 } from '@wishlist/common'
 
 import { AddAttendeeUseCase } from '../../application/command/add-attendee.use-case'
 import { DeleteAttendeeUseCase } from '../../application/command/delete-attendee.use-case'
+import { UpdateAttendeeRoleUseCase } from '../../application/command/update-attendee-role.use-case'
 
 @ApiTags('Event Attendee')
 @Controller('/event/:eventId/attendee')
@@ -18,6 +20,7 @@ export class EventAttendeeController {
   constructor(
     private readonly addAttendeeUseCase: AddAttendeeUseCase,
     private readonly deleteAttendeeUseCase: DeleteAttendeeUseCase,
+    private readonly updateAttendeeRoleUseCase: UpdateAttendeeRoleUseCase,
   ) {}
 
   @Post()
@@ -33,6 +36,21 @@ export class EventAttendeeController {
         email: dto.email,
         role: dto.role,
       },
+    })
+  }
+
+  @Put('/:attendeeId')
+  async updateAttendeeRole(
+    @CurrentUser() currentUser: ICurrentUser,
+    @Param('eventId') eventId: EventId,
+    @Param('attendeeId') attendeeId: AttendeeId,
+    @Body() dto: UpdateEventAttendeeRoleInputDto,
+  ): Promise<void> {
+    await this.updateAttendeeRoleUseCase.execute({
+      currentUser,
+      eventId,
+      attendeeId,
+      role: dto.role,
     })
   }
 

--- a/apps/api/src/event/infrastructure/controllers/event.controller.int-spec.ts
+++ b/apps/api/src/event/infrastructure/controllers/event.controller.int-spec.ts
@@ -65,7 +65,7 @@ describe('EventController', () => {
                   attendees: [
                     {
                       id: maintainerAttendeeId,
-                      role: 'maintainer',
+                      role: 'creator',
                       user: {
                         id: currentUserId,
                         email: Fixtures.BASE_USER_EMAIL,
@@ -76,7 +76,7 @@ describe('EventController', () => {
                     {
                       id: attendeeId1,
                       pending_email: 'temp@temp.fr',
-                      role: 'user',
+                      role: 'participant',
                     },
                   ],
                   created_at: expect.toBeDateString(),
@@ -344,7 +344,7 @@ describe('EventController', () => {
         await request.get(path(eventId)).expect(401)
       })
 
-      it('should return event when current user is attendee MAINTAINER', async () => {
+      it('should return event when current user is attendee CREATOR', async () => {
         const userId2 = await fixtures.insertUser({
           email: 'user2@user2.fr',
           firstname: 'User2',
@@ -401,7 +401,7 @@ describe('EventController', () => {
               attendees: expect.toIncludeSameMembers([
                 {
                   id: maintainerAttendeeId,
-                  role: 'maintainer',
+                  role: 'creator',
                   user: {
                     id: currentUserId,
                     email: Fixtures.BASE_USER_EMAIL,
@@ -411,7 +411,7 @@ describe('EventController', () => {
                 },
                 {
                   id: activeAttendeeId,
-                  role: 'user',
+                  role: 'participant',
                   user: {
                     id: userId2,
                     email: 'user2@user2.fr',
@@ -422,7 +422,7 @@ describe('EventController', () => {
                 {
                   id: pendingAttendeeId,
                   pending_email: 'temp@temp.fr',
-                  role: 'user',
+                  role: 'participant',
                 },
               ]),
               created_at: expect.toBeDateString(),
@@ -431,7 +431,7 @@ describe('EventController', () => {
           )
       })
 
-      it('should return event when current user is attendee USER', async () => {
+      it('should return event when current user is attendee PARTICIPANT', async () => {
         const creatorId = await fixtures.insertUser({
           email: 'user2@user2.fr',
           firstname: 'User2',
@@ -540,7 +540,7 @@ describe('EventController', () => {
             attendees: [{ email: 'test@test.com', role: 'invalid-role' }],
           },
           case: 'invalid attendee role',
-          message: ['attendees.0.role must be one of the following values: maintainer, user'],
+          message: ['attendees.0.role must be one of the following values: creator, admin, participant'],
         },
         {
           body: {
@@ -601,7 +601,7 @@ describe('EventController', () => {
         await expectTable(Fixtures.EVENT_ATTENDEE_TABLE).hasNumberOfRows(1).row(0).toMatchObject({
           event_id: createdEventId,
           user_id: currentUserId,
-          role: 'maintainer',
+          role: 'creator',
         })
       })
 
@@ -624,11 +624,11 @@ describe('EventController', () => {
           attendees: [
             {
               email: user1Email,
-              role: 'maintainer',
+              role: 'admin',
             },
             {
               email: user2Email,
-              role: 'user',
+              role: 'participant',
             },
           ],
         }
@@ -664,19 +664,19 @@ describe('EventController', () => {
           .toMatchObject({
             event_id: createdEventId,
             user_id: currentUserId,
-            role: 'maintainer',
+            role: 'creator',
           })
           .row(1)
           .toMatchObject({
             event_id: createdEventId,
             user_id: user1Id,
-            role: 'maintainer',
+            role: 'admin',
           })
           .row(2)
           .toMatchObject({
             event_id: createdEventId,
             temp_user_email: user2Email,
-            role: 'user',
+            role: 'participant',
           })
 
         await expectMail()
@@ -745,6 +745,40 @@ describe('EventController', () => {
             event_date: DateTime.now().plus({ days: 1 }).toISODate(),
           })
           .expect(401)
+      })
+
+      it('should update event when user is admin of the event', async () => {
+        const creatorId = await fixtures.insertUser({
+          email: 'creator@test.com',
+          firstname: 'Creator',
+          lastname: 'User',
+        })
+
+        const { eventId } = await fixtures.insertEventWithCreator({
+          title: 'Event',
+          description: 'Description',
+          creatorId,
+        })
+        await fixtures.insertAdminAttendee({ eventId, userId: currentUserId })
+
+        const eventDate = DateTime.now().plus({ days: 2 }).toISODate()
+        await request
+          .put(path(eventId))
+          .send({
+            title: 'Updated by admin',
+            description: 'Updated Description',
+            event_date: eventDate,
+          })
+          .expect(200)
+
+        await expectTable(Fixtures.EVENT_TABLE)
+          .hasNumberOfRows(1)
+          .row(0)
+          .toMatchObject({
+            id: eventId,
+            title: 'Updated by admin',
+            event_date: new Date(eventDate),
+          })
       })
 
       it.each([
@@ -909,6 +943,26 @@ describe('EventController', () => {
         await request.delete(path(eventId)).expect(401)
 
         await expectTable(Fixtures.EVENT_TABLE).hasNumberOfRows(1)
+      })
+
+      it('should delete event when user is admin of the event', async () => {
+        const creatorId = await fixtures.insertUser({
+          email: 'creator@test.com',
+          firstname: 'Creator',
+          lastname: 'User',
+        })
+
+        const { eventId } = await fixtures.insertEventWithCreator({
+          title: 'Event',
+          description: 'Description',
+          creatorId,
+        })
+        await fixtures.insertAdminAttendee({ eventId, userId: currentUserId })
+
+        await request.delete(path(eventId)).expect(200)
+
+        await expectTable(Fixtures.EVENT_TABLE).hasNumberOfRows(0)
+        await expectTable(Fixtures.EVENT_ATTENDEE_TABLE).hasNumberOfRows(0)
       })
 
       it('should return 400 when event has wishlists', async () => {

--- a/apps/api/src/event/infrastructure/event.graphql
+++ b/apps/api/src/event/infrastructure/event.graphql
@@ -2,8 +2,9 @@ scalar EventId
 scalar AttendeeId
 
 enum AttendeeRole {
-  MAINTAINER
-  USER
+  CREATOR
+  ADMIN
+  PARTICIPANT
 }
 
 type EventAttendee {
@@ -127,6 +128,14 @@ union RemoveEventAttendeeResult =
   | NotFoundRejection
   | InternalErrorRejection
 
+union UpdateEventAttendeeRoleResult =
+  | VoidOutput
+  | ValidationRejection
+  | UnauthorizedRejection
+  | ForbiddenRejection
+  | NotFoundRejection
+  | InternalErrorRejection
+
 union AdminGetEventByIdResult =
   | Event
   | ValidationRejection
@@ -179,6 +188,11 @@ extend type Mutation {
   deleteEvent(id: EventId!): DeleteEventResult!
   addEventAttendee(eventId: EventId!, input: AddEventAttendeeInput!): AddEventAttendeeResult!
   removeEventAttendee(eventId: EventId!, attendeeId: AttendeeId!): RemoveEventAttendeeResult!
+  updateEventAttendeeRole(
+    eventId: EventId!
+    attendeeId: AttendeeId!
+    role: AttendeeRole!
+  ): UpdateEventAttendeeRoleResult!
   adminUpdateEvent(id: EventId!, input: UpdateEventInput!): AdminUpdateEventResult!
   adminDeleteEvent(id: EventId!): AdminDeleteEventResult!
   adminDeleteEventAttendee(eventId: EventId!, attendeeId: AttendeeId!): AdminDeleteEventAttendeeResult!

--- a/apps/api/src/event/infrastructure/event.mapper.ts
+++ b/apps/api/src/event/infrastructure/event.mapper.ts
@@ -68,8 +68,9 @@ function toGqlEvent(event: Event): GqlEvent {
 
 function toGqlEventAttendee(eventAttendee: EventAttendee): GqlEventAttendee {
   const role = match(eventAttendee.role)
-    .with(AttendeeRole.MAINTAINER, () => GqlAttendeeRole.Maintainer)
-    .with(AttendeeRole.USER, () => GqlAttendeeRole.User)
+    .with(AttendeeRole.CREATOR, () => GqlAttendeeRole.Creator)
+    .with(AttendeeRole.ADMIN, () => GqlAttendeeRole.Admin)
+    .with(AttendeeRole.PARTICIPANT, () => GqlAttendeeRole.Participant)
     .exhaustive()
 
   return {
@@ -83,8 +84,9 @@ function toGqlEventAttendee(eventAttendee: EventAttendee): GqlEventAttendee {
 
 function toGqlEventAttendeeFromDto(attendee: AttendeeDto): GqlEventAttendee {
   const role = match(attendee.role)
-    .with(AttendeeRole.MAINTAINER, () => GqlAttendeeRole.Maintainer)
-    .with(AttendeeRole.USER, () => GqlAttendeeRole.User)
+    .with(AttendeeRole.CREATOR, () => GqlAttendeeRole.Creator)
+    .with(AttendeeRole.ADMIN, () => GqlAttendeeRole.Admin)
+    .with(AttendeeRole.PARTICIPANT, () => GqlAttendeeRole.Participant)
     .exhaustive()
 
   return {

--- a/apps/api/src/event/infrastructure/event.schema.ts
+++ b/apps/api/src/event/infrastructure/event.schema.ts
@@ -1,5 +1,6 @@
 import { PaginationFiltersSchema } from '@wishlist/api/core/graphql'
 import { type AttendeeId, AttendeeRole, type EventId, type UserId } from '@wishlist/common'
+import { match } from 'ts-pattern'
 import z from 'zod'
 
 import {
@@ -15,9 +16,9 @@ export const EventIdSchema = z.string().transform(val => val as EventId)
 export const AttendeeIdSchema = z.string().transform(val => val as AttendeeId)
 export const UserIdSchema = z.string().transform(val => val as UserId)
 
-// The GraphQL AttendeeRole enum wire values (MAINTAINER / USER) map to the
-// domain AttendeeRole enum values (maintainer / user).
-const GqlAttendeeRoleSchema = z.enum(GqlAttendeeRole)
+// The GraphQL AttendeeRole enum wire values (CREATOR / ADMIN / PARTICIPANT) map to the
+// domain AttendeeRole enum values (creator / admin / participant).
+export const GqlAttendeeRoleSchema = z.enum(GqlAttendeeRole)
 
 export const EventPaginationFiltersSchema = PaginationFiltersSchema.extend({
   onlyFuture: z.boolean().default(false),
@@ -63,8 +64,14 @@ export const AddEventAttendeeInputSchema = z.object({
   role: GqlAttendeeRoleSchema.optional(),
 }) satisfies z.ZodType<AddEventAttendeeInput>
 
-// Maps GraphQL enum value (MAINTAINER / USER) to the domain AttendeeRole enum.
+// Maps GraphQL enum value (CREATOR / ADMIN / PARTICIPANT) to the domain AttendeeRole enum.
+export function toDomainAttendeeRole(role: GqlAttendeeRole): AttendeeRole
+export function toDomainAttendeeRole(role?: GqlAttendeeRole): AttendeeRole | undefined
 export function toDomainAttendeeRole(role?: GqlAttendeeRole): AttendeeRole | undefined {
   if (!role) return undefined
-  return role === GqlAttendeeRole.Maintainer ? AttendeeRole.MAINTAINER : AttendeeRole.USER
+  return match(role)
+    .with(GqlAttendeeRole.Creator, () => AttendeeRole.CREATOR)
+    .with(GqlAttendeeRole.Admin, () => AttendeeRole.ADMIN)
+    .with(GqlAttendeeRole.Participant, () => AttendeeRole.PARTICIPANT)
+    .exhaustive()
 }

--- a/apps/api/src/event/infrastructure/resolvers/event-mutation.resolver.int-spec.ts
+++ b/apps/api/src/event/infrastructure/resolvers/event-mutation.resolver.int-spec.ts
@@ -106,7 +106,7 @@ describe('EventMutationResolver (GraphQL)', () => {
         await expectTable(Fixtures.EVENT_ATTENDEE_TABLE).hasNumberOfRows(1).row(0).toMatchObject({
           event_id: res.body.data.createEvent.id,
           user_id: currentUserId,
-          role: 'maintainer',
+          role: 'creator',
         })
       })
 
@@ -120,7 +120,7 @@ describe('EventMutationResolver (GraphQL)', () => {
               input: {
                 title: 'New Year',
                 eventDate,
-                attendees: [{ email: 'invited@test.com', role: 'USER' }],
+                attendees: [{ email: 'invited@test.com', role: 'PARTICIPANT' }],
               },
             },
           })
@@ -405,7 +405,7 @@ describe('EventMutationResolver (GraphQL)', () => {
           .post(GRAPHQL_PATH)
           .send({
             query: mutation,
-            variables: { eventId, input: { email: 'invited@test.com', role: 'USER' } },
+            variables: { eventId, input: { email: 'invited@test.com', role: 'PARTICIPANT' } },
           })
           .expect(200)
 
@@ -413,7 +413,7 @@ describe('EventMutationResolver (GraphQL)', () => {
           __typename: 'EventAttendee',
           id: expect.toBeString(),
           pendingEmail: 'invited@test.com',
-          role: 'USER',
+          role: 'PARTICIPANT',
         })
 
         // 1 maintainer + 1 new attendee
@@ -527,7 +527,7 @@ describe('EventMutationResolver (GraphQL)', () => {
         // Only the maintainer attendee remains
         await expectTable(Fixtures.EVENT_ATTENDEE_TABLE).hasNumberOfRows(1).row(0).toMatchObject({
           user_id: currentUserId,
-          role: 'maintainer',
+          role: 'creator',
         })
       })
 
@@ -570,6 +570,90 @@ describe('EventMutationResolver (GraphQL)', () => {
         expect(res.body.data.removeEventAttendee.__typename).toBe('UnauthorizedRejection')
 
         await expectTable(Fixtures.EVENT_ATTENDEE_TABLE).hasNumberOfRows(2)
+      })
+    })
+  })
+
+  describe('Mutation updateEventAttendeeRole', () => {
+    const mutation = /* GraphQL */ `
+      mutation UpdateEventAttendeeRole($eventId: EventId!, $attendeeId: AttendeeId!, $role: AttendeeRole!) {
+        updateEventAttendeeRole(eventId: $eventId, attendeeId: $attendeeId, role: $role) {
+          __typename
+          ... on VoidOutput {
+            success
+          }
+          ... on UnauthorizedRejection {
+            message
+          }
+        }
+      }
+    `
+
+    it('should not succeed when not authenticated', async () => {
+      const request = await getRequest()
+      const res = await request
+        .post(GRAPHQL_PATH)
+        .send({ query: mutation, variables: { eventId: uuid(), attendeeId: uuid(), role: 'ADMIN' } })
+        .expect(200)
+
+      expect(res.body.data?.updateEventAttendeeRole?.__typename).not.toBe('VoidOutput')
+    })
+
+    describe('when user is authenticated', () => {
+      let request: RequestApp
+      let currentUserId: string
+
+      beforeEach(async () => {
+        request = await getRequest({ signedAs: 'BASE_USER' })
+        currentUserId = await fixtures.getSignedUserId('BASE_USER')
+      })
+
+      it('should update an attendee role when the user is creator', async () => {
+        const { eventId } = await fixtures.insertEventWithMaintainer({
+          title: 'Event',
+          maintainerId: currentUserId,
+        })
+        const attendeeId = await fixtures.insertPendingAttendee({
+          eventId,
+          tempUserEmail: 'pending@test.com',
+        })
+
+        const res = await request
+          .post(GRAPHQL_PATH)
+          .send({ query: mutation, variables: { eventId, attendeeId, role: 'ADMIN' } })
+          .expect(200)
+
+        expect(res.body.data.updateEventAttendeeRole).toEqual({ __typename: 'VoidOutput', success: true })
+
+        await expectTable(Fixtures.EVENT_ATTENDEE_TABLE).hasNumberOfRows(2).row(1).toMatchObject({
+          id: attendeeId,
+          role: 'admin',
+        })
+      })
+
+      it('should return UnauthorizedRejection when the user is not a creator or admin', async () => {
+        const otherUserId = await fixtures.insertUser({
+          email: 'other@test.com',
+          firstname: 'Other',
+          lastname: 'User',
+        })
+
+        const { eventId } = await fixtures.insertEventWithMaintainer({
+          title: 'Other Event',
+          maintainerId: otherUserId,
+        })
+
+        const attendeeId = await fixtures.insertPendingAttendee({
+          eventId,
+          tempUserEmail: 'pending@test.com',
+        })
+
+        const res = await request
+          .post(GRAPHQL_PATH)
+          .send({ query: mutation, variables: { eventId, attendeeId, role: 'ADMIN' } })
+          .expect(200)
+
+        expect(res.body.data.updateEventAttendeeRole.__typename).toBe('UnauthorizedRejection')
       })
     })
   })

--- a/apps/api/src/event/infrastructure/resolvers/event-mutation.resolver.ts
+++ b/apps/api/src/event/infrastructure/resolvers/event-mutation.resolver.ts
@@ -12,7 +12,9 @@ import {
   type CreateEventInput,
   type CreateEventResult,
   type DeleteEventResult,
+  AttendeeRole as GqlAttendeeRole,
   type RemoveEventAttendeeResult,
+  type UpdateEventAttendeeRoleResult,
   type UpdateEventInput,
   type UpdateEventResult,
 } from '../../../gql/generated-types'
@@ -20,6 +22,7 @@ import { AddAttendeeUseCase } from '../../application/command/add-attendee.use-c
 import { CreateEventUseCase } from '../../application/command/create-event.use-case'
 import { DeleteAttendeeUseCase } from '../../application/command/delete-attendee.use-case'
 import { DeleteEventUseCase } from '../../application/command/delete-event.use-case'
+import { UpdateAttendeeRoleUseCase } from '../../application/command/update-attendee-role.use-case'
 import { UpdateEventUseCase } from '../../application/command/update-event.use-case'
 import { eventMapper } from '../event.mapper'
 import {
@@ -27,6 +30,7 @@ import {
   AttendeeIdSchema,
   CreateEventInputSchema,
   EventIdSchema,
+  GqlAttendeeRoleSchema,
   toDomainAttendeeRole,
   UpdateEventInputSchema,
 } from '../event.schema'
@@ -39,6 +43,7 @@ export class EventMutationResolver {
     private readonly deleteEventUseCase: DeleteEventUseCase,
     private readonly addAttendeeUseCase: AddAttendeeUseCase,
     private readonly deleteAttendeeUseCase: DeleteAttendeeUseCase,
+    private readonly updateAttendeeRoleUseCase: UpdateAttendeeRoleUseCase,
   ) {}
 
   @Mutation()
@@ -124,6 +129,22 @@ export class EventMutationResolver {
     @GqlCurrentUser() currentUser: ICurrentUser,
   ): Promise<RemoveEventAttendeeResult> {
     await this.deleteAttendeeUseCase.execute({ currentUser, eventId, attendeeId })
+    return { __typename: 'VoidOutput', success: true }
+  }
+
+  @Mutation()
+  async updateEventAttendeeRole(
+    @Args('eventId', new ZodPipe(EventIdSchema)) eventId: EventId,
+    @Args('attendeeId', new ZodPipe(AttendeeIdSchema)) attendeeId: AttendeeId,
+    @Args('role', new ZodPipe(GqlAttendeeRoleSchema)) role: GqlAttendeeRole,
+    @GqlCurrentUser() currentUser: ICurrentUser,
+  ): Promise<UpdateEventAttendeeRoleResult> {
+    await this.updateAttendeeRoleUseCase.execute({
+      currentUser,
+      eventId,
+      attendeeId,
+      role: toDomainAttendeeRole(role),
+    })
     return { __typename: 'VoidOutput', success: true }
   }
 }

--- a/apps/api/src/event/infrastructure/resolvers/event.resolver.int-spec.ts
+++ b/apps/api/src/event/infrastructure/resolvers/event.resolver.int-spec.ts
@@ -190,7 +190,7 @@ describe('EventResolver (GraphQL)', () => {
 
         const maintainerAttendee = event.attendees.find((a: { id: string }) => a.id === attendeeId)
         expect(maintainerAttendee).toMatchObject({
-          role: 'MAINTAINER',
+          role: 'CREATOR',
           user: {
             id: currentUserId,
             email: Fixtures.BASE_USER_EMAIL,
@@ -199,7 +199,7 @@ describe('EventResolver (GraphQL)', () => {
 
         const guestAttendee = event.attendees.find((a: { id: string }) => a.id === secondAttendeeId)
         expect(guestAttendee).toMatchObject({
-          role: 'USER',
+          role: 'PARTICIPANT',
           user: {
             id: secondUserId,
             email: 'guest@test.fr',

--- a/apps/api/src/gql/generated-types.ts
+++ b/apps/api/src/gql/generated-types.ts
@@ -114,8 +114,9 @@ export type AdminWishlistPaginationFilters = {
 };
 
 export enum AttendeeRole {
-  Maintainer = 'MAINTAINER',
-  User = 'USER'
+  Admin = 'ADMIN',
+  Creator = 'CREATOR',
+  Participant = 'PARTICIPANT'
 }
 
 export enum BusinessRuleCode {
@@ -387,6 +388,7 @@ export type Mutation = {
   unlinkCurrentUserSocial: UnlinkCurrentUserSocialResult;
   unlinkWishlistFromEvent: UnlinkWishlistFromEventResult;
   updateEvent: UpdateEventResult;
+  updateEventAttendeeRole: UpdateEventAttendeeRoleResult;
   updateItem: UpdateItemResult;
   updateSecretSanta: UpdateSecretSantaResult;
   updateSecretSantaUser: UpdateSecretSantaUserResult;
@@ -595,6 +597,13 @@ export type MutationUnlinkWishlistFromEventArgs = {
 export type MutationUpdateEventArgs = {
   id: Scalars['EventId']['input'];
   input: UpdateEventInput;
+};
+
+
+export type MutationUpdateEventAttendeeRoleArgs = {
+  attendeeId: Scalars['AttendeeId']['input'];
+  eventId: Scalars['EventId']['input'];
+  role: AttendeeRole;
 };
 
 
@@ -850,6 +859,8 @@ export type UnauthorizedRejection = {
 export type UnlinkCurrentUserSocialResult = ForbiddenRejection | InternalErrorRejection | UnauthorizedRejection | ValidationRejection | VoidOutput;
 
 export type UnlinkWishlistFromEventResult = ForbiddenRejection | InternalErrorRejection | NotFoundRejection | UnauthorizedRejection | ValidationRejection | VoidOutput;
+
+export type UpdateEventAttendeeRoleResult = ForbiddenRejection | InternalErrorRejection | NotFoundRejection | UnauthorizedRejection | ValidationRejection | VoidOutput;
 
 export type UpdateEventInput = {
   description?: InputMaybe<Scalars['String']['input']>;

--- a/apps/api/src/item/infrastructure/item.controller.int-spec.ts
+++ b/apps/api/src/item/infrastructure/item.controller.int-spec.ts
@@ -695,7 +695,7 @@ describe('ItemController', () => {
         await fixtures.insertActiveAttendee({
           eventId: oldEventId,
           userId: otherUserId,
-          role: AttendeeRole.USER,
+          role: AttendeeRole.PARTICIPANT,
         })
 
         // Create old wishlist
@@ -846,7 +846,7 @@ describe('ItemController', () => {
         await fixtures.insertActiveAttendee({
           eventId,
           userId: otherUserId,
-          role: AttendeeRole.USER,
+          role: AttendeeRole.PARTICIPANT,
         })
 
         const wishlistId = await fixtures.insertWishlist({
@@ -1096,7 +1096,7 @@ describe('ItemController', () => {
         await fixtures.insertActiveAttendee({
           eventId,
           userId: currentUserId,
-          role: AttendeeRole.USER,
+          role: AttendeeRole.PARTICIPANT,
         })
 
         const wishlistId = await fixtures.insertWishlist({
@@ -1380,7 +1380,7 @@ describe('ItemController', () => {
         await fixtures.insertActiveAttendee({
           eventId,
           userId: otherUserId,
-          role: AttendeeRole.USER,
+          role: AttendeeRole.PARTICIPANT,
         })
 
         const wishlistId = await fixtures.insertWishlist({
@@ -1425,13 +1425,13 @@ describe('ItemController', () => {
         await fixtures.insertActiveAttendee({
           eventId,
           userId: currentUserId,
-          role: AttendeeRole.USER,
+          role: AttendeeRole.PARTICIPANT,
         })
 
         await fixtures.insertActiveAttendee({
           eventId,
           userId: thirdUserId,
-          role: AttendeeRole.USER,
+          role: AttendeeRole.PARTICIPANT,
         })
 
         const wishlistId = await fixtures.insertWishlist({
@@ -1476,7 +1476,7 @@ describe('ItemController', () => {
         await fixtures.insertActiveAttendee({
           eventId,
           userId: currentUserId,
-          role: AttendeeRole.USER,
+          role: AttendeeRole.PARTICIPANT,
         })
 
         const wishlistId = await fixtures.insertWishlist({
@@ -1630,7 +1630,7 @@ describe('ItemController', () => {
         await fixtures.insertActiveAttendee({
           eventId,
           userId: otherUserId,
-          role: AttendeeRole.USER,
+          role: AttendeeRole.PARTICIPANT,
         })
 
         const wishlistId = await fixtures.insertWishlist({
@@ -1672,13 +1672,13 @@ describe('ItemController', () => {
         await fixtures.insertActiveAttendee({
           eventId,
           userId: currentUserId,
-          role: AttendeeRole.USER,
+          role: AttendeeRole.PARTICIPANT,
         })
 
         await fixtures.insertActiveAttendee({
           eventId,
           userId: thirdUserId,
-          role: AttendeeRole.USER,
+          role: AttendeeRole.PARTICIPANT,
         })
 
         const wishlistId = await fixtures.insertWishlist({
@@ -1724,7 +1724,7 @@ describe('ItemController', () => {
         await fixtures.insertActiveAttendee({
           eventId,
           userId: currentUserId,
-          role: AttendeeRole.USER,
+          role: AttendeeRole.PARTICIPANT,
         })
 
         const wishlistId = await fixtures.insertWishlist({
@@ -1768,7 +1768,7 @@ describe('ItemController', () => {
         await fixtures.insertActiveAttendee({
           eventId,
           userId: otherUserId,
-          role: AttendeeRole.USER,
+          role: AttendeeRole.PARTICIPANT,
         })
 
         const wishlistId = await fixtures.insertWishlist({
@@ -1835,7 +1835,7 @@ describe('ItemController', () => {
         await fixtures.insertActiveAttendee({
           eventId,
           userId: currentUserId,
-          role: AttendeeRole.USER,
+          role: AttendeeRole.PARTICIPANT,
         })
 
         const wishlistId = await fixtures.insertWishlist({
@@ -1889,7 +1889,7 @@ describe('ItemController', () => {
         await fixtures.insertActiveAttendee({
           eventId,
           userId: currentUserId,
-          role: AttendeeRole.USER,
+          role: AttendeeRole.PARTICIPANT,
         })
 
         const wishlistId = await fixtures.insertWishlist({
@@ -1970,7 +1970,7 @@ describe('ItemController', () => {
         await fixtures.insertActiveAttendee({
           eventId,
           userId: otherUserId,
-          role: AttendeeRole.USER,
+          role: AttendeeRole.PARTICIPANT,
         })
 
         const wishlistId = await fixtures.insertWishlist({
@@ -2042,13 +2042,13 @@ describe('ItemController', () => {
         await fixtures.insertActiveAttendee({
           eventId,
           userId: currentUserId,
-          role: AttendeeRole.USER,
+          role: AttendeeRole.PARTICIPANT,
         })
 
         await fixtures.insertActiveAttendee({
           eventId,
           userId: thirdUserId,
-          role: AttendeeRole.USER,
+          role: AttendeeRole.PARTICIPANT,
         })
 
         const wishlistId = await fixtures.insertWishlist({

--- a/apps/api/src/item/infrastructure/item.resolver.int-spec.ts
+++ b/apps/api/src/item/infrastructure/item.resolver.int-spec.ts
@@ -288,7 +288,7 @@ describe('ItemResolver (GraphQL)', () => {
         await fixtures.insertActiveAttendee({
           eventId,
           userId: currentUserId,
-          role: AttendeeRole.USER,
+          role: AttendeeRole.PARTICIPANT,
         })
 
         const wishlistId = await fixtures.insertWishlist({
@@ -723,7 +723,7 @@ describe('ItemResolver (GraphQL)', () => {
         await fixtures.insertActiveAttendee({
           eventId,
           userId: currentUserId,
-          role: AttendeeRole.USER,
+          role: AttendeeRole.PARTICIPANT,
         })
 
         const wishlistId = await fixtures.insertWishlist({
@@ -764,7 +764,7 @@ describe('ItemResolver (GraphQL)', () => {
         await fixtures.insertActiveAttendee({
           eventId,
           userId: currentUserId,
-          role: AttendeeRole.USER,
+          role: AttendeeRole.PARTICIPANT,
         })
 
         const wishlistId = await fixtures.insertWishlist({

--- a/apps/api/src/secret-santa/infrastructure/controllers/secret-santa.controller.int-spec.ts
+++ b/apps/api/src/secret-santa/infrastructure/controllers/secret-santa.controller.int-spec.ts
@@ -166,7 +166,7 @@ describe('SecretSantaController', () => {
         .expect(({ body }) => {
           expect(body).toEqual({
             id: targetAttendeeId,
-            role: 'user',
+            role: 'participant',
             user: {
               id: targetUserId,
               email: 'target@test.fr',
@@ -676,7 +676,7 @@ describe('SecretSantaController', () => {
                 id: expect.toBeString(),
                 attendee: {
                   id: attendee2Id,
-                  role: 'user',
+                  role: 'participant',
                   user: {
                     id: user2Id,
                     email: 'user2@test.fr',

--- a/apps/api/src/secret-santa/infrastructure/resolvers/secret-santa.resolver.int-spec.ts
+++ b/apps/api/src/secret-santa/infrastructure/resolvers/secret-santa.resolver.int-spec.ts
@@ -217,7 +217,7 @@ describe('SecretSantaResolver (GraphQL)', () => {
       expect(res.body.data.mySecretSantaDraw).toMatchObject({
         __typename: 'EventAttendee',
         id: targetAttendeeId,
-        role: 'USER',
+        role: 'PARTICIPANT',
         user: {
           id: targetUserId,
           email: 'target@test.fr',
@@ -924,7 +924,7 @@ describe('SecretSantaResolver (GraphQL)', () => {
             exclusions: [],
             attendee: {
               id: attendee2Id,
-              role: 'USER',
+              role: 'PARTICIPANT',
               user: {
                 id: user2Id,
                 email: 'user2@test.fr',

--- a/apps/api/src/secret-santa/infrastructure/secret-santa.gql-mapper.ts
+++ b/apps/api/src/secret-santa/infrastructure/secret-santa.gql-mapper.ts
@@ -43,8 +43,9 @@ function toGqlSecretSanta(dto: SecretSantaDto): GqlSecretSanta {
 
 function toGqlSecretSantaDraw(attendee: AttendeeDto): GqlEventAttendee {
   const role = match(attendee.role)
-    .with(AttendeeRole.MAINTAINER, () => GqlAttendeeRole.Maintainer)
-    .with(AttendeeRole.USER, () => GqlAttendeeRole.User)
+    .with(AttendeeRole.CREATOR, () => GqlAttendeeRole.Creator)
+    .with(AttendeeRole.ADMIN, () => GqlAttendeeRole.Admin)
+    .with(AttendeeRole.PARTICIPANT, () => GqlAttendeeRole.Participant)
     .exhaustive()
 
   return {

--- a/apps/api/test-utils/fixtures.ts
+++ b/apps/api/test-utils/fixtures.ts
@@ -132,6 +132,19 @@ export class Fixtures {
     return id
   }
 
+  async insertEventWithCreator(parameters: {
+    title: string
+    description?: string
+    icon?: string
+    eventDate?: Date
+    creatorId: string
+  }): Promise<{ eventId: string; attendeeId: string; eventDate: DateTime }> {
+    const eventDate = parameters.eventDate ?? DateTime.now().plus({ days: 30 }).toJSDate()
+    const eventId = await this.insertEvent({ ...parameters, eventDate })
+    const attendeeId = await this.insertCreatorAttendee({ eventId, userId: parameters.creatorId })
+    return { eventId, attendeeId, eventDate: DateTime.fromJSDate(eventDate) }
+  }
+
   async insertEventWithMaintainer(parameters: {
     title: string
     description?: string
@@ -139,10 +152,7 @@ export class Fixtures {
     eventDate?: Date
     maintainerId: string
   }): Promise<{ eventId: string; attendeeId: string; eventDate: DateTime }> {
-    const eventDate = parameters.eventDate ?? DateTime.now().plus({ days: 30 }).toJSDate()
-    const eventId = await this.insertEvent({ ...parameters, eventDate })
-    const attendeeId = await this.insertMaintainerAttendee({ eventId, userId: parameters.maintainerId })
-    return { eventId, attendeeId, eventDate: DateTime.fromJSDate(eventDate) }
+    return await this.insertEventWithCreator({ ...parameters, creatorId: parameters.maintainerId })
   }
 
   async insertWishlist(parameters: {
@@ -181,7 +191,7 @@ export class Fixtures {
 
     await this.sql.unsafe(
       `INSERT INTO ${Fixtures.EVENT_ATTENDEE_TABLE} (id, event_id, temp_user_email, role) VALUES ($1, $2, $3, $4)`,
-      [id, eventId, tempUserEmail, role ?? AttendeeRole.USER],
+      [id, eventId, tempUserEmail, role ?? AttendeeRole.PARTICIPANT],
     )
 
     return id
@@ -193,18 +203,30 @@ export class Fixtures {
 
     await this.sql.unsafe(
       `INSERT INTO ${Fixtures.EVENT_ATTENDEE_TABLE} (id, event_id, user_id, role) VALUES ($1, $2, $3, $4)`,
-      [id, eventId, userId, role ?? AttendeeRole.USER],
+      [id, eventId, userId, role ?? AttendeeRole.PARTICIPANT],
     )
 
     return id
   }
 
-  insertMaintainerAttendee(parameters: { eventId: string; userId: string }): Promise<string> {
+  insertCreatorAttendee(parameters: { eventId: string; userId: string }): Promise<string> {
     return this.insertActiveAttendee({
       eventId: parameters.eventId,
       userId: parameters.userId,
-      role: AttendeeRole.MAINTAINER,
+      role: AttendeeRole.CREATOR,
     })
+  }
+
+  insertAdminAttendee(parameters: { eventId: string; userId: string }): Promise<string> {
+    return this.insertActiveAttendee({
+      eventId: parameters.eventId,
+      userId: parameters.userId,
+      role: AttendeeRole.ADMIN,
+    })
+  }
+
+  insertMaintainerAttendee(parameters: { eventId: string; userId: string }): Promise<string> {
+    return this.insertCreatorAttendee(parameters)
   }
 
   async insertUserPasswordVerification(parameters: {

--- a/apps/front/src/components/event/AttendeeRoleChip.tsx
+++ b/apps/front/src/components/event/AttendeeRoleChip.tsx
@@ -1,0 +1,117 @@
+import type { MouseEvent } from 'react'
+
+import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown'
+import { Chip, Menu, MenuItem, Stack, styled } from '@mui/material'
+import { useState } from 'react'
+import { match } from 'ts-pattern'
+
+import { AttendeeRole } from '../../gql'
+import { ASSIGNABLE_ATTENDEE_ROLES, getAttendeeRoleIcon, getAttendeeRoleLabel } from './attendee-role'
+
+export type AttendeeRoleChipProps = {
+  role: AttendeeRole
+  editable?: boolean
+  disabled?: boolean
+  onRoleChange?: (role: AttendeeRole) => void
+}
+
+const RoleChip = styled(Chip, { shouldForwardProp: prop => prop !== 'roleVariant' })<{
+  roleVariant: AttendeeRole
+}>(({ theme, roleVariant }) => ({
+  height: 24,
+  fontWeight: 600,
+  fontSize: '0.75rem',
+  maxWidth: '100%',
+  alignSelf: 'center',
+  ...match(roleVariant)
+    .with(AttendeeRole.Creator, () => ({
+      backgroundColor: '#fef3c7',
+      color: '#b45309',
+      border: '1px solid #fcd34d',
+    }))
+    .with(AttendeeRole.Admin, () => ({
+      backgroundColor: '#e0f2fe',
+      color: theme.palette.primary.main,
+      border: '1px solid #7dd3fc',
+    }))
+    .with(AttendeeRole.Participant, () => ({
+      backgroundColor: theme.palette.grey[100],
+      color: theme.palette.text.secondary,
+      border: `1px solid ${theme.palette.grey[300]}`,
+    }))
+    .exhaustive(),
+  '& .MuiChip-label': {
+    display: 'flex',
+    alignItems: 'center',
+    lineHeight: 1,
+    paddingLeft: theme.spacing(1),
+    paddingRight: theme.spacing(1),
+  },
+}))
+
+const ChipLabel = styled('span')({
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: 2,
+})
+
+const DropdownIcon = styled(KeyboardArrowDownIcon)({
+  fontSize: 16,
+  display: 'block',
+})
+
+export const AttendeeRoleChip = ({ role, editable = false, disabled = false, onRoleChange }: AttendeeRoleChipProps) => {
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null)
+  const canOpenMenu = editable && !disabled && !!onRoleChange
+
+  const openMenu = (event: MouseEvent<HTMLElement>) => {
+    event.stopPropagation()
+    if (canOpenMenu) setAnchorEl(event.currentTarget)
+  }
+
+  return (
+    <>
+      <RoleChip
+        roleVariant={role}
+        size="small"
+        label={
+          <ChipLabel>
+            {getAttendeeRoleLabel(role)}
+            {canOpenMenu ? <DropdownIcon /> : null}
+          </ChipLabel>
+        }
+        clickable={canOpenMenu}
+        disabled={disabled}
+        onClick={canOpenMenu ? openMenu : undefined}
+      />
+      {canOpenMenu ? (
+        <Menu
+          anchorEl={anchorEl}
+          open={Boolean(anchorEl)}
+          onClose={() => setAnchorEl(null)}
+          anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+          transformOrigin={{ vertical: 'top', horizontal: 'left' }}
+        >
+          {ASSIGNABLE_ATTENDEE_ROLES.map(assignableRole => {
+            const OptionIcon = getAttendeeRoleIcon(assignableRole)
+            return (
+              <MenuItem
+                key={assignableRole}
+                selected={assignableRole === role}
+                onClick={() => {
+                  setAnchorEl(null)
+                  if (assignableRole !== role) onRoleChange?.(assignableRole)
+                }}
+              >
+                <Stack direction="row" alignItems="center" gap={1}>
+                  <OptionIcon fontSize="small" />
+                  {getAttendeeRoleLabel(assignableRole)}
+                </Stack>
+              </MenuItem>
+            )
+          })}
+        </Menu>
+      ) : null}
+    </>
+  )
+}

--- a/apps/front/src/components/event/AttendeeRolesGuide.tsx
+++ b/apps/front/src/components/event/AttendeeRolesGuide.tsx
@@ -1,0 +1,89 @@
+import { Box, Stack, styled, Typography } from '@mui/material'
+
+import { AttendeeRole } from '../../gql'
+import { getAttendeeRoleDescription, getAttendeeRoleIcon, getAttendeeRoleLabel } from './attendee-role'
+import { NewFeatureBadge } from './NewFeatureBadge'
+
+const ROLES: AttendeeRole[] = [AttendeeRole.Creator, AttendeeRole.Admin, AttendeeRole.Participant]
+
+const Guide = styled(Box)(({ theme }) => ({
+  position: 'relative',
+  overflow: 'hidden',
+  borderRadius: 16,
+  padding: theme.spacing(2.5),
+  background: `linear-gradient(135deg, ${theme.palette.grey[50]} 0%, #eef6fb 100%)`,
+  border: `1px solid ${theme.palette.grey[200]}`,
+}))
+
+const RoleRow = styled(Stack)(({ theme }) => ({
+  flexDirection: 'row',
+  alignItems: 'flex-start',
+  gap: theme.spacing(1.5),
+}))
+
+const RoleIconWrap = styled(Box)(({ theme }) => ({
+  width: 36,
+  height: 36,
+  flexShrink: 0,
+  borderRadius: 10,
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  backgroundColor: theme.palette.common.white,
+  color: theme.palette.primary.main,
+  boxShadow: '0 1px 3px rgba(37, 83, 118, 0.12)',
+}))
+
+const RoleTitle = styled(Typography)({
+  fontWeight: 700,
+  fontSize: '0.9rem',
+  lineHeight: 1.3,
+})
+
+const RoleDescription = styled(Typography)(({ theme }) => ({
+  color: theme.palette.text.secondary,
+  fontSize: '0.8rem',
+  lineHeight: 1.45,
+}))
+
+export const AttendeeRolesGuide = () => {
+  return (
+    <Guide>
+      <Stack gap={2}>
+        <Stack
+          direction={{ xs: 'column', sm: 'row' }}
+          alignItems={{ xs: 'flex-start', sm: 'center' }}
+          justifyContent="space-between"
+          gap={1}
+        >
+          <Box>
+            <Typography fontWeight={700} fontSize="1rem">
+              Les rôles des participants
+            </Typography>
+            <Typography color="text.secondary" fontSize="0.85rem">
+              Chaque personne invitée a un rôle, qui définit ce qu’elle peut faire sur l’événement.
+            </Typography>
+          </Box>
+          <NewFeatureBadge />
+        </Stack>
+
+        <Stack gap={1.5}>
+          {ROLES.map(role => {
+            const Icon = getAttendeeRoleIcon(role)
+            return (
+              <RoleRow key={role}>
+                <RoleIconWrap>
+                  <Icon fontSize="small" />
+                </RoleIconWrap>
+                <Box>
+                  <RoleTitle>{getAttendeeRoleLabel(role)}</RoleTitle>
+                  <RoleDescription>{getAttendeeRoleDescription(role)}</RoleDescription>
+                </Box>
+              </RoleRow>
+            )
+          })}
+        </Stack>
+      </Stack>
+    </Guide>
+  )
+}

--- a/apps/front/src/components/event/CreateEventPage.tsx
+++ b/apps/front/src/components/event/CreateEventPage.tsx
@@ -13,8 +13,6 @@ import {
   Divider,
   IconButton,
   List,
-  ListItem,
-  ListItemButton,
   Stack,
   Step,
   StepLabel,
@@ -38,7 +36,8 @@ import { Subtitle } from '../common/Subtitle'
 import { TextareaMarkdown } from '../common/TextareaMarkdown'
 import { Title } from '../common/Title'
 import { SearchUserSelect } from '../user/SearchUserSelect'
-import { ListItemAttendee } from './ListItemAttendee'
+import { AttendeeRolesGuide } from './AttendeeRolesGuide'
+import { AttendeeListItem, ListItemAttendee } from './ListItemAttendee'
 
 const steps = ['Informations', 'Participants']
 
@@ -142,10 +141,7 @@ export const CreateEventPage = () => {
           ))}
         </Stepper>
       </Box>
-      <Container
-        maxWidth={step === 1 ? 'md' : 'sm'}
-        sx={{ marginTop: '40px', transition: 'max-width 0.3s ease-in-out' }}
-      >
+      <Container maxWidth="md" sx={{ marginTop: '40px', transition: 'max-width 0.3s ease-in-out' }}>
         <Card>
           {step === 1 && (
             <Stack component="form" noValidate gap={3}>
@@ -219,8 +215,10 @@ export const CreateEventPage = () => {
           )}
 
           {step === 2 && (
-            <Stack>
-              <Subtitle>Gérer les participants</Subtitle>
+            <Stack gap={2}>
+              <Subtitle sx={{ marginBottom: 0 }}>Gérer les participants</Subtitle>
+
+              <AttendeeRolesGuide />
 
               <Box>
                 {/*TODO: add a way to add all attendees from a specific event
@@ -246,41 +244,60 @@ export const CreateEventPage = () => {
 
               {attendees.length > 0 && (
                 <>
-                  <Divider sx={{ marginTop: '20px', marginBottom: '10px' }} />
+                  <Divider />
 
-                  <List sx={{ maxHeight: '250px', overflow: 'auto' }}>
-                    {attendees.map(attendee => (
-                      <ListItem
-                        className="animated zoomIn fast"
-                        key={typeof attendee.user === 'string' ? attendee.user : attendee.user.id}
-                        disablePadding
-                        secondaryAction={
-                          <IconButton
-                            edge="end"
-                            aria-label="delete"
-                            onClick={() => setAttendees(prev => prev.filter(value => value !== attendee))}
-                          >
-                            <DeleteIcon />
-                          </IconButton>
-                        }
-                      >
-                        <ListItemButton>
+                  <List disablePadding sx={{ maxHeight: '280px', overflow: 'auto' }}>
+                    {attendees.map(attendee => {
+                      const attendeeEmail = typeof attendee.user === 'string' ? attendee.user : attendee.user.email
+                      const attendeeKey = typeof attendee.user === 'string' ? attendee.user : attendee.user.id
+
+                      return (
+                        <AttendeeListItem
+                          className="animated zoomIn fast"
+                          key={attendeeKey}
+                          secondaryAction={
+                            <IconButton
+                              edge="end"
+                              aria-label="delete"
+                              onClick={() =>
+                                setAttendees(prev =>
+                                  prev.filter(value => {
+                                    const valueEmail = typeof value.user === 'string' ? value.user : value.user.email
+                                    return valueEmail !== attendeeEmail
+                                  }),
+                                )
+                              }
+                            >
+                              <DeleteIcon />
+                            </IconButton>
+                          }
+                        >
                           <ListItemAttendee
                             role={attendee.role}
                             userName={
                               typeof attendee.user !== 'string'
-                                ? `${attendee.user?.firstName} ${attendee.user?.lastName}`
+                                ? `${attendee.user.firstName} ${attendee.user.lastName}`
                                 : ''
                             }
                             isPending={typeof attendee.user === 'string'}
-                            email={typeof attendee.user === 'string' ? attendee.user : attendee.user.email}
+                            email={attendeeEmail}
                             pictureUrl={
                               typeof attendee.user !== 'string' ? (attendee.user.pictureUrl ?? undefined) : undefined
                             }
+                            roleEditable
+                            roleDisabled={loading}
+                            onRoleChange={role =>
+                              setAttendees(prev =>
+                                prev.map(value => {
+                                  const valueEmail = typeof value.user === 'string' ? value.user : value.user.email
+                                  return valueEmail === attendeeEmail ? { ...value, role } : value
+                                }),
+                              )
+                            }
                           />
-                        </ListItemButton>
-                      </ListItem>
-                    ))}
+                        </AttendeeListItem>
+                      )
+                    })}
                   </List>
                 </>
               )}

--- a/apps/front/src/components/event/CreateEventPage.tsx
+++ b/apps/front/src/components/event/CreateEventPage.tsx
@@ -235,7 +235,7 @@ export const CreateEventPage = () => {
                     setAttendees(prevState => [
                       {
                         user: val,
-                        role: AttendeeRole.User,
+                        role: AttendeeRole.Participant,
                       },
                       ...prevState,
                     ])

--- a/apps/front/src/components/event/EditEventAttendees.tsx
+++ b/apps/front/src/components/event/EditEventAttendees.tsx
@@ -3,7 +3,7 @@ import type { RootState } from '../../core'
 import type { EventAttendee } from './event.types'
 
 import DeleteIcon from '@mui/icons-material/Delete'
-import { Box, Divider, List, ListItem, ListItemButton } from '@mui/material'
+import { Box, Divider, List, ListItem, ListItemButton, MenuItem, Select, Stack, styled } from '@mui/material'
 import { useQueryClient } from '@tanstack/react-query'
 import { useMemo } from 'react'
 import { useSelector } from 'react-redux'
@@ -15,6 +15,7 @@ import {
   rejectionPattern,
   useAddEventAttendeeMutation,
   useRemoveEventAttendeeMutation,
+  useUpdateEventAttendeeRoleMutation,
 } from '../../gql'
 import { useToast } from '../../hooks'
 import { Card } from '../common/Card'
@@ -29,6 +30,23 @@ export type EditEventAttendeesProps = {
 }
 
 const mapState = (state: RootState) => ({ email: state.auth.user?.email, id: state.auth.user?.id })
+
+const ASSIGNABLE_ROLES = [
+  { value: AttendeeRole.Admin, label: 'Admin' },
+  { value: AttendeeRole.Participant, label: 'Participant' },
+] as const
+
+const AttendeeListItem = styled(ListItem)(({ theme }) => ({
+  '.MuiListItemSecondaryAction-root': {
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(1),
+  },
+}))
+
+const RoleSelect = styled(Select)({
+  minWidth: 140,
+})
 
 export const EditEventAttendees = ({ eventId, attendees }: EditEventAttendeesProps) => {
   const { id: currentUserId, email: currentUserEmail } = useSelector(mapState)
@@ -48,9 +66,12 @@ export const EditEventAttendees = ({ eventId, attendees }: EditEventAttendeesPro
   const { mutateAsync: removeAttendeeMutation, isPending: deleteAttendeePending } = useRemoveEventAttendeeMutation({
     onError: () => addToast({ message: 'Impossible de supprimer ce participant', variant: 'error' }),
   })
+  const { mutateAsync: updateRoleMutation, isPending: updateRolePending } = useUpdateEventAttendeeRoleMutation({
+    onError: () => addToast({ message: 'Impossible de modifier le rôle', variant: 'error' }),
+  })
 
   const addAttendee = async (email: string) => {
-    const res = await addAttendeeMutation({ eventId, input: { email, role: AttendeeRole.User } })
+    const res = await addAttendeeMutation({ eventId, input: { email, role: AttendeeRole.Participant } })
     match(res.addEventAttendee)
       .with({ __typename: 'EventAttendee' }, () => {
         addToast({ message: "Participant ajouté à l'évènement !", variant: 'info' })
@@ -71,9 +92,20 @@ export const EditEventAttendees = ({ eventId, attendees }: EditEventAttendeesPro
       .exhaustive()
   }
 
+  const updateRole = async (attendeeId: AttendeeId, role: AttendeeRole) => {
+    const res = await updateRoleMutation({ eventId, attendeeId, role })
+    match(res.updateEventAttendeeRole)
+      .with({ __typename: 'VoidOutput' }, () => {
+        addToast({ message: 'Rôle mis à jour', variant: 'info' })
+        void invalidateEvent()
+      })
+      .with(rejectionPattern, rejection => addToast({ message: rejectionMessage(rejection), variant: 'error' }))
+      .exhaustive()
+  }
+
   const loading = useMemo(
-    () => addAttendeePending || deleteAttendeePending,
-    [addAttendeePending, deleteAttendeePending],
+    () => addAttendeePending || deleteAttendeePending || updateRolePending,
+    [addAttendeePending, deleteAttendeePending, updateRolePending],
   )
 
   return (
@@ -92,43 +124,70 @@ export const EditEventAttendees = ({ eventId, attendees }: EditEventAttendeesPro
       <Divider sx={{ marginBlock: '20px' }} />
 
       <List>
-        {attendees.map(attendee => (
-          <ListItem
-            key={attendee.id}
-            className="animated zoomIn fast"
-            disablePadding
-            secondaryAction={
-              <ConfirmIconButton
-                disabled={attendee?.user?.id === currentUserId}
-                confirmTitle="Enlever ce participant ?"
-                confirmText={
-                  <>
-                    Êtes-vous sur de retirer le participant{' '}
-                    <b>
-                      {attendee.pendingEmail
-                        ? attendee.pendingEmail
-                        : `${attendee.user?.firstName} ${attendee.user?.lastName}`}
-                    </b>{' '}
-                    de l'évènement ?
-                  </>
-                }
-                onClick={() => deleteAttendee(attendee.id)}
-              >
-                <DeleteIcon />
-              </ConfirmIconButton>
-            }
-          >
-            <ListItemButton>
-              <ListItemAttendee
-                role={attendee.role}
-                userName={`${attendee.user?.firstName} ${attendee.user?.lastName}`}
-                isPending={!!attendee.pendingEmail}
-                email={attendee.pendingEmail ?? attendee.user?.email ?? ''}
-                pictureUrl={attendee.user?.pictureUrl ?? undefined}
-              />
-            </ListItemButton>
-          </ListItem>
-        ))}
+        {attendees.map(attendee => {
+          const isCurrentUser = attendee.user?.id === currentUserId
+          const isCreator = attendee.role === AttendeeRole.Creator
+          const canDelete = !isCurrentUser && !isCreator
+          const canChangeRole = !isCurrentUser && !isCreator
+
+          return (
+            <AttendeeListItem
+              key={attendee.id}
+              className="animated zoomIn fast"
+              disablePadding
+              secondaryAction={
+                <Stack direction="row" alignItems="center" gap={1}>
+                  {canChangeRole ? (
+                    <RoleSelect
+                      size="small"
+                      value={attendee.role}
+                      disabled={loading}
+                      onClick={event => event.stopPropagation()}
+                      onChange={event => {
+                        const role = event.target.value as AttendeeRole
+                        if (role !== attendee.role) void updateRole(attendee.id, role)
+                      }}
+                    >
+                      {ASSIGNABLE_ROLES.map(option => (
+                        <MenuItem key={option.value} value={option.value}>
+                          {option.label}
+                        </MenuItem>
+                      ))}
+                    </RoleSelect>
+                  ) : null}
+                  <ConfirmIconButton
+                    disabled={!canDelete || loading}
+                    confirmTitle="Enlever ce participant ?"
+                    confirmText={
+                      <>
+                        Êtes-vous sur de retirer le participant{' '}
+                        <b>
+                          {attendee.pendingEmail
+                            ? attendee.pendingEmail
+                            : `${attendee.user?.firstName} ${attendee.user?.lastName}`}
+                        </b>{' '}
+                        de l'évènement ?
+                      </>
+                    }
+                    onClick={() => deleteAttendee(attendee.id)}
+                  >
+                    <DeleteIcon />
+                  </ConfirmIconButton>
+                </Stack>
+              }
+            >
+              <ListItemButton>
+                <ListItemAttendee
+                  role={attendee.role}
+                  userName={`${attendee.user?.firstName} ${attendee.user?.lastName}`}
+                  isPending={!!attendee.pendingEmail}
+                  email={attendee.pendingEmail ?? attendee.user?.email ?? ''}
+                  pictureUrl={attendee.user?.pictureUrl ?? undefined}
+                />
+              </ListItemButton>
+            </AttendeeListItem>
+          )
+        })}
       </List>
     </Card>
   )

--- a/apps/front/src/components/event/EditEventAttendees.tsx
+++ b/apps/front/src/components/event/EditEventAttendees.tsx
@@ -3,7 +3,7 @@ import type { RootState } from '../../core'
 import type { EventAttendee } from './event.types'
 
 import DeleteIcon from '@mui/icons-material/Delete'
-import { Box, Divider, List, ListItem, ListItemButton, MenuItem, Select, Stack, styled } from '@mui/material'
+import { Box, Divider, List, Stack } from '@mui/material'
 import { useQueryClient } from '@tanstack/react-query'
 import { useMemo } from 'react'
 import { useSelector } from 'react-redux'
@@ -22,7 +22,8 @@ import { Card } from '../common/Card'
 import { ConfirmIconButton } from '../common/ConfirmIconButton'
 import { Subtitle } from '../common/Subtitle'
 import { SearchUserSelect } from '../user/SearchUserSelect'
-import { ListItemAttendee } from './ListItemAttendee'
+import { AttendeeRolesGuide } from './AttendeeRolesGuide'
+import { AttendeeListItem, ListItemAttendee } from './ListItemAttendee'
 
 export type EditEventAttendeesProps = {
   eventId: EventId
@@ -30,23 +31,6 @@ export type EditEventAttendeesProps = {
 }
 
 const mapState = (state: RootState) => ({ email: state.auth.user?.email, id: state.auth.user?.id })
-
-const ASSIGNABLE_ROLES = [
-  { value: AttendeeRole.Admin, label: 'Admin' },
-  { value: AttendeeRole.Participant, label: 'Participant' },
-] as const
-
-const AttendeeListItem = styled(ListItem)(({ theme }) => ({
-  '.MuiListItemSecondaryAction-root': {
-    display: 'flex',
-    alignItems: 'center',
-    gap: theme.spacing(1),
-  },
-}))
-
-const RoleSelect = styled(Select)({
-  minWidth: 140,
-})
 
 export const EditEventAttendees = ({ eventId, attendees }: EditEventAttendeesProps) => {
   const { id: currentUserId, email: currentUserEmail } = useSelector(mapState)
@@ -109,52 +93,35 @@ export const EditEventAttendees = ({ eventId, attendees }: EditEventAttendeesPro
   )
 
   return (
-    <Card>
-      <Subtitle>Gérer les participants</Subtitle>
+    <Stack gap={2}>
+      <AttendeeRolesGuide />
 
-      <Box>
-        <SearchUserSelect
-          label="Ajouter un nouveau participant à l'évènement ?"
-          disabled={loading}
-          excludedEmails={[...attendeeEmails, currentUserEmail || '']}
-          onChange={value => addAttendee(typeof value === 'string' ? value : value.email)}
-        />
-      </Box>
+      <Card>
+        <Subtitle>Gérer les participants</Subtitle>
 
-      <Divider sx={{ marginBlock: '20px' }} />
+        <Box>
+          <SearchUserSelect
+            label="Ajouter un nouveau participant à l'évènement ?"
+            disabled={loading}
+            excludedEmails={[...attendeeEmails, currentUserEmail || '']}
+            onChange={value => addAttendee(typeof value === 'string' ? value : value.email)}
+          />
+        </Box>
 
-      <List>
-        {attendees.map(attendee => {
-          const isCurrentUser = attendee.user?.id === currentUserId
-          const isCreator = attendee.role === AttendeeRole.Creator
-          const canDelete = !isCurrentUser && !isCreator
-          const canChangeRole = !isCurrentUser && !isCreator
+        <Divider sx={{ marginBlock: '20px' }} />
 
-          return (
-            <AttendeeListItem
-              key={attendee.id}
-              className="animated zoomIn fast"
-              disablePadding
-              secondaryAction={
-                <Stack direction="row" alignItems="center" gap={1}>
-                  {canChangeRole ? (
-                    <RoleSelect
-                      size="small"
-                      value={attendee.role}
-                      disabled={loading}
-                      onClick={event => event.stopPropagation()}
-                      onChange={event => {
-                        const role = event.target.value as AttendeeRole
-                        if (role !== attendee.role) void updateRole(attendee.id, role)
-                      }}
-                    >
-                      {ASSIGNABLE_ROLES.map(option => (
-                        <MenuItem key={option.value} value={option.value}>
-                          {option.label}
-                        </MenuItem>
-                      ))}
-                    </RoleSelect>
-                  ) : null}
+        <List disablePadding>
+          {attendees.map(attendee => {
+            const isCurrentUser = attendee.user?.id === currentUserId
+            const isCreator = attendee.role === AttendeeRole.Creator
+            const canDelete = !isCurrentUser && !isCreator
+            const canChangeRole = !isCurrentUser && !isCreator
+
+            return (
+              <AttendeeListItem
+                key={attendee.id}
+                className="animated zoomIn fast"
+                secondaryAction={
                   <ConfirmIconButton
                     disabled={!canDelete || loading}
                     confirmTitle="Enlever ce participant ?"
@@ -173,22 +140,23 @@ export const EditEventAttendees = ({ eventId, attendees }: EditEventAttendeesPro
                   >
                     <DeleteIcon />
                   </ConfirmIconButton>
-                </Stack>
-              }
-            >
-              <ListItemButton>
+                }
+              >
                 <ListItemAttendee
                   role={attendee.role}
                   userName={`${attendee.user?.firstName} ${attendee.user?.lastName}`}
                   isPending={!!attendee.pendingEmail}
                   email={attendee.pendingEmail ?? attendee.user?.email ?? ''}
                   pictureUrl={attendee.user?.pictureUrl ?? undefined}
+                  roleEditable={canChangeRole}
+                  roleDisabled={loading}
+                  onRoleChange={role => updateRole(attendee.id, role)}
                 />
-              </ListItemButton>
-            </AttendeeListItem>
-          )
-        })}
-      </List>
-    </Card>
+              </AttendeeListItem>
+            )
+          })}
+        </List>
+      </Card>
+    </Stack>
   )
 }

--- a/apps/front/src/components/event/EventMutations.graphql
+++ b/apps/front/src/components/event/EventMutations.graphql
@@ -70,3 +70,12 @@ mutation RemoveEventAttendee($eventId: EventId!, $attendeeId: AttendeeId!) {
     }
   }
 }
+
+mutation UpdateEventAttendeeRole($eventId: EventId!, $attendeeId: AttendeeId!, $role: AttendeeRole!) {
+  updateEventAttendeeRole(eventId: $eventId, attendeeId: $attendeeId, role: $role) {
+    __typename
+    ... on VoidOutput {
+      success
+    }
+  }
+}

--- a/apps/front/src/components/event/EventPage.tsx
+++ b/apps/front/src/components/event/EventPage.tsx
@@ -5,7 +5,7 @@ import { Alert, Box, Container, Stack } from '@mui/material'
 import { useMemo, useState } from 'react'
 import { useSelector } from 'react-redux'
 
-import { AttendeeRole, isRejection, rejectionMessage, useEventPageGetEventQuery } from '../../gql'
+import { isRejection, rejectionMessage, useEventPageGetEventQuery } from '../../gql'
 import { useSecretSantaSuggestion } from '../../hooks'
 import { Description } from '../common/Description'
 import { SEO } from '../SEO'
@@ -14,6 +14,7 @@ import { EventHeader } from './EventHeader'
 import { EventHeaderSkeleton } from './EventHeaderSkeleton'
 import { EventNotFound } from './EventNotFound'
 import { EventWishlists } from './EventWishlists'
+import { canEditEvent } from './event-permissions'
 import { MySecretSantaDraw } from './MySecretSantaDraw'
 import { SecretSantaSuggestionCard } from './SecretSantaSuggestionCard'
 
@@ -31,10 +32,7 @@ export const EventPage = ({ eventId }: EventPageProps) => {
   const queryRejection = data && isRejection(data) && data.__typename !== 'NotFoundRejection' ? data : undefined
 
   const attendees = useMemo(() => event?.attendees ?? [], [event])
-  const currentUserCanEdit = useMemo(
-    () => attendees.some(a => a.user?.id === currentUserId && a.role === AttendeeRole.Maintainer),
-    [attendees, currentUserId],
-  )
+  const currentUserCanEdit = useMemo(() => canEditEvent(attendees, currentUserId), [attendees, currentUserId])
   const { shouldShowSuggestion, dismissSuggestion } = useSecretSantaSuggestion({
     eventId: eventId,
     eventTitle: event?.title,

--- a/apps/front/src/components/event/ListItemAttendee.tsx
+++ b/apps/front/src/components/event/ListItemAttendee.tsx
@@ -1,7 +1,9 @@
 import LocalPoliceOutlinedIcon from '@mui/icons-material/LocalPoliceOutlined'
 import PersonIcon from '@mui/icons-material/Person'
+import WorkspacePremiumOutlinedIcon from '@mui/icons-material/WorkspacePremiumOutlined'
 import { Avatar, ListItemAvatar, ListItemText, Stack, Tooltip } from '@mui/material'
 import { blue, orange } from '@mui/material/colors'
+import { match } from 'ts-pattern'
 
 import { AttendeeRole } from '../../gql'
 
@@ -12,6 +14,21 @@ type ListItemAttendee = {
   pictureUrl?: string
   isPending: boolean
 }
+
+const RoleBadge = ({ role }: { role: AttendeeRole }) =>
+  match(role)
+    .with(AttendeeRole.Creator, () => (
+      <Tooltip title="Créateur">
+        <WorkspacePremiumOutlinedIcon fontSize="small" />
+      </Tooltip>
+    ))
+    .with(AttendeeRole.Admin, () => (
+      <Tooltip title="Admin">
+        <LocalPoliceOutlinedIcon fontSize="small" />
+      </Tooltip>
+    ))
+    .with(AttendeeRole.Participant, () => null)
+    .exhaustive()
 
 export const ListItemAttendee = (params: ListItemAttendee) => {
   const { userName, email, isPending, pictureUrl, role } = params
@@ -31,11 +48,7 @@ export const ListItemAttendee = (params: ListItemAttendee) => {
       <ListItemText
         primary={
           <Stack flexDirection="row" gap={1} alignItems="center">
-            {role === AttendeeRole.Maintainer && (
-              <Tooltip title="Admin de la liste">
-                <LocalPoliceOutlinedIcon fontSize="small" />
-              </Tooltip>
-            )}
+            <RoleBadge role={role} />
             <b>{isPending ? email : userName}</b>
           </Stack>
         }

--- a/apps/front/src/components/event/ListItemAttendee.tsx
+++ b/apps/front/src/components/event/ListItemAttendee.tsx
@@ -1,19 +1,62 @@
 import LocalPoliceOutlinedIcon from '@mui/icons-material/LocalPoliceOutlined'
 import PersonIcon from '@mui/icons-material/Person'
 import WorkspacePremiumOutlinedIcon from '@mui/icons-material/WorkspacePremiumOutlined'
-import { Avatar, ListItemAvatar, ListItemText, Stack, Tooltip } from '@mui/material'
+import { Avatar, ListItem, ListItemAvatar, ListItemText, Stack, styled, Tooltip } from '@mui/material'
 import { blue, orange } from '@mui/material/colors'
 import { match } from 'ts-pattern'
 
 import { AttendeeRole } from '../../gql'
+import { AttendeeRoleChip } from './AttendeeRoleChip'
 
-type ListItemAttendee = {
+type ListItemAttendeeProps = {
   userName: string
   role: AttendeeRole
   email: string
   pictureUrl?: string
   isPending: boolean
+  roleEditable?: boolean
+  roleDisabled?: boolean
+  onRoleChange?: (role: AttendeeRole) => void
 }
+
+export const AttendeeListItem = styled(ListItem)(({ theme }) => ({
+  alignItems: 'center',
+  paddingRight: theme.spacing(7),
+  [theme.breakpoints.down('sm')]: {
+    paddingLeft: 0,
+    paddingRight: theme.spacing(6),
+  },
+  '.MuiListItemSecondaryAction-root': {
+    right: theme.spacing(0.5),
+  },
+}))
+
+const AttendeeText = styled(ListItemText)({
+  minWidth: 0,
+  marginTop: 0,
+  marginBottom: 0,
+})
+
+const NameRow = styled(Stack)(({ theme }) => ({
+  flexDirection: 'row',
+  alignItems: 'center',
+  gap: theme.spacing(1),
+  minWidth: 0,
+}))
+
+const UserName = styled('b')({
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+  minWidth: 0,
+})
+
+const RoleChipSlot = styled('div')(({ theme }) => ({
+  display: 'flex',
+  alignItems: 'center',
+  flexShrink: 0,
+  marginLeft: theme.spacing(1),
+}))
 
 const RoleBadge = ({ role }: { role: AttendeeRole }) =>
   match(role)
@@ -30,8 +73,8 @@ const RoleBadge = ({ role }: { role: AttendeeRole }) =>
     .with(AttendeeRole.Participant, () => null)
     .exhaustive()
 
-export const ListItemAttendee = (params: ListItemAttendee) => {
-  const { userName, email, isPending, pictureUrl, role } = params
+export const ListItemAttendee = (params: ListItemAttendeeProps) => {
+  const { userName, email, isPending, pictureUrl, role, roleEditable, roleDisabled, onRoleChange } = params
   return (
     <>
       <ListItemAvatar>
@@ -45,15 +88,20 @@ export const ListItemAttendee = (params: ListItemAttendee) => {
           <PersonIcon />
         </Avatar>
       </ListItemAvatar>
-      <ListItemText
+      <AttendeeText
+        primaryTypographyProps={{ component: 'div' }}
+        secondaryTypographyProps={{ component: 'span' }}
         primary={
-          <Stack flexDirection="row" gap={1} alignItems="center">
+          <NameRow>
             <RoleBadge role={role} />
-            <b>{isPending ? email : userName}</b>
-          </Stack>
+            <UserName>{isPending ? email : userName}</UserName>
+          </NameRow>
         }
         secondary={isPending ? 'Invitation en attente de validation' : email}
       />
+      <RoleChipSlot>
+        <AttendeeRoleChip role={role} editable={roleEditable} disabled={roleDisabled} onRoleChange={onRoleChange} />
+      </RoleChipSlot>
     </>
   )
 }

--- a/apps/front/src/components/event/ListItemAttendee.tsx
+++ b/apps/front/src/components/event/ListItemAttendee.tsx
@@ -1,11 +1,9 @@
-import LocalPoliceOutlinedIcon from '@mui/icons-material/LocalPoliceOutlined'
-import PersonIcon from '@mui/icons-material/Person'
-import WorkspacePremiumOutlinedIcon from '@mui/icons-material/WorkspacePremiumOutlined'
-import { Avatar, ListItem, ListItemAvatar, ListItemText, Stack, styled, Tooltip } from '@mui/material'
-import { blue, orange } from '@mui/material/colors'
-import { match } from 'ts-pattern'
+import type { AttendeeRole } from '../../gql'
 
-import { AttendeeRole } from '../../gql'
+import PersonIcon from '@mui/icons-material/Person'
+import { Avatar, ListItem, ListItemAvatar, ListItemText, styled } from '@mui/material'
+import { blue, orange } from '@mui/material/colors'
+
 import { AttendeeRoleChip } from './AttendeeRoleChip'
 
 type ListItemAttendeeProps = {
@@ -37,18 +35,12 @@ const AttendeeText = styled(ListItemText)({
   marginBottom: 0,
 })
 
-const NameRow = styled(Stack)(({ theme }) => ({
-  flexDirection: 'row',
-  alignItems: 'center',
-  gap: theme.spacing(1),
-  minWidth: 0,
-}))
-
 const UserName = styled('b')({
   overflow: 'hidden',
   textOverflow: 'ellipsis',
   whiteSpace: 'nowrap',
   minWidth: 0,
+  display: 'block',
 })
 
 const RoleChipSlot = styled('div')(({ theme }) => ({
@@ -57,21 +49,6 @@ const RoleChipSlot = styled('div')(({ theme }) => ({
   flexShrink: 0,
   marginLeft: theme.spacing(1),
 }))
-
-const RoleBadge = ({ role }: { role: AttendeeRole }) =>
-  match(role)
-    .with(AttendeeRole.Creator, () => (
-      <Tooltip title="Créateur">
-        <WorkspacePremiumOutlinedIcon fontSize="small" />
-      </Tooltip>
-    ))
-    .with(AttendeeRole.Admin, () => (
-      <Tooltip title="Admin">
-        <LocalPoliceOutlinedIcon fontSize="small" />
-      </Tooltip>
-    ))
-    .with(AttendeeRole.Participant, () => null)
-    .exhaustive()
 
 export const ListItemAttendee = (params: ListItemAttendeeProps) => {
   const { userName, email, isPending, pictureUrl, role, roleEditable, roleDisabled, onRoleChange } = params
@@ -91,12 +68,7 @@ export const ListItemAttendee = (params: ListItemAttendeeProps) => {
       <AttendeeText
         primaryTypographyProps={{ component: 'div' }}
         secondaryTypographyProps={{ component: 'span' }}
-        primary={
-          <NameRow>
-            <RoleBadge role={role} />
-            <UserName>{isPending ? email : userName}</UserName>
-          </NameRow>
-        }
+        primary={<UserName>{isPending ? email : userName}</UserName>}
         secondary={isPending ? 'Invitation en attente de validation' : email}
       />
       <RoleChipSlot>

--- a/apps/front/src/components/event/NewFeatureBadge.tsx
+++ b/apps/front/src/components/event/NewFeatureBadge.tsx
@@ -1,0 +1,19 @@
+import { Chip, styled } from '@mui/material'
+
+const Badge = styled(Chip)({
+  height: 20,
+  fontSize: '0.65rem',
+  fontWeight: 700,
+  letterSpacing: '0.04em',
+  textTransform: 'uppercase',
+  backgroundColor: '#dcfce7',
+  color: '#15803d',
+  border: '1px solid #86efac',
+  animation: 'newFeaturePulse 2s ease-in-out infinite',
+  '@keyframes newFeaturePulse': {
+    '0%, 100%': { transform: 'scale(1)' },
+    '50%': { transform: 'scale(1.05)' },
+  },
+})
+
+export const NewFeatureBadge = () => <Badge label="Nouveau" size="small" />

--- a/apps/front/src/components/event/admin/AdminEventPage.tsx
+++ b/apps/front/src/components/event/admin/AdminEventPage.tsx
@@ -3,8 +3,8 @@ import type { AttendeeId, EventId, SecretSantaUserId } from '@wishlist/common'
 import { zodResolver } from '@hookform/resolvers/zod'
 import AccessTimeIcon from '@mui/icons-material/AccessTime'
 import DeleteIcon from '@mui/icons-material/Delete'
-import LocalPoliceOutlinedIcon from '@mui/icons-material/LocalPoliceOutlined'
 import SaveIcon from '@mui/icons-material/Save'
+import WorkspacePremiumOutlinedIcon from '@mui/icons-material/WorkspacePremiumOutlined'
 import { Alert, Box, Button, List, ListItem, ListItemIcon, ListItemText, Stack, TextField } from '@mui/material'
 import { styled, useTheme } from '@mui/material/styles'
 import useMediaQuery from '@mui/material/useMediaQuery'
@@ -209,9 +209,9 @@ export const AdminEventPage = ({ eventId }: AdminEventPageProps) => {
       .exhaustive()
   }
 
-  const maintainerName = useMemo(() => {
+  const creatorName = useMemo(() => {
     if (!event) return ''
-    const user = event.attendees.find(attendee => attendee.role === AttendeeRole.Maintainer)
+    const user = event.attendees.find(attendee => attendee.role === AttendeeRole.Creator)
     if (!user) return ''
     return `${user.user?.firstName} ${user.user?.lastName}`
   }, [event])
@@ -267,9 +267,9 @@ export const AdminEventPage = ({ eventId }: AdminEventPageProps) => {
               <List dense sx={{ flexGrow: 1 }}>
                 <ListItem>
                   <ListItemIcon>
-                    <LocalPoliceOutlinedIcon />
+                    <WorkspacePremiumOutlinedIcon />
                   </ListItemIcon>
-                  <ListItemText primary="Maintenu par" secondary={maintainerName} />
+                  <ListItemText primary="Créé par" secondary={creatorName} />
                 </ListItem>
               </List>
 

--- a/apps/front/src/components/event/admin/AdminListAttendees.tsx
+++ b/apps/front/src/components/event/admin/AdminListAttendees.tsx
@@ -9,6 +9,8 @@ import { DataGrid } from '@mui/x-data-grid'
 import { AttendeeRole } from '../../../gql'
 import { ConfirmIconButton } from '../../common/ConfirmIconButton'
 import { RouterLink } from '../../common/RouterLink'
+import { AttendeeRoleChip } from '../AttendeeRoleChip'
+import { getAttendeeRoleLabel } from '../attendee-role'
 
 type AdminListAttendeesProps = {
   attendees: AdminEventAttendee[]
@@ -69,7 +71,11 @@ export const AdminListAttendees = ({ attendees, deleteAttendee, loading = false 
           },
           {
             field: 'role',
+            headerName: 'Rôle',
             width: 150,
+            display: 'flex',
+            valueGetter: (_, row) => getAttendeeRoleLabel(row.role),
+            renderCell: ({ row }) => <AttendeeRoleChip role={row.role} />,
           },
           {
             field: 'pending',

--- a/apps/front/src/components/event/admin/AdminListAttendees.tsx
+++ b/apps/front/src/components/event/admin/AdminListAttendees.tsx
@@ -93,7 +93,7 @@ export const AdminListAttendees = ({ attendees, deleteAttendee, loading = false 
                   confirmTitle="Supprimer le participant"
                   confirmText="Êtes-vous sûr de vouloir supprimer ce participant ?"
                   onClick={() => deleteAttendee(row.id)}
-                  disabled={row.role === AttendeeRole.Maintainer || loading}
+                  disabled={row.role === AttendeeRole.Creator || loading}
                   size="small"
                   color="error"
                 >

--- a/apps/front/src/components/event/admin/AdminListEvents.tsx
+++ b/apps/front/src/components/event/admin/AdminListEvents.tsx
@@ -30,13 +30,13 @@ const columns: GridColDef<AdminEventListItem>[] = [
     renderCell: ({ value }) => DateTime.fromJSDate(value).toLocaleString(DateTime.DATE_SHORT),
   },
   {
-    field: 'maintainer',
-    headerName: 'Maintainer',
+    field: 'creator',
+    headerName: 'Créateur',
     width: 170,
     valueGetter: (_, row) => {
-      const maintainer = row.attendees.find(attendee => attendee.role === AttendeeRole.Maintainer)?.user
-      if (!maintainer) return 'Unknown'
-      return `${maintainer.firstName} ${maintainer.lastName}`
+      const creator = row.attendees.find(attendee => attendee.role === AttendeeRole.Creator)?.user
+      if (!creator) return 'Unknown'
+      return `${creator.firstName} ${creator.lastName}`
     },
   },
   {

--- a/apps/front/src/components/event/attendee-role.ts
+++ b/apps/front/src/components/event/attendee-role.ts
@@ -1,0 +1,35 @@
+import LocalPoliceOutlinedIcon from '@mui/icons-material/LocalPoliceOutlined'
+import PersonOutlineOutlinedIcon from '@mui/icons-material/PersonOutlineOutlined'
+import WorkspacePremiumOutlinedIcon from '@mui/icons-material/WorkspacePremiumOutlined'
+import { match } from 'ts-pattern'
+
+import { AttendeeRole } from '../../gql'
+
+export const ASSIGNABLE_ATTENDEE_ROLES = [AttendeeRole.Admin, AttendeeRole.Participant] as const
+
+export function getAttendeeRoleLabel(role: AttendeeRole): string {
+  return match(role)
+    .with(AttendeeRole.Creator, () => 'Créateur')
+    .with(AttendeeRole.Admin, () => 'Admin')
+    .with(AttendeeRole.Participant, () => 'Participant')
+    .exhaustive()
+}
+
+export function getAttendeeRoleDescription(role: AttendeeRole): string {
+  return match(role)
+    .with(
+      AttendeeRole.Creator,
+      () => 'Unique. Peut tout gérer, y compris supprimer l’événement. Ne peut pas être retiré.',
+    )
+    .with(AttendeeRole.Admin, () => 'Peut tout gérer comme le créateur, sauf retirer ou modifier le créateur.')
+    .with(AttendeeRole.Participant, () => 'Peut consulter l’événement et y ajouter sa liste.')
+    .exhaustive()
+}
+
+export function getAttendeeRoleIcon(role: AttendeeRole) {
+  return match(role)
+    .with(AttendeeRole.Creator, () => WorkspacePremiumOutlinedIcon)
+    .with(AttendeeRole.Admin, () => LocalPoliceOutlinedIcon)
+    .with(AttendeeRole.Participant, () => PersonOutlineOutlinedIcon)
+    .exhaustive()
+}

--- a/apps/front/src/components/event/event-permissions.ts
+++ b/apps/front/src/components/event/event-permissions.ts
@@ -1,0 +1,10 @@
+import type { EventAttendee } from './event.types'
+
+import { AttendeeRole } from '../../gql'
+
+const EDITABLE_ROLES: AttendeeRole[] = [AttendeeRole.Creator, AttendeeRole.Admin]
+
+export function canEditEvent(attendees: EventAttendee[], userId: string | undefined): boolean {
+  if (!userId) return false
+  return attendees.some(attendee => attendee.user?.id === userId && EDITABLE_ROLES.includes(attendee.role))
+}

--- a/apps/front/src/gql/__generated__/graphql.ts
+++ b/apps/front/src/gql/__generated__/graphql.ts
@@ -413,6 +413,30 @@ export const useRemoveEventAttendeeMutation = <
   }
     )};
 
+export const UpdateEventAttendeeRoleDocument = `
+    mutation UpdateEventAttendeeRole($eventId: EventId!, $attendeeId: AttendeeId!, $role: AttendeeRole!) {
+  updateEventAttendeeRole(eventId: $eventId, attendeeId: $attendeeId, role: $role) {
+    __typename
+    ... on VoidOutput {
+      success
+    }
+  }
+}
+    `;
+
+export const useUpdateEventAttendeeRoleMutation = <
+      TError = unknown,
+      TContext = unknown
+    >(options?: UseMutationOptions<Types.UpdateEventAttendeeRoleMutation, TError, Types.UpdateEventAttendeeRoleMutationVariables, TContext>) => {
+    
+    return useMutation<Types.UpdateEventAttendeeRoleMutation, TError, Types.UpdateEventAttendeeRoleMutationVariables, TContext>(
+      {
+    mutationKey: ['UpdateEventAttendeeRole'],
+    mutationFn: (variables?: Types.UpdateEventAttendeeRoleMutationVariables) => fetchGql<Types.UpdateEventAttendeeRoleMutation, Types.UpdateEventAttendeeRoleMutationVariables>(UpdateEventAttendeeRoleDocument, variables)(),
+    ...options
+  }
+    )};
+
 export const EventPageGetEventDocument = `
     query EventPageGetEvent($eventId: EventId!) {
   event(id: $eventId) {

--- a/apps/front/src/gql/__generated__/types.ts
+++ b/apps/front/src/gql/__generated__/types.ts
@@ -109,8 +109,9 @@ export type AdminWishlistPaginationFilters = {
 };
 
 export enum AttendeeRole {
-  Maintainer = 'MAINTAINER',
-  User = 'USER'
+  Admin = 'ADMIN',
+  Creator = 'CREATOR',
+  Participant = 'PARTICIPANT'
 }
 
 export enum BusinessRuleCode {
@@ -384,6 +385,7 @@ export type Mutation = {
   unlinkCurrentUserSocial: UnlinkCurrentUserSocialResult;
   unlinkWishlistFromEvent: UnlinkWishlistFromEventResult;
   updateEvent: UpdateEventResult;
+  updateEventAttendeeRole: UpdateEventAttendeeRoleResult;
   updateItem: UpdateItemResult;
   updateSecretSanta: UpdateSecretSantaResult;
   updateSecretSantaUser: UpdateSecretSantaUserResult;
@@ -592,6 +594,13 @@ export type MutationUnlinkWishlistFromEventArgs = {
 export type MutationUpdateEventArgs = {
   id: Scalars['EventId']['input'];
   input: UpdateEventInput;
+};
+
+
+export type MutationUpdateEventAttendeeRoleArgs = {
+  attendeeId: Scalars['AttendeeId']['input'];
+  eventId: Scalars['EventId']['input'];
+  role: AttendeeRole;
 };
 
 
@@ -849,6 +858,8 @@ export type UnauthorizedRejection = {
 export type UnlinkCurrentUserSocialResult = ForbiddenRejection | InternalErrorRejection | UnauthorizedRejection | ValidationRejection | VoidOutput;
 
 export type UnlinkWishlistFromEventResult = ForbiddenRejection | InternalErrorRejection | NotFoundRejection | UnauthorizedRejection | ValidationRejection | VoidOutput;
+
+export type UpdateEventAttendeeRoleResult = ForbiddenRejection | InternalErrorRejection | NotFoundRejection | UnauthorizedRejection | ValidationRejection | VoidOutput;
 
 export type UpdateEventInput = {
   description?: InputMaybe<Scalars['String']['input']>;
@@ -1149,6 +1160,22 @@ export type RemoveEventAttendeeMutationVariables = Exact<{
 
 
 export type RemoveEventAttendeeMutation = { __typename?: 'Mutation', removeEventAttendee:
+    | { __typename: 'ForbiddenRejection' }
+    | { __typename: 'InternalErrorRejection' }
+    | { __typename: 'NotFoundRejection' }
+    | { __typename: 'UnauthorizedRejection' }
+    | { __typename: 'ValidationRejection' }
+    | { __typename: 'VoidOutput', success: boolean }
+   };
+
+export type UpdateEventAttendeeRoleMutationVariables = Exact<{
+  eventId: Scalars['EventId']['input'];
+  attendeeId: Scalars['AttendeeId']['input'];
+  role: AttendeeRole;
+}>;
+
+
+export type UpdateEventAttendeeRoleMutation = { __typename?: 'Mutation', updateEventAttendeeRole:
     | { __typename: 'ForbiddenRejection' }
     | { __typename: 'InternalErrorRejection' }
     | { __typename: 'NotFoundRejection' }

--- a/apps/front/src/hooks/domain/useSecretSantaSuggestion.ts
+++ b/apps/front/src/hooks/domain/useSecretSantaSuggestion.ts
@@ -159,7 +159,7 @@ interface UseSecretSantaSuggestionProps {
  * Hook to determine if the Secret Santa suggestion card should be displayed
  *
  * Conditions:
- * - User must be a maintainer (currentUserCanEdit = true)
+ * - User must be a creator or admin (currentUserCanEdit = true)
  * - No Secret Santa should exist yet
  * - Event date must be between December 15 and January 1, OR
  * - Event title must contain Christmas-related keywords
@@ -185,7 +185,7 @@ export function useSecretSantaSuggestion({
   }, [eventId])
 
   const shouldShowSuggestion = useMemo(() => {
-    // Must be maintainer
+    // Must be creator or admin
     if (!currentUserCanEdit) return false
 
     // Check if user has dismissed the suggestion

--- a/apps/front/src/routes/_authenticated/_with-layout/events/$eventId/edit.tsx
+++ b/apps/front/src/routes/_authenticated/_with-layout/events/$eventId/edit.tsx
@@ -12,11 +12,12 @@ import { EditEventAttendees } from '@wishlist/front-components/event/EditEventAt
 import { EditEventInformations } from '@wishlist/front-components/event/EditEventInformations'
 import { EditSecretSanta } from '@wishlist/front-components/event/EditSecretSanta'
 import { EventNotFound } from '@wishlist/front-components/event/EventNotFound'
+import { canEditEvent } from '@wishlist/front-components/event/event-permissions'
 import { SEO } from '@wishlist/front-components/SEO'
 import { useSelector } from 'react-redux'
 import z from 'zod'
 
-import { AttendeeRole, isRejection, rejectionMessage, useEventPageGetEventQuery } from '../../../../../gql'
+import { isRejection, rejectionMessage, useEventPageGetEventQuery } from '../../../../../gql'
 
 export enum TabValues {
   informations = 'informations',
@@ -61,8 +62,7 @@ function RouteComponent() {
   const { data, isLoading: loading } = useEventPageGetEventQuery({ eventId }, { select: d => d.event })
   const event = data?.__typename === 'Event' ? data : undefined
   const queryRejection = data && isRejection(data) && data.__typename !== 'NotFoundRejection' ? data : undefined
-  const currentUserCanEdit =
-    event?.attendees.some(a => a.user?.id === currentUserId && a.role === AttendeeRole.Maintainer) ?? false
+  const currentUserCanEdit = canEditEvent(event?.attendees ?? [], currentUserId)
   const navigate = useNavigate({ from: '/events/$eventId/edit' })
 
   const handleTabChange = (newValue: TabValues) => {

--- a/libs/api-client/src/services/event-attendee.service.ts
+++ b/libs/api-client/src/services/event-attendee.service.ts
@@ -1,4 +1,10 @@
-import type { AddEventAttendeeInputDto, AttendeeDto, AttendeeId, EventId } from '@wishlist/common'
+import type {
+  AddEventAttendeeInputDto,
+  AttendeeDto,
+  AttendeeId,
+  EventId,
+  UpdateEventAttendeeRoleInputDto,
+} from '@wishlist/common'
 import type { AxiosInstance } from 'axios'
 
 export class EventAttendeeService {
@@ -6,6 +12,14 @@ export class EventAttendeeService {
 
   addAttendee(eventId: EventId, data: AddEventAttendeeInputDto): Promise<AttendeeDto> {
     return this.client.post(`/event/${eventId}/attendee`, data).then(res => res.data)
+  }
+
+  async updateAttendeeRole(params: {
+    eventId: EventId
+    attendeeId: AttendeeId
+    data: UpdateEventAttendeeRoleInputDto
+  }): Promise<void> {
+    await this.client.put(`/event/${params.eventId}/attendee/${params.attendeeId}`, params.data)
   }
 
   async deleteAttendee(params: { eventId: EventId; attendeeId: AttendeeId }): Promise<void> {

--- a/libs/common/src/dtos/attendee.dto.ts
+++ b/libs/common/src/dtos/attendee.dto.ts
@@ -35,3 +35,9 @@ export class AddEventAttendeeForEventInputDto extends AddEventAttendeeInputDto {
   @IsNotEmpty()
   declare event_id: EventId
 }
+
+export class UpdateEventAttendeeRoleInputDto {
+  @IsEnum(AttendeeRole)
+  @IsNotEmpty()
+  declare role: AttendeeRole
+}

--- a/libs/common/src/enums/attendee.enum.ts
+++ b/libs/common/src/enums/attendee.enum.ts
@@ -1,4 +1,5 @@
 export enum AttendeeRole {
-  MAINTAINER = 'maintainer',
-  USER = 'user',
+  CREATOR = 'creator',
+  ADMIN = 'admin',
+  PARTICIPANT = 'participant',
 }

--- a/libs/common/src/utils/event.utils.ts
+++ b/libs/common/src/utils/event.utils.ts
@@ -5,5 +5,5 @@ import { AttendeeRole } from '../enums'
 export function canEditEvent(attendees: AttendeeDto[], userId: string): boolean {
   const attendee = attendees.find(a => a?.user?.id === userId)
   if (!attendee) return false
-  return [AttendeeRole.MAINTAINER].includes(attendee.role as AttendeeRole)
+  return [AttendeeRole.CREATOR, AttendeeRole.ADMIN].includes(attendee.role as AttendeeRole)
 }


### PR DESCRIPTION
## Summary
- Replace event attendee roles `MAINTAINER`/`USER` with `CREATOR`, `ADMIN`, and `PARTICIPANT`.
- The event creator is unique and immutable: they cannot be removed or have their role changed.
- Admins have the same management rights as the creator (event info, attendees, Secret Santa, delete event), except they cannot delete or demote the creator.
- Added REST `PUT /event/:eventId/attendee/:attendeeId` and GraphQL `updateEventAttendeeRole` so entitled users can switch attendees between admin and participant.
- Frontend shows role badges and a role selector on the attendees edit screen. New attendees still default to participant.

## Test plan
- [ ] Create an event and confirm the current user is `CREATOR`.
- [ ] Invite someone and confirm they are added as `PARTICIPANT`.
- [ ] As creator, promote a participant to admin, then demote them back.
- [ ] As admin, edit event info, manage attendees, and delete the event.
- [ ] As admin, confirm the creator cannot be removed or have their role changed.
- [ ] As participant, confirm the edit page and role mutations are denied.
- [ ] Run API integration tests for event attendees (`event-attendee.controller.int-spec.ts`, `event-mutation.resolver.int-spec.ts`).


Made with [Cursor](https://cursor.com)