### PR TITLE
fix: add bun test globals types for TypeScript

### DIFF
--- a/apps/api/tsconfig.spec.json
+++ b/apps/api/tsconfig.spec.json
@@ -2,7 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
-    "types": ["bun", "node"],
+    "types": ["bun", "bun-types/test-globals", "node"],
     "verbatimModuleSyntax": true
   },
   "files": ["../../bun-matchers.d.ts"],

--- a/bun-matchers.d.ts
+++ b/bun-matchers.d.ts
@@ -1,3 +1,4 @@
+/// <reference types="bun-types/test-globals" />
 /** biome-ignore-all lint/suspicious/noExplicitAny: bun:test matchers */
 import type CustomMatchers from 'jest-extended'
 

--- a/libs/api-client/tsconfig.spec.json
+++ b/libs/api-client/tsconfig.spec.json
@@ -2,7 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
-    "types": ["bun", "node"],
+    "types": ["bun", "bun-types/test-globals", "node"],
     "declaration": true
   },
   "files": ["../../bun-matchers.d.ts"],

--- a/libs/common/tsconfig.spec.json
+++ b/libs/common/tsconfig.spec.json
@@ -2,7 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
-    "types": ["bun", "node"],
+    "types": ["bun", "bun-types/test-globals", "node"],
     "declaration": true
   },
   "files": ["../../bun-matchers.d.ts"],

--- a/plugin/biome-plugin/tsconfig.spec.json
+++ b/plugin/biome-plugin/tsconfig.spec.json
@@ -2,7 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
-    "types": ["bun", "node"]
+    "types": ["bun", "bun-types/test-globals", "node"]
   },
   "include": ["src/**/*.d.ts", "src/**/*.spec.ts", "src/**/*.test.ts"]
 }

--- a/plugin/drizzle-plugin/tsconfig.spec.json
+++ b/plugin/drizzle-plugin/tsconfig.spec.json
@@ -2,7 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
-    "types": ["bun", "node"]
+    "types": ["bun", "bun-types/test-globals", "node"]
   },
   "include": ["src/**/*.d.ts", "src/**/*.spec.ts", "src/**/*.test.ts"]
 }


### PR DESCRIPTION
## Summary
- Load `bun-types/test-globals` in spec tsconfigs so `describe`/`it`/`expect` (and bun test hooks) are typed in the IDE
- Reference the same globals from `bun-matchers.d.ts`, which is already included by the bun spec projects

## Test plan
- [ ] Open an `*.int-spec.ts` file and confirm `describe`/`it`/`expect` no longer show “Cannot find name” errors
- [ ] If squiggles remain, run **TypeScript: Restart TS Server** and re-check
- [ ] `bunx tsc --noEmit -p apps/api/tsconfig.spec.json` no longer reports missing `describe`/`it`/`expect`


Made with [Cursor](https://cursor.com)