### PR TITLE
chore: bump TypeScript to 6.0.2

### DIFF
--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -9,8 +9,5 @@
     {
       "path": "./tsconfig.spec.json"
     }
-  ],
-  "compilerOptions": {
-    "esModuleInterop": true
-  }
+  ]
 }

--- a/apps/front/tsconfig.json
+++ b/apps/front/tsconfig.json
@@ -2,11 +2,6 @@
   "extends": "../../tsconfig.base.json",
   "files": [],
   "include": [],
-  "compilerOptions": {
-    "jsx": "react-jsx",
-    "moduleResolution": "bundler",
-    "module": "ESNext"
-  },
   "references": [
     {
       "path": "./tsconfig.app.json"

--- a/bun.lock
+++ b/bun.lock
@@ -139,7 +139,7 @@
         "pg": "8.23.0",
         "sass-embedded": "1.97.1",
         "supertest": "7.1.4",
-        "typescript": "5.9.3",
+        "typescript": "6.0.2",
         "unplugin-swc": "1.5.9",
         "vite": "7.3.0",
         "vite-plugin-svgr": "4.5.0",
@@ -4122,7 +4122,7 @@
 
     "typedarray": ["typedarray@0.0.6", "", {}, "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="],
 
-    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+    "typescript": ["typescript@6.0.2", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ=="],
 
     "ua-parser-js": ["ua-parser-js@1.0.41", "", { "bin": { "ua-parser-js": "script/cli.js" } }, "sha512-LbBDqdIC5s8iROCUjMbW1f5dJQTEFB1+KO9ogbvlb3nm9n4YHa5p4KTvFPWvh2Hs8gZMBuiB1/8+pdfe/tDPug=="],
 
@@ -4547,6 +4547,8 @@
     "@nestjs/graphql/ws": ["ws@8.18.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg=="],
 
     "@nestjs/platform-express/express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
+
+    "@nx/eslint/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "@nx/js/jsonc-parser": ["jsonc-parser@3.2.0", "", {}, "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w=="],
 

--- a/package.json
+++ b/package.json
@@ -159,7 +159,7 @@
     "pg": "8.23.0",
     "sass-embedded": "1.97.1",
     "supertest": "7.1.4",
-    "typescript": "5.9.3",
+    "typescript": "6.0.2",
     "unplugin-swc": "1.5.9",
     "vite": "7.3.0",
     "vite-plugin-svgr": "4.5.0",

--- a/plugin/bun-plugin/src/executors/generate-pruned-package-json/generate-pruned-package-json.ts
+++ b/plugin/bun-plugin/src/executors/generate-pruned-package-json/generate-pruned-package-json.ts
@@ -36,7 +36,7 @@ const runExecutor: PromiseExecutor<GeneratePrunedPackageJsonExecutorSchema> = as
     root: context.root,
     isProduction: true,
     skipPackageManager: true,
-  }) as PackageJsonLike;
+  }) as unknown as PackageJsonLike;
 
   stripWorkspaceProtocolDependencies(prunedPackageJson);
   await copyTrustedDependencies(context.root, prunedPackageJson);

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -6,7 +6,7 @@
     "rootDir": ".",
     "sourceMap": true,
     "declaration": false,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "allowJs": true,
     "emitDecoratorMetadata": true,
     "esModuleInterop": true,
@@ -20,19 +20,18 @@
     "lib": ["ESNext", "dom"],
     "skipLibCheck": true,
     "skipDefaultLibCheck": true,
-    "baseUrl": ".",
     "strict": true,
     "paths": {
-      "@wishlist/api-client": ["libs/api-client/src/index.ts"],
-      "@wishlist/api-drizzle": ["apps/api/drizzle/index.ts"],
-      "@wishlist/api-test-utils": ["apps/api/test-utils/index.ts"],
-      "@wishlist/common": ["libs/common/src/index.ts"],
-      "@wishlist/mail": ["libs/mail/src/index.ts"],
-      "@wishlist/front-components/*": ["apps/front/src/components/*"],
-      "@wishlist/front-hooks": ["apps/front/src/hooks"],
-      "@wishlist/biome-plugin": ["plugin/biome-plugin/src/index.ts"],
-      "@wishlist/bun-plugin": ["plugin/bun-plugin/src/index.ts"],
-      "@wishlist/drizzle-plugin": ["plugin/drizzle-plugin/src/index.ts"]
+      "@wishlist/api-client": ["./libs/api-client/src/index.ts"],
+      "@wishlist/api-drizzle": ["./apps/api/drizzle/index.ts"],
+      "@wishlist/api-test-utils": ["./apps/api/test-utils/index.ts"],
+      "@wishlist/common": ["./libs/common/src/index.ts"],
+      "@wishlist/mail": ["./libs/mail/src/index.ts"],
+      "@wishlist/front-components/*": ["./apps/front/src/components/*"],
+      "@wishlist/front-hooks": ["./apps/front/src/hooks"],
+      "@wishlist/biome-plugin": ["./plugin/biome-plugin/src/index.ts"],
+      "@wishlist/bun-plugin": ["./plugin/bun-plugin/src/index.ts"],
+      "@wishlist/drizzle-plugin": ["./plugin/drizzle-plugin/src/index.ts"]
     }
   },
   "exclude": ["node_modules", "tmp"]


### PR DESCRIPTION
## Summary
- Bump TypeScript from 5.9.3 to 6.0.2
- Replace deprecated `moduleResolution: "node"` with `"bundler"` and remove `baseUrl`, prefixing path aliases so they resolve from the config file
- Drop redundant `compilerOptions` from API/front solution-style tsconfigs, and adjust a bun-plugin cast for stricter TypeScript 6 checking

## Test plan
- [ ] `bun typecheck` passes
- [ ] Plugin builds (`biome-plugin`, `bun-plugin`, `drizzle-plugin`) pass
- [ ] Editor no longer shows `compilerOptions` deprecation warnings on tsconfig files
- [ ] Front and API still resolve workspace path aliases (`@wishlist/common`, etc.)


Made with [Cursor](https://cursor.com)