### PR TITLE
test(api): add colocated unit tests for use-case business rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ Guidance for Claude Code when working in this repository.
 
 Nested docs (read the one that matches the files you are changing):
 
-- [`apps/api/CLAUDE.md`](apps/api/CLAUDE.md) — NestJS API, GraphQL, use cases, Drizzle, integration tests
+- [`apps/api/CLAUDE.md`](apps/api/CLAUDE.md) — NestJS API, GraphQL, use cases, Drizzle, unit and integration tests
 - [`apps/front/CLAUDE.md`](apps/front/CLAUDE.md) — React frontend, MUI, GraphQL documents, uploads
 - [`libs/common/CLAUDE.md`](libs/common/CLAUDE.md) — shared branded IDs and remaining HTTP types
 - [`libs/mail/CLAUDE.md`](libs/mail/CLAUDE.md) — react-email templates

--- a/apps/api/CLAUDE.md
+++ b/apps/api/CLAUDE.md
@@ -80,13 +80,80 @@ Yoga plugin `useErrorTransformPlugin` maps thrown Nest exceptions onto the field
 - `bun serve:api` — NestJS API
 - `bun serve:api:with-codegen` — API + GraphQL codegen in watch mode
 
+## Unit tests
+
+Business logic branches (every `throw`, guard clause, conditional, early return in `execute()`) belong in **unit tests**. Integration tests cover wiring: auth guards, Zod pipes, GraphQL round-trips, and database state. Do not re-test use-case branches in int-specs.
+
+**A new use case is not done until it has a colocated unit spec.** Add `{name}.use-case.spec.ts` next to `{name}.use-case.ts` in the same PR. Cover every authorization check, business-rule `throw`, and happy path in `execute()`.
+
+**Use-case specs** (`*.use-case.spec.ts`) live next to the use case:
+
+```
+src/item/application/command/toggle-item.use-case.ts
+src/item/application/command/toggle-item.use-case.spec.ts
+```
+
+- `bun:test`, use `it()` (not `test()`), nested `describe` blocks
+- Instantiate the use case in `beforeEach` (no `Test.createTestingModule`)
+- Mock dependencies with `createMock<T>()` from `test-utils/mocks`
+- Reset with `mock.clearAllMocks()` in `beforeEach`
+- Default happy-path `mockResolvedValue` in `beforeEach`; error cases override with `mockResolvedValueOnce`
+- Real domain models via builders; mock only repositories / `EventBus` / infrastructure
+- `Logger.overrideLogger(false)` in `beforeAll` to keep Nest logs out of the output
+
+```typescript
+describe('ToggleItemUseCase', () => {
+  const itemRepository = createMock<WishlistItemRepository>()
+  const wishlistRepository = createMock<WishlistRepository>()
+  const userRepository = createMock<UserRepository>()
+
+  let useCase: ToggleItemUseCase
+  let owner: User
+  let item: WishlistItem
+
+  beforeAll(() => {
+    Logger.overrideLogger(false)
+  })
+
+  beforeEach(() => {
+    mock.clearAllMocks()
+    owner = new UserBuilder().withEmail('owner@test.fr').build()
+    const wishlist = new WishlistBuilder().withOwner(owner).build()
+    item = new WishlistItemBuilder().withWishlistId(wishlist.id).build()
+
+    itemRepository.findByIdOrFail.mockResolvedValue(item)
+    wishlistRepository.hasAccess.mockResolvedValue(true)
+    wishlistRepository.findByIdOrFail.mockResolvedValue(wishlist)
+    userRepository.findByIdOrFail.mockResolvedValue(owner)
+
+    useCase = new ToggleItemUseCase(itemRepository, wishlistRepository, userRepository)
+  })
+
+  it('should reject when the user has no access to the wishlist', async () => {
+    wishlistRepository.hasAccess.mockResolvedValueOnce(false)
+
+    await expect(useCase.execute({ currentUser: toCurrentUser(owner), itemId: item.id })).rejects.toThrow(
+      UnauthorizedException,
+    )
+    expect(itemRepository.save).not.toHaveBeenCalled()
+  })
+})
+```
+
+**Builders** (`test-utils/builders/`) — fluent `with*()` / `as*()` methods, `build()` creates the domain model (`Model.create()` when possible). Keep auto-generated fields (`id`, `createdAt`, `updatedAt`) inside `build()`, not on the builder API. Convert a `User` to `ICurrentUser` with `toCurrentUser(user)`.
+
+**Examples**
+- `src/item/application/command/toggle-item.use-case.spec.ts`
+- `src/item/application/command/delete-item.use-case.spec.ts`
+- `src/event/application/command/add-attendee.use-case.spec.ts`
+
 ## Integration tests
 
 Most int-specs target GraphQL resolvers (`*.resolver.int-spec.ts`). A few REST controller specs remain for multipart routes and `GET /health`.
 
 - **Unit tests**: `bun nx run api:test`
 - **Int tests**: `bun nx run api:test:int` (need docker to be up, auto create containers at start)
-- **Utilities**: `test-utils/`
+- **Utilities**: `test-utils/` (`createMock`, builders for unit tests; `useTestApp` / fixtures for int tests)
 - **No parallel files**: disabled for stability with shared resources
 - **Auth**: `getRequest({ signedAs })` logs in via the GraphQL `login` mutation
 
@@ -245,7 +312,7 @@ Register new command/query/event-handler classes in `application/index.ts` `hand
 3. **Transactions** — `TransactionManager.runInTransaction` only for multiple SQL queries. Pass tx context when needed.
 4. **Events** — publish after successful commands via `EventBus`; use for emails and other side effects.
 5. **Errors** — domain / Nest exceptions (`BusinessRuleException`, `NotFoundException`). Validate GraphQL input with Zod + `ZodPipe` in resolvers, not inside every use case.
-6. **Tests** — follow the integration guidelines above.
+6. **Tests** — every new use case **must** ship with a colocated `*.use-case.spec.ts` covering its branches. Integration tests cover GraphQL wiring, not those branches. See the unit-test section above.
 
 ### Repository tokens
 

--- a/apps/api/src/auth/application/commands/login.use-case.spec.ts
+++ b/apps/api/src/auth/application/commands/login.use-case.spec.ts
@@ -1,0 +1,89 @@
+import type { JwtService } from '@nestjs/jwt';
+import type { UserRepository } from '../../../user/domain/repository/user.repository';
+
+import { Logger, UnauthorizedException } from '@nestjs/common';
+
+import { UserBuilder } from '../../../../test-utils/builders/user.builder';
+import { createMock } from '../../../../test-utils/mocks';
+import { User } from '../../../user/domain/model/user.model';
+import { PasswordManager } from '../../infrastructure/util/password-manager';
+import { LoginUseCase } from './login.use-case';
+import { beforeAll, beforeEach, describe, expect, it, mock } from 'bun:test';
+
+const PASSWORD = 'Secret123!';
+
+describe('LoginUseCase', () => {
+  const userRepository = createMock<UserRepository>();
+  const jwtService = createMock<JwtService>();
+
+  let useCase: LoginUseCase;
+  let user: User;
+  let passwordHash: string;
+
+  beforeAll(() => {
+    Logger.overrideLogger(false);
+  });
+
+  beforeEach(async () => {
+    mock.clearAllMocks();
+
+    passwordHash = await PasswordManager.hash(PASSWORD);
+    user = new UserBuilder().withEmail('jean@test.fr').withPasswordEnc(passwordHash).build();
+
+    userRepository.findByEmail.mockResolvedValue(user);
+    jwtService.sign.mockReturnValue('token');
+
+    useCase = new LoginUseCase(userRepository, jwtService);
+  });
+
+  it('should reject when the user does not exist', async () => {
+    userRepository.findByEmail.mockResolvedValueOnce(undefined);
+
+    await expect(useCase.execute({ email: 'unknown@test.fr', password: PASSWORD, ip: '127.0.0.1' })).rejects.toThrow(
+      UnauthorizedException,
+    );
+    expect(userRepository.save).not.toHaveBeenCalled();
+    expect(jwtService.sign).not.toHaveBeenCalled();
+  });
+
+  it('should reject when the user is disabled', async () => {
+    userRepository.findByEmail.mockResolvedValueOnce(
+      new UserBuilder().withEmail('jean@test.fr').withPasswordEnc(passwordHash).disabled().build(),
+    );
+
+    await expect(useCase.execute({ email: 'jean@test.fr', password: PASSWORD, ip: '127.0.0.1' })).rejects.toThrow(
+      UnauthorizedException,
+    );
+    expect(userRepository.save).not.toHaveBeenCalled();
+  });
+
+  it('should reject when the password is incorrect', async () => {
+    await expect(
+      useCase.execute({ email: 'jean@test.fr', password: 'WrongPassword1!', ip: '127.0.0.1' }),
+    ).rejects.toThrow(UnauthorizedException);
+    expect(userRepository.save).not.toHaveBeenCalled();
+  });
+
+  it('should reject when the user has no password', async () => {
+    userRepository.findByEmail.mockResolvedValueOnce(new UserBuilder().withEmail('jean@test.fr').build());
+
+    await expect(useCase.execute({ email: 'jean@test.fr', password: PASSWORD, ip: '127.0.0.1' })).rejects.toThrow(
+      UnauthorizedException,
+    );
+    expect(userRepository.save).not.toHaveBeenCalled();
+  });
+
+  it('should return an access token and update the last connection', async () => {
+    const result = await useCase.execute({ email: 'jean@test.fr', password: PASSWORD, ip: '10.0.0.1' });
+
+    expect(result).toEqual({ accessToken: 'token' });
+    expect(jwtService.sign).toHaveBeenCalledWith({
+      sub: user.id,
+      email: user.email,
+      authorities: user.authorities,
+    });
+    expect(userRepository.save).toHaveBeenCalledTimes(1);
+    const savedUser = userRepository.save.mock.calls[0]?.[0];
+    expect(savedUser?.lastIp).toBe('10.0.0.1');
+  });
+});

--- a/apps/api/src/event/application/command/add-attendee.use-case.spec.ts
+++ b/apps/api/src/event/application/command/add-attendee.use-case.spec.ts
@@ -1,0 +1,117 @@
+import type { EventBus } from '@nestjs/cqrs';
+import type { AttendeeId } from '@wishlist/common';
+import type { UserRepository } from '../../../user/domain/repository/user.repository';
+import type { EventRepository } from '../../domain/repository/event.repository';
+import type { EventAttendeeRepository } from '../../domain/repository/event-attendee.repository';
+
+import { BadRequestException, Logger, UnauthorizedException } from '@nestjs/common';
+import { uuid } from '@wishlist/common';
+
+import { EventBuilder } from '../../../../test-utils/builders/event.builder';
+import { toCurrentUser, UserBuilder } from '../../../../test-utils/builders/user.builder';
+import { createMock } from '../../../../test-utils/mocks';
+import { User } from '../../../user/domain/model/user.model';
+import { AttendeeRole } from '../../domain/attendee-role.enum';
+import { AttendeeAddedEvent } from '../../domain/event/attendee-added.event';
+import { Event } from '../../domain/model/event.model';
+import { AddAttendeeUseCase } from './add-attendee.use-case';
+import { beforeAll, beforeEach, describe, expect, it, mock } from 'bun:test';
+
+describe('AddAttendeeUseCase', () => {
+  const eventRepository = createMock<EventRepository>();
+  const attendeeRepository = createMock<EventAttendeeRepository>();
+  const userRepository = createMock<UserRepository>();
+  const eventBus = createMock<EventBus>();
+
+  let useCase: AddAttendeeUseCase;
+  let creator: User;
+  let event: Event;
+  let attendeeId: AttendeeId;
+
+  beforeAll(() => {
+    Logger.overrideLogger(false);
+  });
+
+  beforeEach(() => {
+    mock.clearAllMocks();
+
+    creator = new UserBuilder().withEmail('creator@test.fr').build();
+    event = new EventBuilder().withCreator(creator).build();
+    attendeeId = uuid() as AttendeeId;
+
+    eventRepository.findByIdOrFail.mockResolvedValue(event);
+    attendeeRepository.newId.mockReturnValue(attendeeId);
+    userRepository.findByEmail.mockResolvedValue(undefined);
+    userRepository.findByIdOrFail.mockResolvedValue(creator);
+
+    useCase = new AddAttendeeUseCase(eventRepository, attendeeRepository, userRepository, eventBus);
+  });
+
+  it('should reject when the current user cannot edit the event', async () => {
+    const stranger = new UserBuilder().withEmail('stranger@test.fr').build();
+
+    await expect(
+      useCase.execute({
+        currentUser: toCurrentUser(stranger),
+        eventId: event.id,
+        newAttendee: { email: 'invite@test.fr' },
+      }),
+    ).rejects.toThrow(UnauthorizedException);
+    expect(attendeeRepository.save).not.toHaveBeenCalled();
+    expect(eventBus.publish).not.toHaveBeenCalled();
+  });
+
+  it('should reject when the attendee already exists', async () => {
+    await expect(
+      useCase.execute({
+        currentUser: toCurrentUser(creator),
+        eventId: event.id,
+        newAttendee: { email: creator.email },
+      }),
+    ).rejects.toThrow(BadRequestException);
+    expect(attendeeRepository.save).not.toHaveBeenCalled();
+  });
+
+  it('should reject when assigning the creator role', async () => {
+    await expect(
+      useCase.execute({
+        currentUser: toCurrentUser(creator),
+        eventId: event.id,
+        newAttendee: { email: 'invite@test.fr', role: AttendeeRole.CREATOR },
+      }),
+    ).rejects.toThrow(BadRequestException);
+    expect(attendeeRepository.save).not.toHaveBeenCalled();
+  });
+
+  it('should add an existing user as attendee and publish an event', async () => {
+    const invitee = new UserBuilder().withEmail('invite@test.fr').build();
+    userRepository.findByEmail.mockResolvedValueOnce(invitee);
+
+    const { attendee } = await useCase.execute({
+      currentUser: toCurrentUser(creator),
+      eventId: event.id,
+      newAttendee: { email: invitee.email, role: AttendeeRole.ADMIN },
+    });
+
+    expect(attendee.id).toBe(attendeeId);
+    expect(attendee.user?.id).toBe(invitee.id);
+    expect(attendee.role).toBe(AttendeeRole.ADMIN);
+    expect(attendeeRepository.save).toHaveBeenCalledWith(attendee);
+    expect(eventBus.publish).toHaveBeenCalledTimes(1);
+    expect(eventBus.publish.mock.calls[0]?.[0]).toBeInstanceOf(AttendeeAddedEvent);
+  });
+
+  it('should add a pending attendee when the email is unknown', async () => {
+    const { attendee } = await useCase.execute({
+      currentUser: toCurrentUser(creator),
+      eventId: event.id,
+      newAttendee: { email: 'pending@test.fr' },
+    });
+
+    expect(attendee.user).toBeUndefined();
+    expect(attendee.pendingEmail).toBe('pending@test.fr');
+    expect(attendee.role).toBe(AttendeeRole.PARTICIPANT);
+    expect(attendeeRepository.save).toHaveBeenCalledWith(attendee);
+    expect(eventBus.publish).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/api/src/event/application/command/create-event.use-case.spec.ts
+++ b/apps/api/src/event/application/command/create-event.use-case.spec.ts
@@ -1,0 +1,118 @@
+import type { EventBus } from '@nestjs/cqrs';
+import type { AttendeeId, EventId } from '@wishlist/common';
+import type { UserRepository } from '../../../user/domain/repository/user.repository';
+import type { EventRepository } from '../../domain/repository/event.repository';
+import type { EventAttendeeRepository } from '../../domain/repository/event-attendee.repository';
+
+import { BadRequestException, Logger } from '@nestjs/common';
+import { uuid } from '@wishlist/common';
+
+import { toCurrentUser, UserBuilder } from '../../../../test-utils/builders/user.builder';
+import { createMock } from '../../../../test-utils/mocks';
+import { User } from '../../../user/domain/model/user.model';
+import { AttendeeRole } from '../../domain/attendee-role.enum';
+import { AttendeeAddedEvent } from '../../domain/event/attendee-added.event';
+import { CreateEventUseCase } from './create-event.use-case';
+import { beforeAll, beforeEach, describe, expect, it, mock } from 'bun:test';
+
+describe('CreateEventUseCase', () => {
+  const eventRepository = createMock<EventRepository>();
+  const attendeeRepository = createMock<EventAttendeeRepository>();
+  const userRepository = createMock<UserRepository>();
+  const eventBus = createMock<EventBus>();
+
+  let useCase: CreateEventUseCase;
+  let creator: User;
+  let eventId: EventId;
+
+  beforeAll(() => {
+    Logger.overrideLogger(false);
+  });
+
+  beforeEach(() => {
+    mock.clearAllMocks();
+
+    creator = new UserBuilder().withEmail('creator@test.fr').build();
+    eventId = uuid() as EventId;
+
+    eventRepository.newId.mockReturnValue(eventId);
+    attendeeRepository.newId.mockImplementation(() => uuid() as AttendeeId);
+    userRepository.findByEmails.mockResolvedValue([]);
+    userRepository.findByIdOrFail.mockResolvedValue(creator);
+
+    useCase = new CreateEventUseCase(eventRepository, attendeeRepository, userRepository, eventBus);
+  });
+
+  it('should reject when assigning the creator role to an invited attendee', async () => {
+    await expect(
+      useCase.execute({
+        currentUser: toCurrentUser(creator),
+        newEvent: {
+          title: 'Anniversaire',
+          eventDate: new Date(Date.now() + 86_400_000),
+          attendees: [{ email: 'invite@test.fr', role: AttendeeRole.CREATOR }],
+        },
+      }),
+    ).rejects.toThrow(BadRequestException);
+    expect(eventRepository.save).not.toHaveBeenCalled();
+    expect(eventBus.publish).not.toHaveBeenCalled();
+  });
+
+  it('should create the event with the current user as creator and publish nothing', async () => {
+    const { event } = await useCase.execute({
+      currentUser: toCurrentUser(creator),
+      newEvent: {
+        title: 'Anniversaire',
+        description: 'Une fête',
+        icon: '🎂',
+        eventDate: new Date(Date.now() + 86_400_000),
+      },
+    });
+
+    expect(event.id).toBe(eventId);
+    expect(event.title).toBe('Anniversaire');
+    expect(event.attendees).toHaveLength(1);
+    expect(event.attendees[0]?.user?.id).toBe(creator.id);
+    expect(event.attendees[0]?.role).toBe(AttendeeRole.CREATOR);
+    expect(eventRepository.save).toHaveBeenCalledWith(event);
+    expect(eventBus.publish).not.toHaveBeenCalled();
+  });
+
+  it('should add an existing user as attendee and publish an event', async () => {
+    const invitee = new UserBuilder().withEmail('invite@test.fr').build();
+    userRepository.findByEmails.mockResolvedValueOnce([invitee]);
+
+    const { event } = await useCase.execute({
+      currentUser: toCurrentUser(creator),
+      newEvent: {
+        title: 'Anniversaire',
+        eventDate: new Date(Date.now() + 86_400_000),
+        attendees: [{ email: invitee.email, role: AttendeeRole.ADMIN }],
+      },
+    });
+
+    const invitedAttendee = event.attendees.find(a => a.user?.id === invitee.id);
+    expect(invitedAttendee?.role).toBe(AttendeeRole.ADMIN);
+    expect(event.attendees).toHaveLength(2);
+    expect(eventRepository.save).toHaveBeenCalledWith(event);
+    expect(eventBus.publish).toHaveBeenCalledTimes(1);
+    expect(eventBus.publish.mock.calls[0]?.[0]).toBeInstanceOf(AttendeeAddedEvent);
+  });
+
+  it('should add a pending attendee when the email is unknown', async () => {
+    const { event } = await useCase.execute({
+      currentUser: toCurrentUser(creator),
+      newEvent: {
+        title: 'Anniversaire',
+        eventDate: new Date(Date.now() + 86_400_000),
+        attendees: [{ email: 'pending@test.fr' }],
+      },
+    });
+
+    const pendingAttendee = event.attendees.find(a => a.pendingEmail === 'pending@test.fr');
+    expect(pendingAttendee?.user).toBeUndefined();
+    expect(pendingAttendee?.role).toBe(AttendeeRole.PARTICIPANT);
+    expect(eventBus.publish).toHaveBeenCalledTimes(1);
+    expect(eventBus.publish.mock.calls[0]?.[0]).toBeInstanceOf(AttendeeAddedEvent);
+  });
+});

--- a/apps/api/src/event/application/command/delete-attendee.use-case.spec.ts
+++ b/apps/api/src/event/application/command/delete-attendee.use-case.spec.ts
@@ -1,0 +1,197 @@
+import type { AttendeeId, EventId } from '@wishlist/common';
+import type { TransactionManager } from '../../../core/database/transaction-manager';
+import type { User } from '../../../user/domain/model/user.model';
+import type { WishlistRepository } from '../../../wishlist/domain/wishlist.repository';
+import type { Event } from '../../domain/model/event.model';
+import type { EventAttendee } from '../../domain/model/event-attendee.model';
+import type { EventRepository } from '../../domain/repository/event.repository';
+import type { EventAttendeeRepository } from '../../domain/repository/event-attendee.repository';
+
+import { ConflictException, Logger, NotFoundException, UnauthorizedException } from '@nestjs/common';
+import { uuid } from '@wishlist/common';
+
+import { EventBuilder } from '../../../../test-utils/builders/event.builder';
+import { toCurrentUser, UserBuilder } from '../../../../test-utils/builders/user.builder';
+import { WishlistBuilder } from '../../../../test-utils/builders/wishlist.builder';
+import { WishlistItemBuilder } from '../../../../test-utils/builders/wishlist-item.builder';
+import { createMock } from '../../../../test-utils/mocks';
+import { Wishlist } from '../../../wishlist/domain/wishlist.model';
+import { AttendeeRole } from '../../domain/attendee-role.enum';
+import { DeleteAttendeeUseCase } from './delete-attendee.use-case';
+import { beforeAll, beforeEach, describe, expect, it, mock } from 'bun:test';
+
+function attendeeForUser(event: Event, user: User): EventAttendee {
+  const attendee = event.attendees.find(a => a.user?.id === user.id);
+  if (attendee === undefined) {
+    throw new Error(`Missing attendee for ${user.email}`);
+  }
+  return attendee;
+}
+
+function creatorAttendeeOf(event: Event): EventAttendee {
+  const attendee = event.attendees.find(a => a.isCreator());
+  if (attendee === undefined) {
+    throw new Error('Missing creator attendee');
+  }
+  return attendee;
+}
+
+function pendingAttendeeOf(event: Event, email: string): EventAttendee {
+  const attendee = event.attendees.find(a => a.pendingEmail === email);
+  if (attendee === undefined) {
+    throw new Error(`Missing pending attendee ${email}`);
+  }
+  return attendee;
+}
+
+describe('DeleteAttendeeUseCase', () => {
+  const attendeeRepository = createMock<EventAttendeeRepository>();
+  const eventRepository = createMock<EventRepository>();
+  const wishlistRepository = createMock<WishlistRepository>();
+  const transactionManager = createMock<TransactionManager>();
+
+  let useCase: DeleteAttendeeUseCase;
+  let creator: User;
+  let participant: User;
+  let event: Event;
+  let participantAttendee: EventAttendee;
+
+  beforeAll(() => {
+    Logger.overrideLogger(false);
+  });
+
+  beforeEach(() => {
+    mock.clearAllMocks();
+
+    creator = new UserBuilder().withEmail('creator@test.fr').build();
+    participant = new UserBuilder().withEmail('participant@test.fr').build();
+    event = new EventBuilder().withCreator(creator).withAttendee(participant).build();
+    participantAttendee = attendeeForUser(event, participant);
+
+    eventRepository.findByIdOrFail.mockResolvedValue(event);
+    wishlistRepository.findByEvent.mockResolvedValue([]);
+    transactionManager.runInTransaction.mockImplementation(async fn => fn({} as never));
+
+    useCase = new DeleteAttendeeUseCase(attendeeRepository, eventRepository, wishlistRepository, transactionManager);
+  });
+
+  it('should reject when the current user cannot edit the event', async () => {
+    await expect(
+      useCase.execute({
+        currentUser: toCurrentUser(participant),
+        eventId: event.id,
+        attendeeId: participantAttendee.id,
+      }),
+    ).rejects.toThrow(UnauthorizedException);
+    expect(attendeeRepository.delete).not.toHaveBeenCalled();
+  });
+
+  it('should reject when the attendee is not found', async () => {
+    await expect(
+      useCase.execute({
+        currentUser: toCurrentUser(creator),
+        eventId: event.id,
+        attendeeId: uuid() as AttendeeId,
+      }),
+    ).rejects.toThrow(NotFoundException);
+    expect(attendeeRepository.delete).not.toHaveBeenCalled();
+  });
+
+  it('should reject when deleting yourself', async () => {
+    const admin = new UserBuilder().withEmail('admin@test.fr').build();
+    event = new EventBuilder().withCreator(creator).withAttendee(admin, AttendeeRole.ADMIN).build();
+    eventRepository.findByIdOrFail.mockResolvedValueOnce(event);
+
+    await expect(
+      useCase.execute({
+        currentUser: toCurrentUser(admin),
+        eventId: event.id,
+        attendeeId: attendeeForUser(event, admin).id,
+      }),
+    ).rejects.toThrow(ConflictException);
+    expect(attendeeRepository.delete).not.toHaveBeenCalled();
+  });
+
+  it('should reject when deleting the creator', async () => {
+    const admin = new UserBuilder().withEmail('admin@test.fr').build();
+    event = new EventBuilder().withCreator(creator).withAttendee(admin, AttendeeRole.ADMIN).build();
+    eventRepository.findByIdOrFail.mockResolvedValueOnce(event);
+
+    await expect(
+      useCase.execute({
+        currentUser: toCurrentUser(admin),
+        eventId: event.id,
+        attendeeId: creatorAttendeeOf(event).id,
+      }),
+    ).rejects.toThrow(ConflictException);
+    expect(attendeeRepository.delete).not.toHaveBeenCalled();
+  });
+
+  it('should reject when the attendee wishlist has only this event and items', async () => {
+    const wishlist = new Wishlist({
+      ...new WishlistBuilder().withOwner(participant).withEventIds([event.id]).build(),
+      items: [new WishlistItemBuilder().build()],
+    });
+    wishlistRepository.findByEvent.mockResolvedValueOnce([wishlist]);
+
+    await expect(
+      useCase.execute({
+        currentUser: toCurrentUser(creator),
+        eventId: event.id,
+        attendeeId: participantAttendee.id,
+      }),
+    ).rejects.toThrow(ConflictException);
+    expect(wishlistRepository.delete).not.toHaveBeenCalled();
+    expect(wishlistRepository.save).not.toHaveBeenCalled();
+  });
+
+  it('should unlink the event when the attendee wishlist is linked to multiple events', async () => {
+    const otherEventId = uuid() as EventId;
+    const wishlist = new WishlistBuilder().withOwner(participant).withEventIds([event.id, otherEventId]).build();
+    wishlistRepository.findByEvent.mockResolvedValueOnce([wishlist]);
+
+    await useCase.execute({
+      currentUser: toCurrentUser(creator),
+      eventId: event.id,
+      attendeeId: participantAttendee.id,
+    });
+
+    expect(attendeeRepository.delete).toHaveBeenCalledWith(participantAttendee.id, expect.anything());
+    expect(wishlistRepository.save).toHaveBeenCalledTimes(1);
+    const savedWishlist = wishlistRepository.save.mock.calls[0]?.[0];
+    expect(savedWishlist?.eventIds).toEqual([otherEventId]);
+    expect(wishlistRepository.delete).not.toHaveBeenCalled();
+  });
+
+  it('should delete the wishlist when it has only this event and no items', async () => {
+    const wishlist = new WishlistBuilder().withOwner(participant).withEventIds([event.id]).build();
+    wishlistRepository.findByEvent.mockResolvedValueOnce([wishlist]);
+
+    await useCase.execute({
+      currentUser: toCurrentUser(creator),
+      eventId: event.id,
+      attendeeId: participantAttendee.id,
+    });
+
+    expect(attendeeRepository.delete).toHaveBeenCalledWith(participantAttendee.id, expect.anything());
+    expect(wishlistRepository.delete).toHaveBeenCalledWith(wishlist.id, expect.anything());
+    expect(wishlistRepository.save).not.toHaveBeenCalled();
+  });
+
+  it('should delete a pending attendee without touching wishlists', async () => {
+    event = new EventBuilder().withCreator(creator).withPendingAttendee('pending@test.fr').build();
+    eventRepository.findByIdOrFail.mockResolvedValueOnce(event);
+    const pendingAttendee = pendingAttendeeOf(event, 'pending@test.fr');
+
+    await useCase.execute({
+      currentUser: toCurrentUser(creator),
+      eventId: event.id,
+      attendeeId: pendingAttendee.id,
+    });
+
+    expect(wishlistRepository.findByEvent).not.toHaveBeenCalled();
+    expect(attendeeRepository.delete).toHaveBeenCalledWith(pendingAttendee.id, expect.anything());
+    expect(wishlistRepository.delete).not.toHaveBeenCalled();
+    expect(wishlistRepository.save).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/event/application/command/delete-event.use-case.spec.ts
+++ b/apps/api/src/event/application/command/delete-event.use-case.spec.ts
@@ -1,0 +1,80 @@
+import type { TransactionManager } from '../../../core/database/transaction-manager';
+import type { WishlistRepository } from '../../../wishlist/domain/wishlist.repository';
+import type { EventRepository } from '../../domain/repository/event.repository';
+import type { EventAttendeeRepository } from '../../domain/repository/event-attendee.repository';
+
+import { BadRequestException, Logger, UnauthorizedException } from '@nestjs/common';
+
+import { EventBuilder } from '../../../../test-utils/builders/event.builder';
+import { toCurrentUser, UserBuilder } from '../../../../test-utils/builders/user.builder';
+import { WishlistBuilder } from '../../../../test-utils/builders/wishlist.builder';
+import { createMock } from '../../../../test-utils/mocks';
+import { User } from '../../../user/domain/model/user.model';
+import { Event } from '../../domain/model/event.model';
+import { DeleteEventUseCase } from './delete-event.use-case';
+import { beforeAll, beforeEach, describe, expect, it, mock } from 'bun:test';
+
+describe('DeleteEventUseCase', () => {
+  const eventRepository = createMock<EventRepository>();
+  const attendeeRepository = createMock<EventAttendeeRepository>();
+  const wishlistRepository = createMock<WishlistRepository>();
+  const transactionManager = createMock<TransactionManager>();
+
+  let useCase: DeleteEventUseCase;
+  let creator: User;
+  let event: Event;
+
+  beforeAll(() => {
+    Logger.overrideLogger(false);
+  });
+
+  beforeEach(() => {
+    mock.clearAllMocks();
+
+    creator = new UserBuilder().withEmail('creator@test.fr').build();
+    event = new EventBuilder().withCreator(creator).build();
+
+    eventRepository.findByIdOrFail.mockResolvedValue(event);
+    wishlistRepository.findByEvent.mockResolvedValue([]);
+    transactionManager.runInTransaction.mockImplementation(async fn => fn({} as never));
+
+    useCase = new DeleteEventUseCase(eventRepository, attendeeRepository, wishlistRepository, transactionManager);
+  });
+
+  it('should reject when the current user cannot edit the event', async () => {
+    const stranger = new UserBuilder().withEmail('stranger@test.fr').build();
+
+    await expect(useCase.execute({ currentUser: toCurrentUser(stranger), eventId: event.id })).rejects.toThrow(
+      UnauthorizedException,
+    );
+    expect(transactionManager.runInTransaction).not.toHaveBeenCalled();
+    expect(eventRepository.delete).not.toHaveBeenCalled();
+  });
+
+  it('should reject when the event still has wishlists', async () => {
+    wishlistRepository.findByEvent.mockResolvedValueOnce([
+      new WishlistBuilder().withOwner(creator).withEventIds([event.id]).build(),
+    ]);
+
+    await expect(useCase.execute({ currentUser: toCurrentUser(creator), eventId: event.id })).rejects.toThrow(
+      BadRequestException,
+    );
+    expect(transactionManager.runInTransaction).not.toHaveBeenCalled();
+    expect(eventRepository.delete).not.toHaveBeenCalled();
+  });
+
+  it('should delete attendees then the event in a transaction', async () => {
+    const participant = new UserBuilder().withEmail('participant@test.fr').build();
+    event = new EventBuilder().withCreator(creator).withAttendee(participant).build();
+    eventRepository.findByIdOrFail.mockResolvedValueOnce(event);
+
+    await useCase.execute({ currentUser: toCurrentUser(creator), eventId: event.id });
+
+    expect(transactionManager.runInTransaction).toHaveBeenCalledTimes(1);
+    expect(attendeeRepository.delete).toHaveBeenCalledTimes(event.attendees.length);
+    for (const attendee of event.attendees) {
+      expect(attendeeRepository.delete).toHaveBeenCalledWith(attendee.id, expect.anything());
+    }
+    expect(eventRepository.delete).toHaveBeenCalledWith(event.id, expect.anything());
+  });
+});

--- a/apps/api/src/event/application/command/update-attendee-role.use-case.spec.ts
+++ b/apps/api/src/event/application/command/update-attendee-role.use-case.spec.ts
@@ -1,0 +1,159 @@
+import type { AttendeeId } from '@wishlist/common';
+import type { User } from '../../../user/domain/model/user.model';
+import type { Event } from '../../domain/model/event.model';
+import type { EventAttendee } from '../../domain/model/event-attendee.model';
+import type { EventRepository } from '../../domain/repository/event.repository';
+import type { EventAttendeeRepository } from '../../domain/repository/event-attendee.repository';
+
+import {
+  BadRequestException,
+  ConflictException,
+  Logger,
+  NotFoundException,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { uuid } from '@wishlist/common';
+
+import { EventBuilder } from '../../../../test-utils/builders/event.builder';
+import { toCurrentUser, UserBuilder } from '../../../../test-utils/builders/user.builder';
+import { createMock } from '../../../../test-utils/mocks';
+import { AttendeeRole } from '../../domain/attendee-role.enum';
+import { UpdateAttendeeRoleUseCase } from './update-attendee-role.use-case';
+import { beforeAll, beforeEach, describe, expect, it, mock } from 'bun:test';
+
+function attendeeForUser(event: Event, user: User): EventAttendee {
+  const attendee = event.attendees.find(a => a.user?.id === user.id);
+  if (attendee === undefined) {
+    throw new Error(`Missing attendee for ${user.email}`);
+  }
+  return attendee;
+}
+
+function creatorAttendeeOf(event: Event): EventAttendee {
+  const attendee = event.attendees.find(a => a.isCreator());
+  if (attendee === undefined) {
+    throw new Error('Missing creator attendee');
+  }
+  return attendee;
+}
+
+describe('UpdateAttendeeRoleUseCase', () => {
+  const eventRepository = createMock<EventRepository>();
+  const attendeeRepository = createMock<EventAttendeeRepository>();
+
+  let useCase: UpdateAttendeeRoleUseCase;
+  let creator: User;
+  let participant: User;
+  let event: Event;
+  let participantAttendee: EventAttendee;
+
+  beforeAll(() => {
+    Logger.overrideLogger(false);
+  });
+
+  beforeEach(() => {
+    mock.clearAllMocks();
+
+    creator = new UserBuilder().withEmail('creator@test.fr').build();
+    participant = new UserBuilder().withEmail('participant@test.fr').build();
+    event = new EventBuilder().withCreator(creator).withAttendee(participant).build();
+    participantAttendee = attendeeForUser(event, participant);
+
+    eventRepository.findByIdOrFail.mockResolvedValue(event);
+
+    useCase = new UpdateAttendeeRoleUseCase(eventRepository, attendeeRepository);
+  });
+
+  it('should reject when the current user cannot edit the event', async () => {
+    await expect(
+      useCase.execute({
+        currentUser: toCurrentUser(participant),
+        eventId: event.id,
+        attendeeId: participantAttendee.id,
+        role: AttendeeRole.ADMIN,
+      }),
+    ).rejects.toThrow(UnauthorizedException);
+    expect(attendeeRepository.save).not.toHaveBeenCalled();
+  });
+
+  it('should reject when the attendee is not found', async () => {
+    await expect(
+      useCase.execute({
+        currentUser: toCurrentUser(creator),
+        eventId: event.id,
+        attendeeId: uuid() as AttendeeId,
+        role: AttendeeRole.ADMIN,
+      }),
+    ).rejects.toThrow(NotFoundException);
+    expect(attendeeRepository.save).not.toHaveBeenCalled();
+  });
+
+  it('should reject when changing your own role', async () => {
+    const admin = new UserBuilder().withEmail('admin@test.fr').build();
+    event = new EventBuilder().withCreator(creator).withAttendee(admin, AttendeeRole.ADMIN).build();
+    eventRepository.findByIdOrFail.mockResolvedValueOnce(event);
+
+    await expect(
+      useCase.execute({
+        currentUser: toCurrentUser(admin),
+        eventId: event.id,
+        attendeeId: attendeeForUser(event, admin).id,
+        role: AttendeeRole.PARTICIPANT,
+      }),
+    ).rejects.toThrow(ConflictException);
+    expect(attendeeRepository.save).not.toHaveBeenCalled();
+  });
+
+  it('should reject when changing the creator role', async () => {
+    const admin = new UserBuilder().withEmail('admin@test.fr').build();
+    event = new EventBuilder().withCreator(creator).withAttendee(admin, AttendeeRole.ADMIN).build();
+    eventRepository.findByIdOrFail.mockResolvedValueOnce(event);
+    await expect(
+      useCase.execute({
+        currentUser: toCurrentUser(admin),
+        eventId: event.id,
+        attendeeId: creatorAttendeeOf(event).id,
+        role: AttendeeRole.ADMIN,
+      }),
+    ).rejects.toThrow(ConflictException);
+    expect(attendeeRepository.save).not.toHaveBeenCalled();
+  });
+
+  it('should reject when assigning the creator role', async () => {
+    await expect(
+      useCase.execute({
+        currentUser: toCurrentUser(creator),
+        eventId: event.id,
+        attendeeId: participantAttendee.id,
+        role: AttendeeRole.CREATOR,
+      }),
+    ).rejects.toThrow(BadRequestException);
+    expect(attendeeRepository.save).not.toHaveBeenCalled();
+  });
+
+  it('should reject when the role is not admin or participant', async () => {
+    await expect(
+      useCase.execute({
+        currentUser: toCurrentUser(creator),
+        eventId: event.id,
+        attendeeId: participantAttendee.id,
+        role: 'unknown' as AttendeeRole,
+      }),
+    ).rejects.toThrow(BadRequestException);
+    expect(attendeeRepository.save).not.toHaveBeenCalled();
+  });
+
+  it('should update the attendee role', async () => {
+    await useCase.execute({
+      currentUser: toCurrentUser(creator),
+      eventId: event.id,
+      attendeeId: participantAttendee.id,
+      role: AttendeeRole.ADMIN,
+    });
+
+    expect(attendeeRepository.save).toHaveBeenCalledTimes(1);
+    const savedAttendee = attendeeRepository.save.mock.calls[0]?.[0];
+    expect(savedAttendee?.id).toBe(participantAttendee.id);
+    expect(savedAttendee?.role).toBe(AttendeeRole.ADMIN);
+  });
+});

--- a/apps/api/src/event/application/command/update-event.use-case.spec.ts
+++ b/apps/api/src/event/application/command/update-event.use-case.spec.ts
@@ -1,0 +1,69 @@
+import type { EventRepository } from '../../domain/repository/event.repository';
+
+import { Logger, UnauthorizedException } from '@nestjs/common';
+
+import { EventBuilder } from '../../../../test-utils/builders/event.builder';
+import { toCurrentUser, UserBuilder } from '../../../../test-utils/builders/user.builder';
+import { createMock } from '../../../../test-utils/mocks';
+import { User } from '../../../user/domain/model/user.model';
+import { Event } from '../../domain/model/event.model';
+import { UpdateEventUseCase } from './update-event.use-case';
+import { beforeAll, beforeEach, describe, expect, it, mock } from 'bun:test';
+
+describe('UpdateEventUseCase', () => {
+  const eventRepository = createMock<EventRepository>();
+
+  let useCase: UpdateEventUseCase;
+  let creator: User;
+  let event: Event;
+
+  beforeAll(() => {
+    Logger.overrideLogger(false);
+  });
+
+  beforeEach(() => {
+    mock.clearAllMocks();
+
+    creator = new UserBuilder().withEmail('creator@test.fr').build();
+    event = new EventBuilder().withCreator(creator).build();
+
+    eventRepository.findByIdOrFail.mockResolvedValue(event);
+
+    useCase = new UpdateEventUseCase(eventRepository);
+  });
+
+  it('should reject when the current user cannot edit the event', async () => {
+    const stranger = new UserBuilder().withEmail('stranger@test.fr').build();
+
+    await expect(
+      useCase.execute({
+        currentUser: toCurrentUser(stranger),
+        eventId: event.id,
+        updateEvent: { title: 'Nouveau titre', eventDate: event.eventDate },
+      }),
+    ).rejects.toThrow(UnauthorizedException);
+    expect(eventRepository.save).not.toHaveBeenCalled();
+  });
+
+  it('should update the event when the creator requests it', async () => {
+    const updateEvent = {
+      title: 'Nouveau titre',
+      description: 'Une description',
+      icon: '🎉',
+      eventDate: new Date(Date.now() + 172_800_000),
+    };
+
+    await useCase.execute({
+      currentUser: toCurrentUser(creator),
+      eventId: event.id,
+      updateEvent,
+    });
+
+    expect(eventRepository.save).toHaveBeenCalledTimes(1);
+    const savedEvent = eventRepository.save.mock.calls[0]?.[0];
+    expect(savedEvent?.title).toBe(updateEvent.title);
+    expect(savedEvent?.description).toBe(updateEvent.description);
+    expect(savedEvent?.icon).toBe(updateEvent.icon);
+    expect(savedEvent?.eventDate).toBe(updateEvent.eventDate);
+  });
+});

--- a/apps/api/src/event/application/query/get-event-attendees-by-ids.use-case.spec.ts
+++ b/apps/api/src/event/application/query/get-event-attendees-by-ids.use-case.spec.ts
@@ -1,0 +1,26 @@
+import type { EventAttendeeRepository } from '../../domain/repository/event-attendee.repository';
+
+import { EventBuilder } from '../../../../test-utils/builders/event.builder';
+import { UserBuilder } from '../../../../test-utils/builders/user.builder';
+import { createMock } from '../../../../test-utils/mocks';
+import { GetEventAttendeesByIdsUseCase } from './get-event-attendees-by-ids.use-case';
+import { beforeEach, describe, expect, it, mock } from 'bun:test';
+
+describe('GetEventAttendeesByIdsUseCase', () => {
+  const eventAttendeeRepository = createMock<EventAttendeeRepository>();
+  let useCase: GetEventAttendeesByIdsUseCase;
+
+  beforeEach(() => {
+    mock.clearAllMocks();
+    useCase = new GetEventAttendeesByIdsUseCase(eventAttendeeRepository);
+  });
+
+  it('should return attendees matching the given ids', async () => {
+    const event = new EventBuilder().withCreator(new UserBuilder().build()).build();
+    eventAttendeeRepository.findByIds.mockResolvedValueOnce(event.attendees);
+
+    const result = await useCase.execute({ attendeeIds: event.attendees.map(attendee => attendee.id) });
+
+    expect(result).toEqual(event.attendees);
+  });
+});

--- a/apps/api/src/event/application/query/get-events-by-ids.use-case.spec.ts
+++ b/apps/api/src/event/application/query/get-events-by-ids.use-case.spec.ts
@@ -1,0 +1,56 @@
+import type { EventRepository } from '../../domain/repository/event.repository';
+
+import { Logger } from '@nestjs/common';
+
+import { EventBuilder } from '../../../../test-utils/builders/event.builder';
+import { toCurrentUser, UserBuilder } from '../../../../test-utils/builders/user.builder';
+import { createMock } from '../../../../test-utils/mocks';
+import { User } from '../../../user/domain/model/user.model';
+import { Event } from '../../domain/model/event.model';
+import { GetEventsByIdsUseCase } from './get-events-by-ids.use-case';
+import { beforeAll, beforeEach, describe, expect, it, mock } from 'bun:test';
+
+describe('GetEventsByIdsUseCase', () => {
+  const eventRepository = createMock<EventRepository>();
+
+  let useCase: GetEventsByIdsUseCase;
+  let creator: User;
+  let event: Event;
+
+  beforeAll(() => {
+    Logger.overrideLogger(false);
+  });
+
+  beforeEach(() => {
+    mock.clearAllMocks();
+
+    creator = new UserBuilder().withEmail('creator@test.fr').build();
+    event = new EventBuilder().withCreator(creator).build();
+
+    eventRepository.findByIds.mockResolvedValue([event]);
+
+    useCase = new GetEventsByIdsUseCase(eventRepository);
+  });
+
+  it('should return events the current user can view', async () => {
+    const events = await useCase.execute({
+      currentUser: toCurrentUser(creator),
+      eventIds: [event.id],
+    });
+
+    expect(events).toEqual([event]);
+  });
+
+  it('should filter out events the current user cannot view', async () => {
+    const stranger = new UserBuilder().withEmail('stranger@test.fr').build();
+    const hiddenEvent = new EventBuilder().withCreator(stranger).build();
+    eventRepository.findByIds.mockResolvedValueOnce([event, hiddenEvent]);
+
+    const events = await useCase.execute({
+      currentUser: toCurrentUser(creator),
+      eventIds: [event.id, hiddenEvent.id],
+    });
+
+    expect(events).toEqual([event]);
+  });
+});

--- a/apps/api/src/event/application/query/get-events-by-user.use-case.spec.ts
+++ b/apps/api/src/event/application/query/get-events-by-user.use-case.spec.ts
@@ -1,0 +1,49 @@
+import type { EventRepository } from '../../domain/repository/event.repository';
+
+import { Logger } from '@nestjs/common';
+
+import { EventBuilder } from '../../../../test-utils/builders/event.builder';
+import { UserBuilder } from '../../../../test-utils/builders/user.builder';
+import { createMock } from '../../../../test-utils/mocks';
+import { User } from '../../../user/domain/model/user.model';
+import { Event } from '../../domain/model/event.model';
+import { GetEventsByUserUseCase } from './get-events-by-user.use-case';
+import { beforeAll, beforeEach, describe, expect, it, mock } from 'bun:test';
+
+describe('GetEventsByUserUseCase', () => {
+  const eventRepository = createMock<EventRepository>();
+
+  let useCase: GetEventsByUserUseCase;
+  let user: User;
+  let event: Event;
+
+  beforeAll(() => {
+    Logger.overrideLogger(false);
+  });
+
+  beforeEach(() => {
+    mock.clearAllMocks();
+
+    user = new UserBuilder().withEmail('jean@test.fr').build();
+    event = new EventBuilder().withCreator(user).build();
+    eventRepository.findByUserIdPaginated.mockResolvedValue({ events: [event], totalCount: 1 });
+
+    useCase = new GetEventsByUserUseCase(eventRepository);
+  });
+
+  it('should return paginated events for the user', async () => {
+    const result = await useCase.execute({
+      userId: user.id,
+      pageNumber: 2,
+      pageSize: 10,
+      ignorePastEvents: true,
+    });
+
+    expect(result).toEqual({ events: [event], totalCount: 1 });
+    expect(eventRepository.findByUserIdPaginated).toHaveBeenCalledWith({
+      userId: user.id,
+      pagination: { take: 10, skip: 10 },
+      onlyFuture: true,
+    });
+  });
+});

--- a/apps/api/src/event/application/query/get-events-for-user.use-case.spec.ts
+++ b/apps/api/src/event/application/query/get-events-for-user.use-case.spec.ts
@@ -1,0 +1,49 @@
+import type { EventRepository } from '../../domain/repository/event.repository';
+
+import { Logger } from '@nestjs/common';
+
+import { EventBuilder } from '../../../../test-utils/builders/event.builder';
+import { UserBuilder } from '../../../../test-utils/builders/user.builder';
+import { createMock } from '../../../../test-utils/mocks';
+import { User } from '../../../user/domain/model/user.model';
+import { Event } from '../../domain/model/event.model';
+import { GetEventsForUserUseCase } from './get-events-for-user.use-case';
+import { beforeAll, beforeEach, describe, expect, it, mock } from 'bun:test';
+
+describe('GetEventsForUserUseCase', () => {
+  const eventRepository = createMock<EventRepository>();
+
+  let useCase: GetEventsForUserUseCase;
+  let user: User;
+  let event: Event;
+
+  beforeAll(() => {
+    Logger.overrideLogger(false);
+  });
+
+  beforeEach(() => {
+    mock.clearAllMocks();
+
+    user = new UserBuilder().withEmail('jean@test.fr').build();
+    event = new EventBuilder().withCreator(user).build();
+    eventRepository.findByUserIdPaginated.mockResolvedValue({ events: [event], totalCount: 1 });
+
+    useCase = new GetEventsForUserUseCase(eventRepository);
+  });
+
+  it('should return paginated events for the user', async () => {
+    const result = await useCase.execute({
+      userId: user.id,
+      pageNumber: 2,
+      pageSize: 10,
+      ignorePastEvents: false,
+    });
+
+    expect(result).toEqual({ events: [event], totalCount: 1 });
+    expect(eventRepository.findByUserIdPaginated).toHaveBeenCalledWith({
+      userId: user.id,
+      pagination: { take: 10, skip: 10 },
+      onlyFuture: false,
+    });
+  });
+});

--- a/apps/api/src/event/application/query/get-events.use-case.spec.ts
+++ b/apps/api/src/event/application/query/get-events.use-case.spec.ts
@@ -1,0 +1,27 @@
+import type { EventRepository } from '../../domain/repository/event.repository';
+
+import { EventBuilder } from '../../../../test-utils/builders/event.builder';
+import { UserBuilder } from '../../../../test-utils/builders/user.builder';
+import { createMock } from '../../../../test-utils/mocks';
+import { GetEventsUseCase } from './get-events.use-case';
+import { beforeEach, describe, expect, it, mock } from 'bun:test';
+
+describe('GetEventsUseCase', () => {
+  const eventRepository = createMock<EventRepository>();
+  let useCase: GetEventsUseCase;
+
+  beforeEach(() => {
+    mock.clearAllMocks();
+    useCase = new GetEventsUseCase(eventRepository);
+  });
+
+  it('should return paginated events', async () => {
+    const events = [new EventBuilder().withCreator(new UserBuilder().build()).build()];
+    eventRepository.findAllPaginated.mockResolvedValueOnce({ events, totalCount: 11 });
+
+    const result = await useCase.execute({ pageNumber: 2, pageSize: 10 });
+
+    expect(result).toEqual({ events, totalCount: 11 });
+    expect(eventRepository.findAllPaginated).toHaveBeenCalledWith({ pagination: { take: 10, skip: 10 } });
+  });
+});

--- a/apps/api/src/item/application/command/create-item.use-case.spec.ts
+++ b/apps/api/src/item/application/command/create-item.use-case.spec.ts
@@ -1,0 +1,102 @@
+import type { ItemId } from '@wishlist/common';
+import type { WishlistRepository } from '../../../wishlist/domain/wishlist.repository';
+import type { WishlistItemRepository } from '../../domain/wishlist-item.repository';
+
+import { Logger, UnauthorizedException } from '@nestjs/common';
+import { uuid } from '@wishlist/common';
+
+import { toCurrentUser, UserBuilder } from '../../../../test-utils/builders/user.builder';
+import { WishlistBuilder } from '../../../../test-utils/builders/wishlist.builder';
+import { createMock } from '../../../../test-utils/mocks';
+import { User } from '../../../user/domain/model/user.model';
+import { Wishlist } from '../../../wishlist/domain/wishlist.model';
+import { CreateItemUseCase } from './create-item.use-case';
+import { beforeAll, beforeEach, describe, expect, it, mock } from 'bun:test';
+
+describe('CreateItemUseCase', () => {
+  const wishlistRepository = createMock<WishlistRepository>();
+  const itemRepository = createMock<WishlistItemRepository>();
+
+  let useCase: CreateItemUseCase;
+  let owner: User;
+  let wishlist: Wishlist;
+  let itemId: ItemId;
+
+  beforeAll(() => {
+    Logger.overrideLogger(false);
+  });
+
+  beforeEach(() => {
+    mock.clearAllMocks();
+
+    owner = new UserBuilder().withEmail('owner@test.fr').build();
+    wishlist = new WishlistBuilder().withOwner(owner).build();
+    itemId = uuid() as ItemId;
+
+    wishlistRepository.findByIdOrFail.mockResolvedValue(wishlist);
+    wishlistRepository.hasAccess.mockResolvedValue(true);
+    itemRepository.newId.mockReturnValue(itemId);
+    itemRepository.save.mockResolvedValue(undefined);
+
+    useCase = new CreateItemUseCase(wishlistRepository, itemRepository);
+  });
+
+  it('should reject when the user has no access to the wishlist', async () => {
+    wishlistRepository.hasAccess.mockResolvedValueOnce(false);
+
+    await expect(
+      useCase.execute({
+        currentUser: toCurrentUser(owner),
+        wishlistId: wishlist.id,
+        newItem: { name: 'Un livre' },
+      }),
+    ).rejects.toThrow(UnauthorizedException);
+    expect(itemRepository.save).not.toHaveBeenCalled();
+  });
+
+  it('should create a non-suggested item when the owner adds it', async () => {
+    const item = await useCase.execute({
+      currentUser: toCurrentUser(owner),
+      wishlistId: wishlist.id,
+      newItem: { name: 'Un livre', description: 'SF', score: 5 },
+    });
+
+    expect(item.id).toBe(itemId);
+    expect(item.wishlistId).toBe(wishlist.id);
+    expect(item.name).toBe('Un livre');
+    expect(item.description).toBe('SF');
+    expect(item.score).toBe(5);
+    expect(item.isSuggested).toBe(false);
+    expect(itemRepository.save).toHaveBeenCalledWith(item);
+  });
+
+  it('should create a suggested item when a participant adds it', async () => {
+    const participant = new UserBuilder().withEmail('participant@test.fr').build();
+
+    const item = await useCase.execute({
+      currentUser: toCurrentUser(participant),
+      wishlistId: wishlist.id,
+      newItem: { name: 'Un jeu' },
+    });
+
+    expect(item.isSuggested).toBe(true);
+    expect(item.name).toBe('Un jeu');
+    expect(itemRepository.save).toHaveBeenCalledWith(item);
+  });
+
+  it('should create a non-suggested item when a co-owner adds it', async () => {
+    const coOwner = new UserBuilder().withEmail('coowner@test.fr').build();
+    wishlistRepository.findByIdOrFail.mockResolvedValueOnce(
+      new WishlistBuilder().withOwner(owner).withCoOwner(coOwner).build(),
+    );
+
+    const item = await useCase.execute({
+      currentUser: toCurrentUser(coOwner),
+      wishlistId: wishlist.id,
+      newItem: { name: 'Un vinyle' },
+    });
+
+    expect(item.isSuggested).toBe(false);
+    expect(itemRepository.save).toHaveBeenCalledWith(item);
+  });
+});

--- a/apps/api/src/item/application/command/delete-item.use-case.spec.ts
+++ b/apps/api/src/item/application/command/delete-item.use-case.spec.ts
@@ -1,0 +1,116 @@
+import type { WishlistRepository } from '../../../wishlist/domain/wishlist.repository';
+import type { WishlistItemRepository } from '../../domain/wishlist-item.repository';
+
+import { Logger, UnauthorizedException } from '@nestjs/common';
+
+import { toCurrentUser, UserBuilder } from '../../../../test-utils/builders/user.builder';
+import { WishlistBuilder } from '../../../../test-utils/builders/wishlist.builder';
+import { WishlistItemBuilder } from '../../../../test-utils/builders/wishlist-item.builder';
+import { createMock } from '../../../../test-utils/mocks';
+import { User } from '../../../user/domain/model/user.model';
+import { Wishlist } from '../../../wishlist/domain/wishlist.model';
+import { WishlistItem } from '../../domain/wishlist-item.model';
+import { DeleteItemUseCase } from './delete-item.use-case';
+import { beforeAll, beforeEach, describe, expect, it, mock } from 'bun:test';
+
+describe('DeleteItemUseCase', () => {
+  const itemRepository = createMock<WishlistItemRepository>();
+  const wishlistRepository = createMock<WishlistRepository>();
+
+  let useCase: DeleteItemUseCase;
+  let owner: User;
+  let participant: User;
+  let wishlist: Wishlist;
+  let item: WishlistItem;
+
+  beforeAll(() => {
+    Logger.overrideLogger(false);
+  });
+
+  beforeEach(() => {
+    mock.clearAllMocks();
+
+    owner = new UserBuilder().withEmail('owner@test.fr').build();
+    participant = new UserBuilder().withEmail('participant@test.fr').build();
+    wishlist = new WishlistBuilder().withOwner(owner).withHideItems(true).build();
+    item = new WishlistItemBuilder().withWishlistId(wishlist.id).build();
+
+    itemRepository.findByIdOrFail.mockResolvedValue(item);
+    wishlistRepository.hasAccess.mockResolvedValue(true);
+    wishlistRepository.findByIdOrFail.mockResolvedValue(wishlist);
+
+    useCase = new DeleteItemUseCase(itemRepository, wishlistRepository);
+  });
+
+  it('should reject when the user has no access to the wishlist', async () => {
+    wishlistRepository.hasAccess.mockResolvedValueOnce(false);
+
+    await expect(useCase.execute({ currentUser: toCurrentUser(participant), itemId: item.id })).rejects.toThrow(
+      UnauthorizedException,
+    );
+    expect(itemRepository.delete).not.toHaveBeenCalled();
+    expect(itemRepository.save).not.toHaveBeenCalled();
+  });
+
+  it('should reject when the owner tries to delete a suggested item on a hidden list', async () => {
+    itemRepository.findByIdOrFail.mockResolvedValueOnce(
+      new WishlistItemBuilder().withWishlistId(wishlist.id).asSuggested().build(),
+    );
+
+    await expect(useCase.execute({ currentUser: toCurrentUser(owner), itemId: item.id })).rejects.toThrow(
+      UnauthorizedException,
+    );
+    expect(itemRepository.delete).not.toHaveBeenCalled();
+  });
+
+  it('should reject when a suggested item is already taken by someone else', async () => {
+    itemRepository.findByIdOrFail.mockResolvedValueOnce(
+      new WishlistItemBuilder().withWishlistId(wishlist.id).asSuggested().takenBy(owner).build(),
+    );
+
+    await expect(useCase.execute({ currentUser: toCurrentUser(participant), itemId: item.id })).rejects.toThrow(
+      UnauthorizedException,
+    );
+    expect(itemRepository.delete).not.toHaveBeenCalled();
+  });
+
+  it('should reject when a participant tries to delete a non-suggested item', async () => {
+    await expect(useCase.execute({ currentUser: toCurrentUser(participant), itemId: item.id })).rejects.toThrow(
+      UnauthorizedException,
+    );
+    expect(itemRepository.delete).not.toHaveBeenCalled();
+  });
+
+  it('should convert a taken non-suggested item to suggested instead of deleting it', async () => {
+    itemRepository.findByIdOrFail.mockResolvedValueOnce(
+      new WishlistItemBuilder().withWishlistId(wishlist.id).takenBy(participant).build(),
+    );
+
+    await useCase.execute({ currentUser: toCurrentUser(owner), itemId: item.id });
+
+    expect(itemRepository.delete).not.toHaveBeenCalled();
+    expect(itemRepository.save).toHaveBeenCalledTimes(1);
+    const savedItem = itemRepository.save.mock.calls[0]?.[0];
+    expect(savedItem?.isSuggested).toBe(true);
+  });
+
+  it('should delete a non-suggested item that is not taken when the owner requests it', async () => {
+    await useCase.execute({ currentUser: toCurrentUser(owner), itemId: item.id });
+
+    expect(itemRepository.delete).toHaveBeenCalledWith(item.id);
+    expect(itemRepository.save).not.toHaveBeenCalled();
+  });
+
+  it('should delete a suggested item taken by the current participant', async () => {
+    const suggestedItem = new WishlistItemBuilder()
+      .withWishlistId(wishlist.id)
+      .asSuggested()
+      .takenBy(participant)
+      .build();
+    itemRepository.findByIdOrFail.mockResolvedValueOnce(suggestedItem);
+
+    await useCase.execute({ currentUser: toCurrentUser(participant), itemId: suggestedItem.id });
+
+    expect(itemRepository.delete).toHaveBeenCalledWith(suggestedItem.id);
+  });
+});

--- a/apps/api/src/item/application/command/import-items.use-case.spec.ts
+++ b/apps/api/src/item/application/command/import-items.use-case.spec.ts
@@ -1,0 +1,102 @@
+import type { ItemId } from '@wishlist/common';
+import type { TransactionManager } from '../../../core/database/transaction-manager';
+import type { WishlistRepository } from '../../../wishlist/domain/wishlist.repository';
+import type { WishlistItemRepository } from '../../domain/wishlist-item.repository';
+
+import { Logger, UnauthorizedException } from '@nestjs/common';
+import { uuid } from '@wishlist/common';
+
+import { toCurrentUser, UserBuilder } from '../../../../test-utils/builders/user.builder';
+import { WishlistBuilder } from '../../../../test-utils/builders/wishlist.builder';
+import { WishlistItemBuilder } from '../../../../test-utils/builders/wishlist-item.builder';
+import { createMock } from '../../../../test-utils/mocks';
+import { User } from '../../../user/domain/model/user.model';
+import { Wishlist } from '../../../wishlist/domain/wishlist.model';
+import { WishlistItem } from '../../domain/wishlist-item.model';
+import { ImportItemsUseCase } from './import-items.use-case';
+import { beforeAll, beforeEach, describe, expect, it, mock } from 'bun:test';
+
+describe('ImportItemsUseCase', () => {
+  const wishlistRepository = createMock<WishlistRepository>();
+  const itemRepository = createMock<WishlistItemRepository>();
+  const transactionManager = createMock<TransactionManager>();
+
+  let useCase: ImportItemsUseCase;
+  let owner: User;
+  let stranger: User;
+  let targetWishlist: Wishlist;
+  let sourceWishlist: Wishlist;
+  let sourceItem: WishlistItem;
+  let importedItemId: ItemId;
+
+  beforeAll(() => {
+    Logger.overrideLogger(false);
+  });
+
+  beforeEach(() => {
+    mock.clearAllMocks();
+
+    owner = new UserBuilder().withEmail('owner@test.fr').build();
+    stranger = new UserBuilder().withEmail('stranger@test.fr').build();
+    targetWishlist = new WishlistBuilder().withOwner(owner).build();
+    sourceWishlist = new WishlistBuilder().withOwner(owner).withTitle('Ancienne liste').build();
+    sourceItem = new WishlistItemBuilder().withWishlistId(sourceWishlist.id).withName('Un livre').build();
+    importedItemId = uuid() as ItemId;
+
+    wishlistRepository.findByIdOrFail.mockResolvedValue(targetWishlist);
+    wishlistRepository.hasAccess.mockResolvedValue(true);
+    wishlistRepository.findByIds.mockResolvedValue([sourceWishlist]);
+    itemRepository.findByIds.mockResolvedValue([sourceItem]);
+    itemRepository.newId.mockReturnValue(importedItemId);
+    transactionManager.runInTransaction.mockImplementation(async callback => callback(undefined as never));
+
+    useCase = new ImportItemsUseCase(wishlistRepository, itemRepository, transactionManager);
+  });
+
+  it('should reject when the user has no access to the target wishlist', async () => {
+    wishlistRepository.hasAccess.mockResolvedValueOnce(false);
+
+    await expect(
+      useCase.execute({
+        currentUser: toCurrentUser(owner),
+        wishlistId: targetWishlist.id,
+        sourceItemIds: [sourceItem.id],
+      }),
+    ).rejects.toThrow(UnauthorizedException);
+    expect(itemRepository.findByIds).not.toHaveBeenCalled();
+    expect(transactionManager.runInTransaction).not.toHaveBeenCalled();
+  });
+
+  it('should reject when a source wishlist is not owned by the current user', async () => {
+    wishlistRepository.findByIds.mockResolvedValueOnce([
+      new WishlistBuilder().withOwner(stranger).withTitle('Liste d un autre').build(),
+    ]);
+
+    await expect(
+      useCase.execute({
+        currentUser: toCurrentUser(owner),
+        wishlistId: targetWishlist.id,
+        sourceItemIds: [sourceItem.id],
+      }),
+    ).rejects.toThrow(UnauthorizedException);
+    expect(transactionManager.runInTransaction).not.toHaveBeenCalled();
+    expect(itemRepository.save).not.toHaveBeenCalled();
+  });
+
+  it('should import items owned by the current user into the target wishlist', async () => {
+    const importedItems = await useCase.execute({
+      currentUser: toCurrentUser(owner),
+      wishlistId: targetWishlist.id,
+      sourceItemIds: [sourceItem.id],
+    });
+
+    expect(importedItems).toHaveLength(1);
+    expect(importedItems[0]?.id).toBe(importedItemId);
+    expect(importedItems[0]?.wishlistId).toBe(targetWishlist.id);
+    expect(importedItems[0]?.name).toBe('Un livre');
+    expect(importedItems[0]?.importSourceId).toBe(sourceItem.id);
+    expect(transactionManager.runInTransaction).toHaveBeenCalledTimes(1);
+    expect(itemRepository.save).toHaveBeenCalledTimes(1);
+    expect(itemRepository.save).toHaveBeenCalledWith(importedItems[0], undefined);
+  });
+});

--- a/apps/api/src/item/application/command/notify-new-items.use-case.spec.ts
+++ b/apps/api/src/item/application/command/notify-new-items.use-case.spec.ts
@@ -1,0 +1,78 @@
+import type { WishlistRepository } from '../../../wishlist/domain/wishlist.repository';
+import type { WishlistItemRepository } from '../../domain/wishlist-item.repository';
+
+import { Logger } from '@nestjs/common';
+import { uuid } from '@wishlist/common';
+
+import { createMock } from '../../../../test-utils/mocks';
+import { FrontendRoutesService } from '../../../core/frontend-routes/frontend-routes.service';
+import { MailService } from '../../../core/mail/mail.service';
+import { MailTemplate } from '../../../core/mail/mail.type';
+import { NotifyNewItemsUseCase } from './notify-new-items.use-case';
+import { beforeAll, beforeEach, describe, expect, it, mock } from 'bun:test';
+
+describe('NotifyNewItemsUseCase', () => {
+  const itemRepository = createMock<WishlistItemRepository>();
+  const wishlistRepository = createMock<WishlistRepository>();
+  const mailService = createMock<MailService>();
+  const frontendRoutes = createMock<FrontendRoutesService>({
+    routes: { wishlist: { byId: (id: string) => `https://app/wishlists/${id}` } },
+  } as never);
+
+  let useCase: NotifyNewItemsUseCase;
+
+  beforeAll(() => {
+    Logger.overrideLogger(false);
+  });
+
+  beforeEach(() => {
+    mock.clearAllMocks();
+    itemRepository.findAllNewItems.mockResolvedValue([]);
+    useCase = new NotifyNewItemsUseCase(itemRepository, wishlistRepository, mailService, frontendRoutes);
+  });
+
+  it('should do nothing when there are no new items', async () => {
+    await useCase.execute();
+
+    expect(mailService.sendMail).not.toHaveBeenCalled();
+  });
+
+  it('should skip a wishlist that has no emails to notify', async () => {
+    itemRepository.findAllNewItems.mockResolvedValueOnce([
+      { wishlistId: uuid(), wishlistTitle: 'Liste', ownerId: uuid(), ownerName: 'Jean', nbNewItems: 2 },
+    ]);
+    wishlistRepository.findEmailsToNotify.mockResolvedValueOnce([]);
+
+    await useCase.execute();
+
+    expect(mailService.sendMail).not.toHaveBeenCalled();
+  });
+
+  it('should send a reminder email when there are new items and recipients', async () => {
+    const wishlistId = uuid();
+    itemRepository.findAllNewItems.mockResolvedValueOnce([
+      { wishlistId, wishlistTitle: 'Liste', ownerId: uuid(), ownerName: 'Jean', nbNewItems: 3 },
+    ]);
+    wishlistRepository.findEmailsToNotify.mockResolvedValueOnce(['a@test.fr']);
+
+    await useCase.execute();
+
+    expect(mailService.sendMail).toHaveBeenCalledTimes(1);
+    expect(mailService.sendMail.mock.calls[0]?.[0]).toMatchObject({
+      to: ['a@test.fr'],
+      template: MailTemplate.NEW_ITEMS_REMINDER,
+      context: {
+        wishlistTitle: 'Liste',
+        nbItems: 3,
+        userName: 'Jean',
+      },
+    });
+  });
+
+  it('should swallow errors from fetching new items', async () => {
+    itemRepository.findAllNewItems.mockRejectedValueOnce(new Error('db down'));
+
+    await expect(useCase.execute()).resolves.toBeUndefined();
+    expect(mailService.sendMail).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/item/application/command/toggle-item.use-case.spec.ts
+++ b/apps/api/src/item/application/command/toggle-item.use-case.spec.ts
@@ -1,0 +1,147 @@
+import type { UserRepository } from '../../../user/domain/repository/user.repository';
+import type { WishlistRepository } from '../../../wishlist/domain/wishlist.repository';
+import type { WishlistItemRepository } from '../../domain/wishlist-item.repository';
+
+import { Logger, NotFoundException, UnauthorizedException } from '@nestjs/common';
+
+import { toCurrentUser, UserBuilder } from '../../../../test-utils/builders/user.builder';
+import { WishlistBuilder } from '../../../../test-utils/builders/wishlist.builder';
+import { WishlistItemBuilder } from '../../../../test-utils/builders/wishlist-item.builder';
+import { createMock } from '../../../../test-utils/mocks';
+import { User } from '../../../user/domain/model/user.model';
+import { Wishlist } from '../../../wishlist/domain/wishlist.model';
+import { WishlistItem } from '../../domain/wishlist-item.model';
+import { ToggleItemUseCase } from './toggle-item.use-case';
+import { beforeAll, beforeEach, describe, expect, it, mock } from 'bun:test';
+
+describe('ToggleItemUseCase', () => {
+  const itemRepository = createMock<WishlistItemRepository>();
+  const wishlistRepository = createMock<WishlistRepository>();
+  const userRepository = createMock<UserRepository>();
+
+  let useCase: ToggleItemUseCase;
+  let owner: User;
+  let participant: User;
+  let wishlist: Wishlist;
+  let item: WishlistItem;
+
+  beforeAll(() => {
+    Logger.overrideLogger(false);
+  });
+
+  beforeEach(() => {
+    mock.clearAllMocks();
+
+    owner = new UserBuilder().withEmail('owner@test.fr').build();
+    participant = new UserBuilder().withEmail('participant@test.fr').build();
+    wishlist = new WishlistBuilder().withOwner(owner).withHideItems(true).build();
+    item = new WishlistItemBuilder().withWishlistId(wishlist.id).build();
+
+    itemRepository.findByIdOrFail.mockResolvedValue(item);
+    wishlistRepository.hasAccess.mockResolvedValue(true);
+    wishlistRepository.findByIdOrFail.mockResolvedValue(wishlist);
+    userRepository.findByIdOrFail.mockResolvedValue(participant);
+
+    useCase = new ToggleItemUseCase(itemRepository, wishlistRepository, userRepository);
+  });
+
+  it('should reject when the user has no access to the wishlist', async () => {
+    wishlistRepository.hasAccess.mockResolvedValueOnce(false);
+
+    await expect(useCase.execute({ currentUser: toCurrentUser(participant), itemId: item.id })).rejects.toThrow(
+      UnauthorizedException,
+    );
+    expect(itemRepository.save).not.toHaveBeenCalled();
+    expect(wishlistRepository.findByIdOrFail).not.toHaveBeenCalled();
+  });
+
+  describe('when the current user is a participant', () => {
+    it('should check an item that is not yet taken by them', async () => {
+      const result = await useCase.execute({ currentUser: toCurrentUser(participant), itemId: item.id });
+
+      expect(result.takers).toHaveLength(1);
+      expect(result.takers[0]?.user.id).toBe(participant.id);
+      expect(itemRepository.save).toHaveBeenCalledTimes(1);
+    });
+
+    it('should uncheck an item already taken by them', async () => {
+      itemRepository.findByIdOrFail.mockResolvedValueOnce(
+        new WishlistItemBuilder().withWishlistId(wishlist.id).takenBy(participant).build(),
+      );
+
+      const result = await useCase.execute({ currentUser: toCurrentUser(participant), itemId: item.id });
+
+      expect(result.takers).toEqual([]);
+      expect(itemRepository.save).toHaveBeenCalledTimes(1);
+      expect(userRepository.findByIdOrFail).not.toHaveBeenCalled();
+    });
+
+    it('should join an item already taken by someone else', async () => {
+      const otherTaker = new UserBuilder().withEmail('other@test.fr').build();
+      itemRepository.findByIdOrFail.mockResolvedValueOnce(
+        new WishlistItemBuilder().withWishlistId(wishlist.id).takenBy(otherTaker).build(),
+      );
+
+      const result = await useCase.execute({ currentUser: toCurrentUser(participant), itemId: item.id });
+
+      expect(result.takers.map(taker => taker.user.id).toSorted()).toEqual([otherTaker.id, participant.id].toSorted());
+      expect(itemRepository.save).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('when the current user is the owner and hideItems is enabled', () => {
+    it('should reject checking their own items', async () => {
+      await expect(useCase.execute({ currentUser: toCurrentUser(owner), itemId: item.id })).rejects.toThrow(
+        UnauthorizedException,
+      );
+      expect(itemRepository.save).not.toHaveBeenCalled();
+    });
+
+    it('should reject unchecking their own items', async () => {
+      itemRepository.findByIdOrFail.mockResolvedValueOnce(
+        new WishlistItemBuilder().withWishlistId(wishlist.id).takenBy(owner).build(),
+      );
+
+      await expect(useCase.execute({ currentUser: toCurrentUser(owner), itemId: item.id })).rejects.toThrow(
+        UnauthorizedException,
+      );
+      expect(itemRepository.save).not.toHaveBeenCalled();
+    });
+
+    it('should hide suggested items when checking', async () => {
+      itemRepository.findByIdOrFail.mockResolvedValueOnce(
+        new WishlistItemBuilder().withWishlistId(wishlist.id).asSuggested().build(),
+      );
+
+      await expect(useCase.execute({ currentUser: toCurrentUser(owner), itemId: item.id })).rejects.toThrow(
+        NotFoundException,
+      );
+      expect(itemRepository.save).not.toHaveBeenCalled();
+    });
+
+    it('should hide suggested items when unchecking', async () => {
+      itemRepository.findByIdOrFail.mockResolvedValueOnce(
+        new WishlistItemBuilder().withWishlistId(wishlist.id).asSuggested().takenBy(owner).build(),
+      );
+
+      await expect(useCase.execute({ currentUser: toCurrentUser(owner), itemId: item.id })).rejects.toThrow(
+        NotFoundException,
+      );
+      expect(itemRepository.save).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when the current user is the owner and hideItems is disabled', () => {
+    it('should allow checking their own items', async () => {
+      const publicWishlist = new WishlistBuilder().withOwner(owner).withHideItems(false).build();
+      wishlistRepository.findByIdOrFail.mockResolvedValueOnce(publicWishlist);
+      userRepository.findByIdOrFail.mockResolvedValueOnce(owner);
+
+      const result = await useCase.execute({ currentUser: toCurrentUser(owner), itemId: item.id });
+
+      expect(result.takers).toHaveLength(1);
+      expect(result.takers[0]?.user.id).toBe(owner.id);
+      expect(itemRepository.save).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/apps/api/src/item/application/command/update-item.use-case.spec.ts
+++ b/apps/api/src/item/application/command/update-item.use-case.spec.ts
@@ -1,0 +1,139 @@
+import type { WishlistRepository } from '../../../wishlist/domain/wishlist.repository';
+import type { WishlistItemRepository } from '../../domain/wishlist-item.repository';
+
+import { Logger, NotFoundException, UnauthorizedException } from '@nestjs/common';
+
+import { toCurrentUser, UserBuilder } from '../../../../test-utils/builders/user.builder';
+import { WishlistBuilder } from '../../../../test-utils/builders/wishlist.builder';
+import { WishlistItemBuilder } from '../../../../test-utils/builders/wishlist-item.builder';
+import { createMock } from '../../../../test-utils/mocks';
+import { User } from '../../../user/domain/model/user.model';
+import { Wishlist } from '../../../wishlist/domain/wishlist.model';
+import { WishlistItem } from '../../domain/wishlist-item.model';
+import { UpdateItemUseCase } from './update-item.use-case';
+import { beforeAll, beforeEach, describe, expect, it, mock } from 'bun:test';
+
+describe('UpdateItemUseCase', () => {
+  const itemRepository = createMock<WishlistItemRepository>();
+  const wishlistRepository = createMock<WishlistRepository>();
+
+  let useCase: UpdateItemUseCase;
+  let owner: User;
+  let participant: User;
+  let wishlist: Wishlist;
+  let item: WishlistItem;
+
+  beforeAll(() => {
+    Logger.overrideLogger(false);
+  });
+
+  beforeEach(() => {
+    mock.clearAllMocks();
+
+    owner = new UserBuilder().withEmail('owner@test.fr').build();
+    participant = new UserBuilder().withEmail('participant@test.fr').build();
+    wishlist = new WishlistBuilder().withOwner(owner).withHideItems(true).build();
+    item = new WishlistItemBuilder().withWishlistId(wishlist.id).build();
+
+    itemRepository.findByIdOrFail.mockResolvedValue(item);
+    wishlistRepository.hasAccess.mockResolvedValue(true);
+    wishlistRepository.findByIdOrFail.mockResolvedValue(wishlist);
+
+    useCase = new UpdateItemUseCase(itemRepository, wishlistRepository);
+  });
+
+  it('should reject when the user has no access to the wishlist', async () => {
+    wishlistRepository.hasAccess.mockResolvedValueOnce(false);
+
+    await expect(
+      useCase.execute({
+        currentUser: toCurrentUser(participant),
+        itemId: item.id,
+        updateItem: { name: 'Nouveau nom' },
+      }),
+    ).rejects.toThrow(UnauthorizedException);
+    expect(itemRepository.save).not.toHaveBeenCalled();
+  });
+
+  it('should hide a suggested item when the owner updates it on a hidden list', async () => {
+    itemRepository.findByIdOrFail.mockResolvedValueOnce(
+      new WishlistItemBuilder().withWishlistId(wishlist.id).asSuggested().build(),
+    );
+
+    await expect(
+      useCase.execute({
+        currentUser: toCurrentUser(owner),
+        itemId: item.id,
+        updateItem: { name: 'Nouveau nom' },
+      }),
+    ).rejects.toThrow(NotFoundException);
+    expect(itemRepository.save).not.toHaveBeenCalled();
+  });
+
+  it('should reject when a suggested item is already taken by someone else', async () => {
+    itemRepository.findByIdOrFail.mockResolvedValueOnce(
+      new WishlistItemBuilder().withWishlistId(wishlist.id).asSuggested().takenBy(owner).build(),
+    );
+
+    await expect(
+      useCase.execute({
+        currentUser: toCurrentUser(participant),
+        itemId: item.id,
+        updateItem: { name: 'Nouveau nom' },
+      }),
+    ).rejects.toThrow(UnauthorizedException);
+    expect(itemRepository.save).not.toHaveBeenCalled();
+  });
+
+  it('should reject when a participant tries to update a non-suggested item', async () => {
+    await expect(
+      useCase.execute({
+        currentUser: toCurrentUser(participant),
+        itemId: item.id,
+        updateItem: { name: 'Nouveau nom' },
+      }),
+    ).rejects.toThrow(UnauthorizedException);
+    expect(itemRepository.save).not.toHaveBeenCalled();
+  });
+
+  it('should update a non-suggested item when the owner requests it', async () => {
+    await useCase.execute({
+      currentUser: toCurrentUser(owner),
+      itemId: item.id,
+      updateItem: {
+        name: 'Nouveau nom',
+        description: 'SF',
+        score: 4,
+        url: 'https://example.com/item?utm_source=share',
+        pictureUrl: 'https://example.com/pic.png',
+      },
+    });
+
+    expect(itemRepository.save).toHaveBeenCalledTimes(1);
+    const savedItem = itemRepository.save.mock.calls[0]?.[0];
+    expect(savedItem?.name).toBe('Nouveau nom');
+    expect(savedItem?.description).toBe('SF');
+    expect(savedItem?.score).toBe(4);
+    expect(savedItem?.imageUrl).toBe('https://example.com/pic.png');
+    expect(savedItem?.url).toBeDefined();
+  });
+
+  it('should update a suggested item taken by the current participant', async () => {
+    const suggestedItem = new WishlistItemBuilder()
+      .withWishlistId(wishlist.id)
+      .asSuggested()
+      .takenBy(participant)
+      .build();
+    itemRepository.findByIdOrFail.mockResolvedValueOnce(suggestedItem);
+
+    await useCase.execute({
+      currentUser: toCurrentUser(participant),
+      itemId: suggestedItem.id,
+      updateItem: { name: 'Suggestion mise à jour' },
+    });
+
+    expect(itemRepository.save).toHaveBeenCalledTimes(1);
+    const savedItem = itemRepository.save.mock.calls[0]?.[0];
+    expect(savedItem?.name).toBe('Suggestion mise à jour');
+  });
+});

--- a/apps/api/src/item/application/query/get-importable-items.use-case.spec.ts
+++ b/apps/api/src/item/application/query/get-importable-items.use-case.spec.ts
@@ -1,0 +1,66 @@
+import type { WishlistRepository } from '../../../wishlist/domain/wishlist.repository';
+import type { WishlistItemRepository } from '../../domain/wishlist-item.repository';
+
+import { Logger, UnauthorizedException } from '@nestjs/common';
+
+import { UserBuilder } from '../../../../test-utils/builders/user.builder';
+import { WishlistBuilder } from '../../../../test-utils/builders/wishlist.builder';
+import { WishlistItemBuilder } from '../../../../test-utils/builders/wishlist-item.builder';
+import { createMock } from '../../../../test-utils/mocks';
+import { User } from '../../../user/domain/model/user.model';
+import { Wishlist } from '../../../wishlist/domain/wishlist.model';
+import { WishlistItem } from '../../domain/wishlist-item.model';
+import { GetImportableItemsUseCase } from './get-importable-items.use-case';
+import { beforeAll, beforeEach, describe, expect, it, mock } from 'bun:test';
+
+describe('GetImportableItemsUseCase', () => {
+  const itemRepository = createMock<WishlistItemRepository>();
+  const wishlistRepository = createMock<WishlistRepository>();
+
+  let useCase: GetImportableItemsUseCase;
+  let owner: User;
+  let stranger: User;
+  let wishlist: Wishlist;
+  let importableItems: WishlistItem[];
+
+  beforeAll(() => {
+    Logger.overrideLogger(false);
+  });
+
+  beforeEach(() => {
+    mock.clearAllMocks();
+
+    owner = new UserBuilder().withEmail('owner@test.fr').build();
+    stranger = new UserBuilder().withEmail('stranger@test.fr').build();
+    wishlist = new WishlistBuilder().withOwner(owner).build();
+    importableItems = [new WishlistItemBuilder().withName('Un livre').build()];
+
+    wishlistRepository.findByIdOrFail.mockResolvedValue(wishlist);
+    itemRepository.findImportableItems.mockResolvedValue(importableItems);
+
+    useCase = new GetImportableItemsUseCase(itemRepository, wishlistRepository);
+  });
+
+  it('should reject when the user is not the owner of the wishlist', async () => {
+    await expect(
+      useCase.execute({
+        userId: stranger.id,
+        wishlistId: wishlist.id,
+      }),
+    ).rejects.toThrow(UnauthorizedException);
+    expect(itemRepository.findImportableItems).not.toHaveBeenCalled();
+  });
+
+  it('should return importable items when the user owns the wishlist', async () => {
+    const result = await useCase.execute({
+      userId: owner.id,
+      wishlistId: wishlist.id,
+    });
+
+    expect(result).toBe(importableItems);
+    expect(itemRepository.findImportableItems).toHaveBeenCalledWith({
+      userId: owner.id,
+      wishlistId: wishlist.id,
+    });
+  });
+});

--- a/apps/api/src/secret-santa/application/command/add-secret-santa-users.use-case.spec.ts
+++ b/apps/api/src/secret-santa/application/command/add-secret-santa-users.use-case.spec.ts
@@ -1,0 +1,119 @@
+import type { AttendeeId, SecretSantaUserId } from '@wishlist/common';
+import type { EventRepository } from '../../../event/domain/repository/event.repository';
+import type { SecretSantaRepository } from '../../domain/repository/secret-santa.repository';
+import type { SecretSantaUserRepository } from '../../domain/repository/secret-santa-user.repository';
+
+import { BadRequestException, ForbiddenException, Logger } from '@nestjs/common';
+import { uuid } from '@wishlist/common';
+
+import { EventBuilder } from '../../../../test-utils/builders/event.builder';
+import { SecretSantaBuilder } from '../../../../test-utils/builders/secret-santa.builder';
+import { SecretSantaUserBuilder } from '../../../../test-utils/builders/secret-santa-user.builder';
+import { toCurrentUser, UserBuilder } from '../../../../test-utils/builders/user.builder';
+import { createMock } from '../../../../test-utils/mocks';
+import { Event } from '../../../event/domain/model/event.model';
+import { User } from '../../../user/domain/model/user.model';
+import { SecretSanta } from '../../domain/model/secret-santa.model';
+import { AddSecretSantaUsersUseCase } from './add-secret-santa-users.use-case';
+import { beforeAll, beforeEach, describe, expect, it, mock } from 'bun:test';
+
+describe('AddSecretSantaUsersUseCase', () => {
+  const secretSantaRepository = createMock<SecretSantaRepository>();
+  const secretSantaUserRepository = createMock<SecretSantaUserRepository>();
+  const eventRepository = createMock<EventRepository>();
+
+  let useCase: AddSecretSantaUsersUseCase;
+  let creator: User;
+  let participant: User;
+  let event: Event;
+  let santa: SecretSanta;
+
+  beforeAll(() => {
+    Logger.overrideLogger(false);
+  });
+
+  beforeEach(() => {
+    mock.clearAllMocks();
+
+    creator = new UserBuilder().withEmail('creator@test.fr').build();
+    participant = new UserBuilder().withEmail('participant@test.fr').build();
+    event = new EventBuilder().withCreator(creator).withAttendee(participant).build();
+    santa = new SecretSantaBuilder().withEventId(event.id).build();
+
+    secretSantaRepository.findByIdOrFail.mockResolvedValue(santa);
+    eventRepository.findByIdOrFail.mockResolvedValue(event);
+    secretSantaUserRepository.newId.mockImplementation(() => uuid() as SecretSantaUserId);
+
+    useCase = new AddSecretSantaUsersUseCase(secretSantaRepository, secretSantaUserRepository, eventRepository);
+  });
+
+  it('should reject when the current user cannot edit the event', async () => {
+    await expect(
+      useCase.execute({
+        currentUser: toCurrentUser(participant),
+        secretSantaId: santa.id,
+        attendeeIds: event.attendees.map(a => a.id),
+      }),
+    ).rejects.toThrow(ForbiddenException);
+    expect(secretSantaUserRepository.saveAll).not.toHaveBeenCalled();
+  });
+
+  it('should reject when the secret santa is already started', async () => {
+    secretSantaRepository.findByIdOrFail.mockResolvedValueOnce(
+      new SecretSantaBuilder().withEventId(event.id).started().build(),
+    );
+
+    await expect(
+      useCase.execute({
+        currentUser: toCurrentUser(creator),
+        secretSantaId: santa.id,
+        attendeeIds: event.attendees.map(a => a.id),
+      }),
+    ).rejects.toThrow(ForbiddenException);
+    expect(secretSantaUserRepository.saveAll).not.toHaveBeenCalled();
+  });
+
+  it('should reject when an attendee is already in the secret santa', async () => {
+    const users = event.attendees.map(a => new SecretSantaUserBuilder().withAttendeeId(a.id).build());
+    secretSantaRepository.findByIdOrFail.mockResolvedValueOnce(
+      new SecretSantaBuilder().withEventId(event.id).withUsers(users).build(),
+    );
+
+    await expect(
+      useCase.execute({
+        currentUser: toCurrentUser(creator),
+        secretSantaId: santa.id,
+        attendeeIds: [event.attendees[0]!.id],
+      }),
+    ).rejects.toThrow(BadRequestException);
+    expect(secretSantaUserRepository.saveAll).not.toHaveBeenCalled();
+  });
+
+  it('should reject when an attendee is not found for the event', async () => {
+    const unknownAttendeeId = uuid() as AttendeeId;
+
+    await expect(
+      useCase.execute({
+        currentUser: toCurrentUser(creator),
+        secretSantaId: santa.id,
+        attendeeIds: [unknownAttendeeId],
+      }),
+    ).rejects.toThrow(BadRequestException);
+    expect(secretSantaUserRepository.saveAll).not.toHaveBeenCalled();
+  });
+
+  it('should add secret santa users and save them', async () => {
+    const attendeeIds = event.attendees.map(a => a.id);
+
+    const { users } = await useCase.execute({
+      currentUser: toCurrentUser(creator),
+      secretSantaId: santa.id,
+      attendeeIds,
+    });
+
+    expect(users).toHaveLength(attendeeIds.length);
+    expect(users.map(user => user.attendeeId).toSorted()).toEqual([...attendeeIds].toSorted());
+    expect(users.every(user => user.secretSantaId === santa.id)).toBe(true);
+    expect(secretSantaUserRepository.saveAll).toHaveBeenCalledWith(users);
+  });
+});

--- a/apps/api/src/secret-santa/application/command/cancel-secret-santa.use-case.spec.ts
+++ b/apps/api/src/secret-santa/application/command/cancel-secret-santa.use-case.spec.ts
@@ -1,0 +1,101 @@
+import type { EventBus } from '@nestjs/cqrs';
+import type { TransactionManager } from '../../../core/database/transaction-manager';
+import type { EventRepository } from '../../../event/domain/repository/event.repository';
+import type { SecretSantaRepository } from '../../domain/repository/secret-santa.repository';
+import type { SecretSantaUserRepository } from '../../domain/repository/secret-santa-user.repository';
+
+import { ForbiddenException, Logger } from '@nestjs/common';
+
+import { EventBuilder } from '../../../../test-utils/builders/event.builder';
+import { SecretSantaBuilder } from '../../../../test-utils/builders/secret-santa.builder';
+import { SecretSantaUserBuilder } from '../../../../test-utils/builders/secret-santa-user.builder';
+import { toCurrentUser, UserBuilder } from '../../../../test-utils/builders/user.builder';
+import { createMock } from '../../../../test-utils/mocks';
+import { Event } from '../../../event/domain/model/event.model';
+import { User } from '../../../user/domain/model/user.model';
+import { SecretSantaCancelledEvent } from '../../domain/event/secret-santa-cancelled.event';
+import { SecretSanta } from '../../domain/model/secret-santa.model';
+import { CancelSecretSantaUseCase } from './cancel-secret-santa.use-case';
+import { beforeAll, beforeEach, describe, expect, it, mock } from 'bun:test';
+
+describe('CancelSecretSantaUseCase', () => {
+  const secretSantaRepository = createMock<SecretSantaRepository>();
+  const secretSantaUserRepository = createMock<SecretSantaUserRepository>();
+  const eventRepository = createMock<EventRepository>();
+  const transactionManager = createMock<TransactionManager>();
+  const eventBus = createMock<EventBus>();
+
+  let useCase: CancelSecretSantaUseCase;
+  let creator: User;
+  let participant: User;
+  let event: Event;
+  let santa: SecretSanta;
+
+  beforeAll(() => {
+    Logger.overrideLogger(false);
+  });
+
+  beforeEach(() => {
+    mock.clearAllMocks();
+
+    creator = new UserBuilder().withEmail('creator@test.fr').build();
+    participant = new UserBuilder().withEmail('participant@test.fr').build();
+    event = new EventBuilder().withCreator(creator).withAttendee(participant).build();
+    const users = event.attendees.map(a => new SecretSantaUserBuilder().withAttendeeId(a.id).build());
+    santa = new SecretSantaBuilder().withEventId(event.id).withUsers(users).started().build();
+
+    secretSantaRepository.findByIdOrFail.mockResolvedValue(santa);
+    eventRepository.findByIdOrFail.mockResolvedValue(event);
+    transactionManager.runInTransaction.mockImplementation(async fn => fn({} as never));
+
+    useCase = new CancelSecretSantaUseCase(
+      secretSantaRepository,
+      secretSantaUserRepository,
+      eventRepository,
+      transactionManager,
+      eventBus,
+    );
+  });
+
+  it('should reject when the current user cannot edit the event', async () => {
+    await expect(useCase.execute({ currentUser: toCurrentUser(participant), secretSantaId: santa.id })).rejects.toThrow(
+      ForbiddenException,
+    );
+    expect(transactionManager.runInTransaction).not.toHaveBeenCalled();
+    expect(eventBus.publish).not.toHaveBeenCalled();
+  });
+
+  it('should reject when the secret santa has not started yet', async () => {
+    const users = event.attendees.map(a => new SecretSantaUserBuilder().withAttendeeId(a.id).build());
+    secretSantaRepository.findByIdOrFail.mockResolvedValueOnce(
+      new SecretSantaBuilder().withEventId(event.id).withUsers(users).build(),
+    );
+
+    await expect(useCase.execute({ currentUser: toCurrentUser(creator), secretSantaId: santa.id })).rejects.toThrow(
+      'Secret Santa not yet started',
+    );
+    expect(transactionManager.runInTransaction).not.toHaveBeenCalled();
+    expect(eventBus.publish).not.toHaveBeenCalled();
+  });
+
+  it('should cancel the secret santa, persist in a transaction and publish an event', async () => {
+    await useCase.execute({ currentUser: toCurrentUser(creator), secretSantaId: santa.id });
+
+    expect(transactionManager.runInTransaction).toHaveBeenCalledTimes(1);
+    expect(secretSantaRepository.save).toHaveBeenCalledTimes(1);
+    expect(secretSantaUserRepository.saveAll).toHaveBeenCalledTimes(1);
+
+    const savedSanta = secretSantaRepository.save.mock.calls[0]?.[0];
+    expect(savedSanta?.isCreated()).toBe(true);
+    expect(savedSanta?.users.every(user => user.drawUserId === undefined)).toBe(true);
+
+    expect(eventBus.publish).toHaveBeenCalledTimes(1);
+    const published = eventBus.publish.mock.calls[0]?.[0];
+    expect(published).toBeInstanceOf(SecretSantaCancelledEvent);
+    expect(published).toMatchObject({
+      eventTitle: event.title,
+      eventId: event.id,
+      attendeeEmails: event.attendees.map(attendee => attendee.getEmail()),
+    });
+  });
+});

--- a/apps/api/src/secret-santa/application/command/create-secret-santa.use-case.spec.ts
+++ b/apps/api/src/secret-santa/application/command/create-secret-santa.use-case.spec.ts
@@ -1,0 +1,76 @@
+import type { SecretSantaId } from '@wishlist/common';
+import type { EventRepository } from '../../../event/domain/repository/event.repository';
+import type { SecretSantaRepository } from '../../domain/repository/secret-santa.repository';
+
+import { ConflictException, ForbiddenException, Logger } from '@nestjs/common';
+import { uuid } from '@wishlist/common';
+
+import { EventBuilder } from '../../../../test-utils/builders/event.builder';
+import { toCurrentUser, UserBuilder } from '../../../../test-utils/builders/user.builder';
+import { createMock } from '../../../../test-utils/mocks';
+import { Event } from '../../../event/domain/model/event.model';
+import { User } from '../../../user/domain/model/user.model';
+import { CreateSecretSantaUseCase } from './create-secret-santa.use-case';
+import { beforeAll, beforeEach, describe, expect, it, mock } from 'bun:test';
+
+describe('CreateSecretSantaUseCase', () => {
+  const eventRepository = createMock<EventRepository>();
+  const secretSantaRepository = createMock<SecretSantaRepository>();
+
+  let useCase: CreateSecretSantaUseCase;
+  let creator: User;
+  let participant: User;
+  let event: Event;
+  let secretSantaId: SecretSantaId;
+
+  beforeAll(() => {
+    Logger.overrideLogger(false);
+  });
+
+  beforeEach(() => {
+    mock.clearAllMocks();
+
+    creator = new UserBuilder().withEmail('creator@test.fr').build();
+    participant = new UserBuilder().withEmail('participant@test.fr').build();
+    event = new EventBuilder().withCreator(creator).withAttendee(participant).build();
+    secretSantaId = uuid() as SecretSantaId;
+
+    secretSantaRepository.existsForEvent.mockResolvedValue(false);
+    eventRepository.findByIdOrFail.mockResolvedValue(event);
+    secretSantaRepository.newId.mockReturnValue(secretSantaId);
+
+    useCase = new CreateSecretSantaUseCase(eventRepository, secretSantaRepository);
+  });
+
+  it('should reject when a secret santa already exists for the event', async () => {
+    secretSantaRepository.existsForEvent.mockResolvedValueOnce(true);
+
+    await expect(useCase.execute({ currentUser: toCurrentUser(creator), eventId: event.id })).rejects.toThrow(
+      ConflictException,
+    );
+    expect(eventRepository.findByIdOrFail).not.toHaveBeenCalled();
+    expect(secretSantaRepository.save).not.toHaveBeenCalled();
+  });
+
+  it('should reject when the current user cannot edit the event', async () => {
+    await expect(useCase.execute({ currentUser: toCurrentUser(participant), eventId: event.id })).rejects.toThrow(
+      ForbiddenException,
+    );
+    expect(secretSantaRepository.save).not.toHaveBeenCalled();
+  });
+
+  it('should create and save a secret santa', async () => {
+    const { secretSanta } = await useCase.execute({
+      currentUser: toCurrentUser(creator),
+      eventId: event.id,
+      description: 'Tirage au sort',
+      budget: 30,
+    });
+
+    expect(secretSanta.id).toBe(secretSantaId);
+    expect(secretSanta.eventId).toBe(event.id);
+    expect(secretSanta.description).toBe('Tirage au sort');
+    expect(secretSanta.budget).toBe(30);
+    expect(secretSantaRepository.save).toHaveBeenCalledWith(secretSanta);
+  });
+});

--- a/apps/api/src/secret-santa/application/command/delete-secret-santa-user.use-case.spec.ts
+++ b/apps/api/src/secret-santa/application/command/delete-secret-santa-user.use-case.spec.ts
@@ -1,0 +1,90 @@
+import type { EventRepository } from '../../../event/domain/repository/event.repository';
+import type { SecretSantaRepository } from '../../domain/repository/secret-santa.repository';
+import type { SecretSantaUserRepository } from '../../domain/repository/secret-santa-user.repository';
+
+import { ForbiddenException, Logger } from '@nestjs/common';
+
+import { EventBuilder } from '../../../../test-utils/builders/event.builder';
+import { SecretSantaBuilder } from '../../../../test-utils/builders/secret-santa.builder';
+import { SecretSantaUserBuilder } from '../../../../test-utils/builders/secret-santa-user.builder';
+import { toCurrentUser, UserBuilder } from '../../../../test-utils/builders/user.builder';
+import { createMock } from '../../../../test-utils/mocks';
+import { Event } from '../../../event/domain/model/event.model';
+import { User } from '../../../user/domain/model/user.model';
+import { SecretSanta } from '../../domain/model/secret-santa.model';
+import { SecretSantaUser } from '../../domain/model/secret-santa-user.model';
+import { DeleteSecretSantaUserUseCase } from './delete-secret-santa-user.use-case';
+import { beforeAll, beforeEach, describe, expect, it, mock } from 'bun:test';
+
+describe('DeleteSecretSantaUserUseCase', () => {
+  const secretSantaRepository = createMock<SecretSantaRepository>();
+  const secretSantaUserRepository = createMock<SecretSantaUserRepository>();
+  const eventRepository = createMock<EventRepository>();
+
+  let useCase: DeleteSecretSantaUserUseCase;
+  let creator: User;
+  let participant: User;
+  let event: Event;
+  let santa: SecretSanta;
+  let santaUser: SecretSantaUser;
+
+  beforeAll(() => {
+    Logger.overrideLogger(false);
+  });
+
+  beforeEach(() => {
+    mock.clearAllMocks();
+
+    creator = new UserBuilder().withEmail('creator@test.fr').build();
+    participant = new UserBuilder().withEmail('participant@test.fr').build();
+    event = new EventBuilder().withCreator(creator).withAttendee(participant).build();
+    const users = event.attendees.map(a => new SecretSantaUserBuilder().withAttendeeId(a.id).build());
+    santaUser = users[0]!;
+    santa = new SecretSantaBuilder().withEventId(event.id).withUsers(users).build();
+
+    secretSantaRepository.findByIdOrFail.mockResolvedValue(santa);
+    eventRepository.findByIdOrFail.mockResolvedValue(event);
+
+    useCase = new DeleteSecretSantaUserUseCase(secretSantaRepository, secretSantaUserRepository, eventRepository);
+  });
+
+  it('should reject when the current user cannot edit the event', async () => {
+    await expect(
+      useCase.execute({
+        currentUser: toCurrentUser(participant),
+        secretSantaId: santa.id,
+        secretSantaUserId: santaUser.id,
+      }),
+    ).rejects.toThrow(ForbiddenException);
+    expect(secretSantaUserRepository.delete).not.toHaveBeenCalled();
+  });
+
+  it('should reject when the secret santa is already started', async () => {
+    secretSantaRepository.findByIdOrFail.mockResolvedValueOnce(
+      new SecretSantaBuilder()
+        .withEventId(event.id)
+        .withUsers(event.attendees.map(a => new SecretSantaUserBuilder().withAttendeeId(a.id).build()))
+        .started()
+        .build(),
+    );
+
+    await expect(
+      useCase.execute({
+        currentUser: toCurrentUser(creator),
+        secretSantaId: santa.id,
+        secretSantaUserId: santaUser.id,
+      }),
+    ).rejects.toThrow(ForbiddenException);
+    expect(secretSantaUserRepository.delete).not.toHaveBeenCalled();
+  });
+
+  it('should delete the secret santa user', async () => {
+    await useCase.execute({
+      currentUser: toCurrentUser(creator),
+      secretSantaId: santa.id,
+      secretSantaUserId: santaUser.id,
+    });
+
+    expect(secretSantaUserRepository.delete).toHaveBeenCalledWith(santaUser.id);
+  });
+});

--- a/apps/api/src/secret-santa/application/command/delete-secret-santa.use-case.spec.ts
+++ b/apps/api/src/secret-santa/application/command/delete-secret-santa.use-case.spec.ts
@@ -1,0 +1,73 @@
+import type { EventRepository } from '../../../event/domain/repository/event.repository';
+import type { SecretSantaRepository } from '../../domain/repository/secret-santa.repository';
+
+import { ForbiddenException, Logger } from '@nestjs/common';
+
+import { EventBuilder } from '../../../../test-utils/builders/event.builder';
+import { SecretSantaBuilder } from '../../../../test-utils/builders/secret-santa.builder';
+import { SecretSantaUserBuilder } from '../../../../test-utils/builders/secret-santa-user.builder';
+import { toCurrentUser, UserBuilder } from '../../../../test-utils/builders/user.builder';
+import { createMock } from '../../../../test-utils/mocks';
+import { Event } from '../../../event/domain/model/event.model';
+import { User } from '../../../user/domain/model/user.model';
+import { SecretSanta } from '../../domain/model/secret-santa.model';
+import { DeleteSecretSantaUseCase } from './delete-secret-santa.use-case';
+import { beforeAll, beforeEach, describe, expect, it, mock } from 'bun:test';
+
+describe('DeleteSecretSantaUseCase', () => {
+  const secretSantaRepository = createMock<SecretSantaRepository>();
+  const eventRepository = createMock<EventRepository>();
+
+  let useCase: DeleteSecretSantaUseCase;
+  let creator: User;
+  let participant: User;
+  let event: Event;
+  let santa: SecretSanta;
+
+  beforeAll(() => {
+    Logger.overrideLogger(false);
+  });
+
+  beforeEach(() => {
+    mock.clearAllMocks();
+
+    creator = new UserBuilder().withEmail('creator@test.fr').build();
+    participant = new UserBuilder().withEmail('participant@test.fr').build();
+    event = new EventBuilder().withCreator(creator).withAttendee(participant).build();
+    const users = event.attendees.map(a => new SecretSantaUserBuilder().withAttendeeId(a.id).build());
+    santa = new SecretSantaBuilder().withEventId(event.id).withUsers(users).build();
+
+    secretSantaRepository.findByIdOrFail.mockResolvedValue(santa);
+    eventRepository.findByIdOrFail.mockResolvedValue(event);
+
+    useCase = new DeleteSecretSantaUseCase(secretSantaRepository, eventRepository);
+  });
+
+  it('should reject when the current user cannot edit the event', async () => {
+    await expect(useCase.execute({ currentUser: toCurrentUser(participant), secretSantaId: santa.id })).rejects.toThrow(
+      ForbiddenException,
+    );
+    expect(secretSantaRepository.delete).not.toHaveBeenCalled();
+  });
+
+  it('should reject when the secret santa is already started', async () => {
+    secretSantaRepository.findByIdOrFail.mockResolvedValueOnce(
+      new SecretSantaBuilder()
+        .withEventId(event.id)
+        .withUsers(event.attendees.map(a => new SecretSantaUserBuilder().withAttendeeId(a.id).build()))
+        .started()
+        .build(),
+    );
+
+    await expect(useCase.execute({ currentUser: toCurrentUser(creator), secretSantaId: santa.id })).rejects.toThrow(
+      ForbiddenException,
+    );
+    expect(secretSantaRepository.delete).not.toHaveBeenCalled();
+  });
+
+  it('should delete the secret santa', async () => {
+    await useCase.execute({ currentUser: toCurrentUser(creator), secretSantaId: santa.id });
+
+    expect(secretSantaRepository.delete).toHaveBeenCalledWith(santa.id);
+  });
+});

--- a/apps/api/src/secret-santa/application/command/start-secret-santa.use-case.spec.ts
+++ b/apps/api/src/secret-santa/application/command/start-secret-santa.use-case.spec.ts
@@ -1,0 +1,135 @@
+import type { EventBus } from '@nestjs/cqrs';
+import type { TransactionManager } from '../../../core/database/transaction-manager';
+import type { EventRepository } from '../../../event/domain/repository/event.repository';
+import type { SecretSantaRepository } from '../../domain/repository/secret-santa.repository';
+import type { SecretSantaUserRepository } from '../../domain/repository/secret-santa-user.repository';
+
+import { BadRequestException, ForbiddenException, Logger } from '@nestjs/common';
+
+import { EventBuilder } from '../../../../test-utils/builders/event.builder';
+import { SecretSantaBuilder } from '../../../../test-utils/builders/secret-santa.builder';
+import { SecretSantaUserBuilder } from '../../../../test-utils/builders/secret-santa-user.builder';
+import { toCurrentUser, UserBuilder } from '../../../../test-utils/builders/user.builder';
+import { createMock } from '../../../../test-utils/mocks';
+import { Event } from '../../../event/domain/model/event.model';
+import { User } from '../../../user/domain/model/user.model';
+import { SecretSantaStartedEvent } from '../../domain/event/secret-santa-started.event';
+import { SecretSanta } from '../../domain/model/secret-santa.model';
+import { StartSecretSantaUseCase } from './start-secret-santa.use-case';
+import { beforeAll, beforeEach, describe, expect, it, mock } from 'bun:test';
+
+describe('StartSecretSantaUseCase', () => {
+  const secretSantaRepository = createMock<SecretSantaRepository>();
+  const secretSantaUserRepository = createMock<SecretSantaUserRepository>();
+  const eventRepository = createMock<EventRepository>();
+  const eventBus = createMock<EventBus>();
+  const transactionManager = createMock<TransactionManager>();
+
+  let useCase: StartSecretSantaUseCase;
+  let creator: User;
+  let participant: User;
+  let event: Event;
+  let santa: SecretSanta;
+
+  beforeAll(() => {
+    Logger.overrideLogger(false);
+  });
+
+  beforeEach(() => {
+    mock.clearAllMocks();
+
+    creator = new UserBuilder().withEmail('creator@test.fr').build();
+    participant = new UserBuilder().withEmail('participant@test.fr').build();
+    event = new EventBuilder().withCreator(creator).withAttendee(participant).build();
+    const users = event.attendees.map(a => new SecretSantaUserBuilder().withAttendeeId(a.id).build());
+    santa = new SecretSantaBuilder().withEventId(event.id).withUsers(users).withBudget(25).build();
+
+    secretSantaRepository.findByIdOrFail.mockResolvedValue(santa);
+    eventRepository.findByIdOrFail.mockResolvedValue(event);
+    transactionManager.runInTransaction.mockImplementation(async fn => fn({} as never));
+
+    useCase = new StartSecretSantaUseCase(
+      secretSantaRepository,
+      secretSantaUserRepository,
+      eventRepository,
+      eventBus,
+      transactionManager,
+    );
+  });
+
+  it('should reject when the current user cannot edit the event', async () => {
+    await expect(useCase.execute({ currentUser: toCurrentUser(participant), secretSantaId: santa.id })).rejects.toThrow(
+      ForbiddenException,
+    );
+    expect(transactionManager.runInTransaction).not.toHaveBeenCalled();
+    expect(eventBus.publish).not.toHaveBeenCalled();
+  });
+
+  it('should reject when the secret santa is already started', async () => {
+    secretSantaRepository.findByIdOrFail.mockResolvedValueOnce(
+      new SecretSantaBuilder()
+        .withEventId(event.id)
+        .withUsers(event.attendees.map(a => new SecretSantaUserBuilder().withAttendeeId(a.id).build()))
+        .started()
+        .build(),
+    );
+
+    await expect(useCase.execute({ currentUser: toCurrentUser(creator), secretSantaId: santa.id })).rejects.toThrow(
+      ForbiddenException,
+    );
+    expect(transactionManager.runInTransaction).not.toHaveBeenCalled();
+    expect(eventBus.publish).not.toHaveBeenCalled();
+  });
+
+  it('should reject when the event is already finished', async () => {
+    const finishedEvent = new EventBuilder().withCreator(creator).withAttendee(participant).finished().build();
+    const users = finishedEvent.attendees.map(a => new SecretSantaUserBuilder().withAttendeeId(a.id).build());
+    secretSantaRepository.findByIdOrFail.mockResolvedValueOnce(
+      new SecretSantaBuilder().withEventId(finishedEvent.id).withUsers(users).build(),
+    );
+    eventRepository.findByIdOrFail.mockResolvedValueOnce(finishedEvent);
+
+    await expect(useCase.execute({ currentUser: toCurrentUser(creator), secretSantaId: santa.id })).rejects.toThrow(
+      BadRequestException,
+    );
+    expect(transactionManager.runInTransaction).not.toHaveBeenCalled();
+    expect(eventBus.publish).not.toHaveBeenCalled();
+  });
+
+  it('should reject when there are not enough users to start', async () => {
+    const soloEvent = new EventBuilder().withCreator(creator).build();
+    const users = soloEvent.attendees.map(a => new SecretSantaUserBuilder().withAttendeeId(a.id).build());
+    secretSantaRepository.findByIdOrFail.mockResolvedValueOnce(
+      new SecretSantaBuilder().withEventId(soloEvent.id).withUsers(users).build(),
+    );
+    eventRepository.findByIdOrFail.mockResolvedValueOnce(soloEvent);
+
+    await expect(useCase.execute({ currentUser: toCurrentUser(creator), secretSantaId: santa.id })).rejects.toThrow(
+      BadRequestException,
+    );
+    expect(transactionManager.runInTransaction).not.toHaveBeenCalled();
+    expect(eventBus.publish).not.toHaveBeenCalled();
+  });
+
+  it('should assign the draw, persist in a transaction and publish an event', async () => {
+    await useCase.execute({ currentUser: toCurrentUser(creator), secretSantaId: santa.id });
+
+    expect(transactionManager.runInTransaction).toHaveBeenCalledTimes(1);
+    expect(secretSantaUserRepository.saveAll).toHaveBeenCalledTimes(1);
+    expect(secretSantaRepository.save).toHaveBeenCalledTimes(1);
+
+    const savedSanta = secretSantaRepository.save.mock.calls[0]?.[0];
+    expect(savedSanta?.isStarted()).toBe(true);
+    expect(savedSanta?.users.every(user => user.drawUserId !== undefined)).toBe(true);
+
+    expect(eventBus.publish).toHaveBeenCalledTimes(1);
+    const published = eventBus.publish.mock.calls[0]?.[0];
+    expect(published).toBeInstanceOf(SecretSantaStartedEvent);
+    expect(published).toMatchObject({
+      eventTitle: event.title,
+      eventId: event.id,
+      budget: 25,
+      drawns: event.attendees.map(attendee => ({ email: attendee.getEmail() })),
+    });
+  });
+});

--- a/apps/api/src/secret-santa/application/command/update-secret-santa-user.use-case.spec.ts
+++ b/apps/api/src/secret-santa/application/command/update-secret-santa-user.use-case.spec.ts
@@ -1,0 +1,124 @@
+import type { SecretSantaUserId } from '@wishlist/common';
+import type { EventRepository } from '../../../event/domain/repository/event.repository';
+import type { SecretSantaRepository } from '../../domain/repository/secret-santa.repository';
+import type { SecretSantaUserRepository } from '../../domain/repository/secret-santa-user.repository';
+
+import { BadRequestException, ForbiddenException, Logger } from '@nestjs/common';
+import { uuid } from '@wishlist/common';
+
+import { EventBuilder } from '../../../../test-utils/builders/event.builder';
+import { SecretSantaBuilder } from '../../../../test-utils/builders/secret-santa.builder';
+import { SecretSantaUserBuilder } from '../../../../test-utils/builders/secret-santa-user.builder';
+import { toCurrentUser, UserBuilder } from '../../../../test-utils/builders/user.builder';
+import { createMock } from '../../../../test-utils/mocks';
+import { Event } from '../../../event/domain/model/event.model';
+import { User } from '../../../user/domain/model/user.model';
+import { SecretSanta } from '../../domain/model/secret-santa.model';
+import { SecretSantaUser } from '../../domain/model/secret-santa-user.model';
+import { UpdateSecretSantaUserUseCase } from './update-secret-santa-user.use-case';
+import { beforeAll, beforeEach, describe, expect, it, mock } from 'bun:test';
+
+describe('UpdateSecretSantaUserUseCase', () => {
+  const secretSantaRepository = createMock<SecretSantaRepository>();
+  const secretSantaUserRepository = createMock<SecretSantaUserRepository>();
+  const eventRepository = createMock<EventRepository>();
+
+  let useCase: UpdateSecretSantaUserUseCase;
+  let creator: User;
+  let participant: User;
+  let event: Event;
+  let santa: SecretSanta;
+  let santaUser: SecretSantaUser;
+  let otherSantaUser: SecretSantaUser;
+
+  beforeAll(() => {
+    Logger.overrideLogger(false);
+  });
+
+  beforeEach(() => {
+    mock.clearAllMocks();
+
+    creator = new UserBuilder().withEmail('creator@test.fr').build();
+    participant = new UserBuilder().withEmail('participant@test.fr').build();
+    event = new EventBuilder().withCreator(creator).withAttendee(participant).build();
+    const users = event.attendees.map(a => new SecretSantaUserBuilder().withAttendeeId(a.id).build());
+    santaUser = users[0]!;
+    otherSantaUser = users[1]!;
+    santa = new SecretSantaBuilder().withEventId(event.id).withUsers(users).build();
+
+    secretSantaRepository.findByIdOrFail.mockResolvedValue(santa);
+    eventRepository.findByIdOrFail.mockResolvedValue(event);
+
+    useCase = new UpdateSecretSantaUserUseCase(secretSantaRepository, secretSantaUserRepository, eventRepository);
+  });
+
+  it('should reject when the current user cannot edit the event', async () => {
+    await expect(
+      useCase.execute({
+        currentUser: toCurrentUser(participant),
+        secretSantaId: santa.id,
+        secretSantaUserId: santaUser.id,
+        exclusions: [otherSantaUser.id],
+      }),
+    ).rejects.toThrow(ForbiddenException);
+    expect(secretSantaUserRepository.saveAll).not.toHaveBeenCalled();
+  });
+
+  it('should reject when the secret santa is already started', async () => {
+    secretSantaRepository.findByIdOrFail.mockResolvedValueOnce(
+      new SecretSantaBuilder()
+        .withEventId(event.id)
+        .withUsers(event.attendees.map(a => new SecretSantaUserBuilder().withAttendeeId(a.id).build()))
+        .started()
+        .build(),
+    );
+
+    await expect(
+      useCase.execute({
+        currentUser: toCurrentUser(creator),
+        secretSantaId: santa.id,
+        secretSantaUserId: santaUser.id,
+        exclusions: [otherSantaUser.id],
+      }),
+    ).rejects.toThrow(ForbiddenException);
+    expect(secretSantaUserRepository.saveAll).not.toHaveBeenCalled();
+  });
+
+  it('should reject when the user excludes himself', async () => {
+    await expect(
+      useCase.execute({
+        currentUser: toCurrentUser(creator),
+        secretSantaId: santa.id,
+        secretSantaUserId: santaUser.id,
+        exclusions: [santaUser.id],
+      }),
+    ).rejects.toThrow(BadRequestException);
+    expect(secretSantaUserRepository.saveAll).not.toHaveBeenCalled();
+  });
+
+  it('should reject when the secret santa user is not found', async () => {
+    await expect(
+      useCase.execute({
+        currentUser: toCurrentUser(creator),
+        secretSantaId: santa.id,
+        secretSantaUserId: uuid() as SecretSantaUserId,
+        exclusions: [otherSantaUser.id],
+      }),
+    ).rejects.toThrow('Secret Santa user not found');
+    expect(secretSantaUserRepository.saveAll).not.toHaveBeenCalled();
+  });
+
+  it('should update exclusions and save all users', async () => {
+    await useCase.execute({
+      currentUser: toCurrentUser(creator),
+      secretSantaId: santa.id,
+      secretSantaUserId: santaUser.id,
+      exclusions: [otherSantaUser.id],
+    });
+
+    expect(secretSantaUserRepository.saveAll).toHaveBeenCalledTimes(1);
+    const savedUsers = secretSantaUserRepository.saveAll.mock.calls[0]?.[0];
+    const updated = savedUsers?.find(user => user.id === santaUser.id);
+    expect(updated?.exclusions).toEqual([otherSantaUser.id]);
+  });
+});

--- a/apps/api/src/secret-santa/application/command/update-secret-santa.use-case.spec.ts
+++ b/apps/api/src/secret-santa/application/command/update-secret-santa.use-case.spec.ts
@@ -1,0 +1,90 @@
+import type { EventRepository } from '../../../event/domain/repository/event.repository';
+import type { SecretSantaRepository } from '../../domain/repository/secret-santa.repository';
+
+import { ConflictException, ForbiddenException, Logger } from '@nestjs/common';
+
+import { EventBuilder } from '../../../../test-utils/builders/event.builder';
+import { SecretSantaBuilder } from '../../../../test-utils/builders/secret-santa.builder';
+import { SecretSantaUserBuilder } from '../../../../test-utils/builders/secret-santa-user.builder';
+import { toCurrentUser, UserBuilder } from '../../../../test-utils/builders/user.builder';
+import { createMock } from '../../../../test-utils/mocks';
+import { Event } from '../../../event/domain/model/event.model';
+import { User } from '../../../user/domain/model/user.model';
+import { SecretSanta } from '../../domain/model/secret-santa.model';
+import { UpdateSecretSantaUseCase } from './update-secret-santa.use-case';
+import { beforeAll, beforeEach, describe, expect, it, mock } from 'bun:test';
+
+describe('UpdateSecretSantaUseCase', () => {
+  const secretSantaRepository = createMock<SecretSantaRepository>();
+  const eventRepository = createMock<EventRepository>();
+
+  let useCase: UpdateSecretSantaUseCase;
+  let creator: User;
+  let participant: User;
+  let event: Event;
+  let santa: SecretSanta;
+
+  beforeAll(() => {
+    Logger.overrideLogger(false);
+  });
+
+  beforeEach(() => {
+    mock.clearAllMocks();
+
+    creator = new UserBuilder().withEmail('creator@test.fr').build();
+    participant = new UserBuilder().withEmail('participant@test.fr').build();
+    event = new EventBuilder().withCreator(creator).withAttendee(participant).build();
+    const users = event.attendees.map(a => new SecretSantaUserBuilder().withAttendeeId(a.id).build());
+    santa = new SecretSantaBuilder().withEventId(event.id).withUsers(users).withBudget(20).build();
+
+    secretSantaRepository.findByIdOrFail.mockResolvedValue(santa);
+    eventRepository.findByIdOrFail.mockResolvedValue(event);
+
+    useCase = new UpdateSecretSantaUseCase(secretSantaRepository, eventRepository);
+  });
+
+  it('should reject when the current user cannot edit the event', async () => {
+    await expect(
+      useCase.execute({
+        currentUser: toCurrentUser(participant),
+        secretSantaId: santa.id,
+        budget: 40,
+      }),
+    ).rejects.toThrow(ForbiddenException);
+    expect(secretSantaRepository.save).not.toHaveBeenCalled();
+  });
+
+  it('should reject when the secret santa is already started', async () => {
+    secretSantaRepository.findByIdOrFail.mockResolvedValueOnce(
+      new SecretSantaBuilder()
+        .withEventId(event.id)
+        .withUsers(event.attendees.map(a => new SecretSantaUserBuilder().withAttendeeId(a.id).build()))
+        .started()
+        .build(),
+    );
+
+    await expect(
+      useCase.execute({
+        currentUser: toCurrentUser(creator),
+        secretSantaId: santa.id,
+        budget: 40,
+      }),
+    ).rejects.toThrow(ConflictException);
+    expect(secretSantaRepository.save).not.toHaveBeenCalled();
+  });
+
+  it('should update and save the secret santa', async () => {
+    await useCase.execute({
+      currentUser: toCurrentUser(creator),
+      secretSantaId: santa.id,
+      description: 'Nouveau budget',
+      budget: 50,
+    });
+
+    expect(secretSantaRepository.save).toHaveBeenCalledTimes(1);
+    const saved = secretSantaRepository.save.mock.calls[0]?.[0];
+    expect(saved?.description).toBe('Nouveau budget');
+    expect(saved?.budget).toBe(50);
+    expect(saved?.id).toBe(santa.id);
+  });
+});

--- a/apps/api/src/secret-santa/application/query/get-secret-santa-draw.use-case.spec.ts
+++ b/apps/api/src/secret-santa/application/query/get-secret-santa-draw.use-case.spec.ts
@@ -1,0 +1,72 @@
+import type { EventAttendeeRepository } from '../../../event/domain/repository/event-attendee.repository';
+import type { SecretSantaUserRepository } from '../../domain/repository/secret-santa-user.repository';
+
+import { Logger } from '@nestjs/common';
+
+import { EventBuilder } from '../../../../test-utils/builders/event.builder';
+import { SecretSantaUserBuilder } from '../../../../test-utils/builders/secret-santa-user.builder';
+import { toCurrentUser, UserBuilder } from '../../../../test-utils/builders/user.builder';
+import { createMock } from '../../../../test-utils/mocks';
+import { EventAttendee } from '../../../event/domain/model/event-attendee.model';
+import { User } from '../../../user/domain/model/user.model';
+import { SecretSantaUser } from '../../domain/model/secret-santa-user.model';
+import { GetSecretSantaDrawUseCase } from './get-secret-santa-draw.use-case';
+import { beforeAll, beforeEach, describe, expect, it, mock } from 'bun:test';
+
+describe('GetSecretSantaDrawUseCase', () => {
+  const secretSantaUserRepository = createMock<SecretSantaUserRepository>();
+  const attendeeRepository = createMock<EventAttendeeRepository>();
+
+  let useCase: GetSecretSantaDrawUseCase;
+  let creator: User;
+  let participant: User;
+  let attendee: EventAttendee;
+  let santaUser: SecretSantaUser;
+
+  beforeAll(() => {
+    Logger.overrideLogger(false);
+  });
+
+  beforeEach(() => {
+    mock.clearAllMocks();
+
+    creator = new UserBuilder().withEmail('creator@test.fr').build();
+    participant = new UserBuilder().withEmail('participant@test.fr').build();
+    const event = new EventBuilder().withCreator(creator).withAttendee(participant).build();
+    attendee = event.attendees[1]!;
+    santaUser = new SecretSantaUserBuilder().withAttendeeId(attendee.id).build();
+
+    secretSantaUserRepository.findDrawSecretSantaUserForEvent.mockResolvedValue(santaUser);
+    attendeeRepository.findById.mockResolvedValue(attendee);
+
+    useCase = new GetSecretSantaDrawUseCase(secretSantaUserRepository, attendeeRepository);
+  });
+
+  it('should return undefined when there is no draw for the current user', async () => {
+    secretSantaUserRepository.findDrawSecretSantaUserForEvent.mockResolvedValueOnce(undefined);
+
+    const result = await useCase.execute({ currentUser: toCurrentUser(creator), eventId: attendee.eventId });
+
+    expect(result.attendee).toBeUndefined();
+    expect(attendeeRepository.findById).not.toHaveBeenCalled();
+  });
+
+  it('should return undefined when the drawn attendee cannot be found', async () => {
+    attendeeRepository.findById.mockResolvedValueOnce(undefined);
+
+    const result = await useCase.execute({ currentUser: toCurrentUser(creator), eventId: attendee.eventId });
+
+    expect(result.attendee).toBeUndefined();
+    expect(attendeeRepository.findById).toHaveBeenCalledWith(santaUser.attendeeId);
+  });
+
+  it('should return the drawn attendee', async () => {
+    const result = await useCase.execute({ currentUser: toCurrentUser(creator), eventId: attendee.eventId });
+
+    expect(result.attendee).toBe(attendee);
+    expect(secretSantaUserRepository.findDrawSecretSantaUserForEvent).toHaveBeenCalledWith({
+      eventId: attendee.eventId,
+      userId: creator.id,
+    });
+  });
+});

--- a/apps/api/src/secret-santa/application/query/get-secret-santa.use-case.spec.ts
+++ b/apps/api/src/secret-santa/application/query/get-secret-santa.use-case.spec.ts
@@ -1,0 +1,68 @@
+import type { EventRepository } from '../../../event/domain/repository/event.repository';
+import type { SecretSantaRepository } from '../../domain/repository/secret-santa.repository';
+
+import { ForbiddenException, Logger } from '@nestjs/common';
+
+import { EventBuilder } from '../../../../test-utils/builders/event.builder';
+import { SecretSantaBuilder } from '../../../../test-utils/builders/secret-santa.builder';
+import { SecretSantaUserBuilder } from '../../../../test-utils/builders/secret-santa-user.builder';
+import { toCurrentUser, UserBuilder } from '../../../../test-utils/builders/user.builder';
+import { createMock } from '../../../../test-utils/mocks';
+import { Event } from '../../../event/domain/model/event.model';
+import { User } from '../../../user/domain/model/user.model';
+import { SecretSanta } from '../../domain/model/secret-santa.model';
+import { GetSecretSantaUseCase } from './get-secret-santa.use-case';
+import { beforeAll, beforeEach, describe, expect, it, mock } from 'bun:test';
+
+describe('GetSecretSantaUseCase', () => {
+  const secretSantaRepository = createMock<SecretSantaRepository>();
+  const eventRepository = createMock<EventRepository>();
+
+  let useCase: GetSecretSantaUseCase;
+  let creator: User;
+  let participant: User;
+  let event: Event;
+  let santa: SecretSanta;
+
+  beforeAll(() => {
+    Logger.overrideLogger(false);
+  });
+
+  beforeEach(() => {
+    mock.clearAllMocks();
+
+    creator = new UserBuilder().withEmail('creator@test.fr').build();
+    participant = new UserBuilder().withEmail('participant@test.fr').build();
+    event = new EventBuilder().withCreator(creator).withAttendee(participant).build();
+    const users = event.attendees.map(a => new SecretSantaUserBuilder().withAttendeeId(a.id).build());
+    santa = new SecretSantaBuilder().withEventId(event.id).withUsers(users).build();
+
+    secretSantaRepository.findForEvent.mockResolvedValue(santa);
+    eventRepository.findByIdOrFail.mockResolvedValue(event);
+
+    useCase = new GetSecretSantaUseCase(secretSantaRepository, eventRepository);
+  });
+
+  it('should return undefined when no secret santa exists for the event', async () => {
+    secretSantaRepository.findForEvent.mockResolvedValueOnce(undefined);
+
+    const result = await useCase.execute({ currentUser: toCurrentUser(creator), eventId: event.id });
+
+    expect(result.secretSanta).toBeUndefined();
+    expect(eventRepository.findByIdOrFail).not.toHaveBeenCalled();
+  });
+
+  it('should reject when the current user cannot view the event', async () => {
+    const stranger = new UserBuilder().withEmail('stranger@test.fr').build();
+
+    await expect(useCase.execute({ currentUser: toCurrentUser(stranger), eventId: event.id })).rejects.toThrow(
+      ForbiddenException,
+    );
+  });
+
+  it('should return the secret santa when the user can view the event', async () => {
+    const result = await useCase.execute({ currentUser: toCurrentUser(participant), eventId: event.id });
+
+    expect(result.secretSanta).toBe(santa);
+  });
+});

--- a/apps/api/src/user/application/command/confirm-email-change.use-case.spec.ts
+++ b/apps/api/src/user/application/command/confirm-email-change.use-case.spec.ts
@@ -1,0 +1,109 @@
+import type { EventBus } from '@nestjs/cqrs';
+import type { UserRepository } from '../../domain/repository/user.repository';
+import type { UserEmailChangeVerificationRepository } from '../../domain/repository/user-email-change-verification.repository';
+
+import { Logger, UnauthorizedException } from '@nestjs/common';
+
+import { UserBuilder } from '../../../../test-utils/builders/user.builder';
+import { UserEmailChangeVerificationBuilder } from '../../../../test-utils/builders/user-email-change-verification.builder';
+import { createMock } from '../../../../test-utils/mocks';
+import { TransactionManager } from '../../../core/database/transaction-manager';
+import { EmailChangedEvent } from '../../domain/event/email-changed.event';
+import { User } from '../../domain/model/user.model';
+import { UserEmailChangeVerification } from '../../domain/model/user-email-change-verification.model';
+import { ConfirmEmailChangeUseCase } from './confirm-email-change.use-case';
+import { beforeAll, beforeEach, describe, expect, it, mock } from 'bun:test';
+
+describe('ConfirmEmailChangeUseCase', () => {
+  const userRepository = createMock<UserRepository>();
+  const emailChangeVerificationRepository = createMock<UserEmailChangeVerificationRepository>();
+  const transactionManager = createMock<TransactionManager>();
+  const eventBus = createMock<EventBus>();
+
+  let useCase: ConfirmEmailChangeUseCase;
+  let user: User;
+  let verification: UserEmailChangeVerification;
+
+  beforeAll(() => {
+    Logger.overrideLogger(false);
+  });
+
+  beforeEach(() => {
+    mock.clearAllMocks();
+
+    user = new UserBuilder().withEmail('jean@test.fr').build();
+    verification = new UserEmailChangeVerificationBuilder()
+      .withUser(user)
+      .withNewEmail('new@test.fr')
+      .withToken('valid-token')
+      .build();
+
+    emailChangeVerificationRepository.findByTokenAndEmail.mockResolvedValue(verification);
+    userRepository.findByEmail.mockResolvedValue(undefined);
+    transactionManager.runInTransaction.mockImplementation(async callback => callback(undefined as never));
+
+    useCase = new ConfirmEmailChangeUseCase(
+      userRepository,
+      emailChangeVerificationRepository,
+      transactionManager,
+      eventBus,
+    );
+  });
+
+  it('should reject when the verification is not found', async () => {
+    emailChangeVerificationRepository.findByTokenAndEmail.mockResolvedValueOnce(undefined);
+
+    await expect(useCase.execute({ newEmail: 'new@test.fr', token: 'valid-token' })).rejects.toThrow(
+      UnauthorizedException,
+    );
+    expect(transactionManager.runInTransaction).not.toHaveBeenCalled();
+    expect(eventBus.publish).not.toHaveBeenCalled();
+  });
+
+  it('should reject when the verification is expired', async () => {
+    emailChangeVerificationRepository.findByTokenAndEmail.mockResolvedValueOnce(
+      new UserEmailChangeVerificationBuilder()
+        .withUser(user)
+        .withNewEmail('new@test.fr')
+        .withToken('valid-token')
+        .expired()
+        .build(),
+    );
+
+    await expect(useCase.execute({ newEmail: 'new@test.fr', token: 'valid-token' })).rejects.toThrow(
+      UnauthorizedException,
+    );
+    expect(transactionManager.runInTransaction).not.toHaveBeenCalled();
+  });
+
+  it('should reject when the new email is already used by another user', async () => {
+    userRepository.findByEmail.mockResolvedValueOnce(new UserBuilder().withEmail('new@test.fr').build());
+
+    await expect(useCase.execute({ newEmail: 'new@test.fr', token: 'valid-token' })).rejects.toThrow(
+      UnauthorizedException,
+    );
+    expect(transactionManager.runInTransaction).not.toHaveBeenCalled();
+  });
+
+  it('should update the email, invalidate the verification and publish an event', async () => {
+    await useCase.execute({ newEmail: 'NEW@test.fr', token: 'valid-token' });
+
+    expect(userRepository.save).toHaveBeenCalledTimes(1);
+    const savedUser = userRepository.save.mock.calls[0]?.[0];
+    expect(savedUser?.email).toBe('new@test.fr');
+    expect(emailChangeVerificationRepository.save).toHaveBeenCalledTimes(1);
+    const savedVerification = emailChangeVerificationRepository.save.mock.calls[0]?.[0];
+    expect(savedVerification?.expiredAt.getTime()).toBeLessThan(verification.expiredAt.getTime());
+    expect(eventBus.publish).toHaveBeenCalledTimes(1);
+    expect(eventBus.publish.mock.calls[0]?.[0]).toBeInstanceOf(EmailChangedEvent);
+  });
+
+  it('should allow confirming when the new email still belongs to the same user', async () => {
+    userRepository.findByEmail.mockResolvedValueOnce(user);
+
+    await useCase.execute({ newEmail: 'new@test.fr', token: 'valid-token' });
+
+    expect(userRepository.save).toHaveBeenCalledTimes(1);
+    expect(eventBus.publish).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/api/src/user/application/command/create-email-change-verification.use-case.spec.ts
+++ b/apps/api/src/user/application/command/create-email-change-verification.use-case.spec.ts
@@ -1,0 +1,96 @@
+import type { EventBus } from '@nestjs/cqrs';
+import type { UserEmailChangeVerificationId } from '@wishlist/common';
+import type { UserRepository } from '../../domain/repository/user.repository';
+import type { UserEmailChangeVerificationRepository } from '../../domain/repository/user-email-change-verification.repository';
+
+import { BadRequestException, Logger, UnauthorizedException } from '@nestjs/common';
+import { uuid } from '@wishlist/common';
+
+import { toCurrentUser, UserBuilder } from '../../../../test-utils/builders/user.builder';
+import { UserEmailChangeVerificationBuilder } from '../../../../test-utils/builders/user-email-change-verification.builder';
+import { createMock } from '../../../../test-utils/mocks';
+import { EmailChangeVerificationCreatedEvent } from '../../domain/event/email-change-verification-created.event';
+import { User } from '../../domain/model/user.model';
+import { CreateEmailChangeVerificationUseCase } from './create-email-change-verification.use-case';
+import { beforeAll, beforeEach, describe, expect, it, mock } from 'bun:test';
+
+describe('CreateEmailChangeVerificationUseCase', () => {
+  const userRepository = createMock<UserRepository>();
+  const emailChangeVerificationRepository = createMock<UserEmailChangeVerificationRepository>();
+  const eventBus = createMock<EventBus>();
+  const config = {
+    resetPasswordTokenDurationInMinutes: 15,
+    emailChangeVerificationTokenDurationInMinutes: 60,
+  };
+
+  let useCase: CreateEmailChangeVerificationUseCase;
+  let user: User;
+  let verificationId: UserEmailChangeVerificationId;
+
+  beforeAll(() => {
+    Logger.overrideLogger(false);
+  });
+
+  beforeEach(() => {
+    mock.clearAllMocks();
+
+    user = new UserBuilder().withEmail('jean@test.fr').build();
+    verificationId = uuid() as UserEmailChangeVerificationId;
+
+    userRepository.findByIdOrFail.mockResolvedValue(user);
+    userRepository.findByEmail.mockResolvedValue(undefined);
+    emailChangeVerificationRepository.findByUserId.mockResolvedValue([]);
+    emailChangeVerificationRepository.newId.mockReturnValue(verificationId);
+
+    useCase = new CreateEmailChangeVerificationUseCase(
+      userRepository,
+      emailChangeVerificationRepository,
+      config,
+      eventBus,
+    );
+  });
+
+  it('should reject when the new email is the same as the current email', async () => {
+    await expect(useCase.execute({ currentUser: toCurrentUser(user), newEmail: 'Jean@test.fr' })).rejects.toThrow(
+      BadRequestException,
+    );
+    expect(emailChangeVerificationRepository.save).not.toHaveBeenCalled();
+    expect(eventBus.publish).not.toHaveBeenCalled();
+  });
+
+  it('should reject when the new email is already taken', async () => {
+    userRepository.findByEmail.mockResolvedValueOnce(new UserBuilder().withEmail('taken@test.fr').build());
+
+    await expect(useCase.execute({ currentUser: toCurrentUser(user), newEmail: 'taken@test.fr' })).rejects.toThrow(
+      BadRequestException,
+    );
+    expect(emailChangeVerificationRepository.save).not.toHaveBeenCalled();
+  });
+
+  it('should reject when an email change request is already pending', async () => {
+    emailChangeVerificationRepository.findByUserId.mockResolvedValueOnce([
+      new UserEmailChangeVerificationBuilder().withUser(user).build(),
+    ]);
+
+    await expect(useCase.execute({ currentUser: toCurrentUser(user), newEmail: 'new@test.fr' })).rejects.toThrow(
+      UnauthorizedException,
+    );
+    expect(emailChangeVerificationRepository.save).not.toHaveBeenCalled();
+  });
+
+  it('should create a verification when previous ones are expired', async () => {
+    emailChangeVerificationRepository.findByUserId.mockResolvedValueOnce([
+      new UserEmailChangeVerificationBuilder().withUser(user).expired().build(),
+    ]);
+
+    await useCase.execute({ currentUser: toCurrentUser(user), newEmail: 'NEW@test.fr' });
+
+    expect(emailChangeVerificationRepository.save).toHaveBeenCalledTimes(1);
+    const saved = emailChangeVerificationRepository.save.mock.calls[0]?.[0];
+    expect(saved?.id).toBe(verificationId);
+    expect(saved?.newEmail).toBe('new@test.fr');
+    expect(saved?.user.id).toBe(user.id);
+    expect(eventBus.publish).toHaveBeenCalledTimes(1);
+    expect(eventBus.publish.mock.calls[0]?.[0]).toBeInstanceOf(EmailChangeVerificationCreatedEvent);
+  });
+});

--- a/apps/api/src/user/application/command/create-password-verification.use-case.spec.ts
+++ b/apps/api/src/user/application/command/create-password-verification.use-case.spec.ts
@@ -1,0 +1,78 @@
+import type { EventBus } from '@nestjs/cqrs';
+import type { UserPasswordVerificationId } from '@wishlist/common';
+import type { UserRepository } from '../../domain/repository/user.repository';
+import type { UserPasswordVerificationRepository } from '../../domain/repository/user-password-verification.repository';
+
+import { Logger, NotFoundException, UnauthorizedException } from '@nestjs/common';
+import { uuid } from '@wishlist/common';
+
+import { UserBuilder } from '../../../../test-utils/builders/user.builder';
+import { UserPasswordVerificationBuilder } from '../../../../test-utils/builders/user-password-verification.builder';
+import { createMock } from '../../../../test-utils/mocks';
+import { PasswordVerificationCreatedEvent } from '../../domain/event/password-verification-created.event';
+import { User } from '../../domain/model/user.model';
+import { CreatePasswordVerificationUseCase } from './create-password-verification.use-case';
+import { beforeAll, beforeEach, describe, expect, it, mock } from 'bun:test';
+
+describe('CreatePasswordVerificationUseCase', () => {
+  const userRepository = createMock<UserRepository>();
+  const verificationEntityRepository = createMock<UserPasswordVerificationRepository>();
+  const eventBus = createMock<EventBus>();
+  const config = {
+    resetPasswordTokenDurationInMinutes: 15,
+    emailChangeVerificationTokenDurationInMinutes: 60,
+  };
+
+  let useCase: CreatePasswordVerificationUseCase;
+  let user: User;
+  let verificationId: UserPasswordVerificationId;
+
+  beforeAll(() => {
+    Logger.overrideLogger(false);
+  });
+
+  beforeEach(() => {
+    mock.clearAllMocks();
+
+    user = new UserBuilder().withEmail('jean@test.fr').build();
+    verificationId = uuid() as UserPasswordVerificationId;
+
+    userRepository.findByEmail.mockResolvedValue(user);
+    verificationEntityRepository.findByUserId.mockResolvedValue([]);
+    verificationEntityRepository.newId.mockReturnValue(verificationId);
+
+    useCase = new CreatePasswordVerificationUseCase(userRepository, verificationEntityRepository, config, eventBus);
+  });
+
+  it('should reject when the user does not exist', async () => {
+    userRepository.findByEmail.mockResolvedValueOnce(undefined);
+
+    await expect(useCase.execute({ email: 'unknown@test.fr' })).rejects.toThrow(NotFoundException);
+    expect(verificationEntityRepository.save).not.toHaveBeenCalled();
+    expect(eventBus.publish).not.toHaveBeenCalled();
+  });
+
+  it('should reject when a reset email has already been sent', async () => {
+    verificationEntityRepository.findByUserId.mockResolvedValueOnce([
+      new UserPasswordVerificationBuilder().withUser(user).build(),
+    ]);
+
+    await expect(useCase.execute({ email: user.email })).rejects.toThrow(UnauthorizedException);
+    expect(verificationEntityRepository.save).not.toHaveBeenCalled();
+  });
+
+  it('should create a verification when previous ones are expired', async () => {
+    verificationEntityRepository.findByUserId.mockResolvedValueOnce([
+      new UserPasswordVerificationBuilder().withUser(user).expired().build(),
+    ]);
+
+    await useCase.execute({ email: user.email });
+
+    expect(verificationEntityRepository.save).toHaveBeenCalledTimes(1);
+    const saved = verificationEntityRepository.save.mock.calls[0]?.[0];
+    expect(saved?.id).toBe(verificationId);
+    expect(saved?.user.id).toBe(user.id);
+    expect(eventBus.publish).toHaveBeenCalledTimes(1);
+    expect(eventBus.publish.mock.calls[0]?.[0]).toBeInstanceOf(PasswordVerificationCreatedEvent);
+  });
+});

--- a/apps/api/src/user/application/command/create-user.use-case.spec.ts
+++ b/apps/api/src/user/application/command/create-user.use-case.spec.ts
@@ -1,0 +1,76 @@
+import type { EventBus } from '@nestjs/cqrs';
+import type { UserId } from '@wishlist/common';
+import type { UserRepository } from '../../domain/repository/user.repository';
+
+import { Logger, UnauthorizedException } from '@nestjs/common';
+import { uuid } from '@wishlist/common';
+
+import { UserBuilder } from '../../../../test-utils/builders/user.builder';
+import { createMock } from '../../../../test-utils/mocks';
+import { UserCreatedEvent } from '../../domain/event/user-created.event';
+import { User } from '../../domain/model/user.model';
+import { CreateUserUseCase } from './create-user.use-case';
+import { beforeAll, beforeEach, describe, expect, it, mock } from 'bun:test';
+
+describe('CreateUserUseCase', () => {
+  const userRepository = createMock<UserRepository>();
+  const eventBus = createMock<EventBus>();
+
+  let useCase: CreateUserUseCase;
+  let userId: UserId;
+
+  beforeAll(() => {
+    Logger.overrideLogger(false);
+  });
+
+  beforeEach(() => {
+    mock.clearAllMocks();
+
+    userId = uuid() as UserId;
+    userRepository.newId.mockReturnValue(userId);
+    userRepository.findByEmail.mockResolvedValue(undefined);
+
+    useCase = new CreateUserUseCase(userRepository, eventBus);
+  });
+
+  it('should reject when the email is already taken', async () => {
+    userRepository.findByEmail.mockResolvedValueOnce(new UserBuilder().withEmail('taken@test.fr').build());
+
+    await expect(
+      useCase.execute({
+        newUser: {
+          firstname: 'Jean',
+          lastname: 'Dupont',
+          email: 'taken@test.fr',
+          password: 'Secret123!',
+        },
+        ip: '127.0.0.1',
+      }),
+    ).rejects.toThrow(UnauthorizedException);
+    expect(userRepository.save).not.toHaveBeenCalled();
+    expect(eventBus.publish).not.toHaveBeenCalled();
+  });
+
+  it('should create the user, persist and publish an event', async () => {
+    const { user } = await useCase.execute({
+      newUser: {
+        firstname: 'Jean',
+        lastname: 'Dupont',
+        email: 'jean@test.fr',
+        password: 'Secret123!',
+        birthday: new Date('1990-01-01'),
+      },
+      ip: '127.0.0.1',
+    });
+
+    expect(user).toBeInstanceOf(User);
+    expect(user.id).toBe(userId);
+    expect(user.email).toBe('jean@test.fr');
+    expect(user.firstName).toBe('Jean');
+    expect(user.lastName).toBe('Dupont');
+    expect(user.passwordEnc).toBeDefined();
+    expect(userRepository.save).toHaveBeenCalledWith(user);
+    expect(eventBus.publish).toHaveBeenCalledTimes(1);
+    expect(eventBus.publish.mock.calls[0]?.[0]).toBeInstanceOf(UserCreatedEvent);
+  });
+});

--- a/apps/api/src/user/application/command/delete-user.use-case.spec.ts
+++ b/apps/api/src/user/application/command/delete-user.use-case.spec.ts
@@ -1,0 +1,76 @@
+import type { UserRepository } from '../../domain/repository/user.repository';
+
+import { Logger, UnauthorizedException } from '@nestjs/common';
+
+import { toCurrentUser, UserBuilder } from '../../../../test-utils/builders/user.builder';
+import { createMock } from '../../../../test-utils/mocks';
+import { User } from '../../domain/model/user.model';
+import { DeleteUserUseCase } from './delete-user.use-case';
+import { beforeAll, beforeEach, describe, expect, it, mock } from 'bun:test';
+
+describe('DeleteUserUseCase', () => {
+  const userRepository = createMock<UserRepository>();
+
+  let useCase: DeleteUserUseCase;
+  let admin: User;
+  let target: User;
+
+  beforeAll(() => {
+    Logger.overrideLogger(false);
+  });
+
+  beforeEach(() => {
+    mock.clearAllMocks();
+
+    admin = new UserBuilder().withEmail('admin@test.fr').asAdmin().build();
+    target = new UserBuilder().withEmail('target@test.fr').build();
+    userRepository.findByIdOrFail.mockResolvedValue(target);
+
+    useCase = new DeleteUserUseCase(userRepository);
+  });
+
+  it('should reject when the current user tries to delete themselves', async () => {
+    await expect(useCase.execute({ currentUser: toCurrentUser(admin), userId: admin.id })).rejects.toThrow(
+      UnauthorizedException,
+    );
+    expect(userRepository.findByIdOrFail).not.toHaveBeenCalled();
+    expect(userRepository.delete).not.toHaveBeenCalled();
+  });
+
+  it('should reject when an admin tries to delete another admin', async () => {
+    const otherAdmin = new UserBuilder().withEmail('other-admin@test.fr').asAdmin().build();
+    userRepository.findByIdOrFail.mockResolvedValueOnce(otherAdmin);
+
+    await expect(useCase.execute({ currentUser: toCurrentUser(admin), userId: otherAdmin.id })).rejects.toThrow(
+      UnauthorizedException,
+    );
+    expect(userRepository.delete).not.toHaveBeenCalled();
+  });
+
+  it('should reject when a super-admin tries to delete another super-admin', async () => {
+    const superAdmin = new UserBuilder().withEmail('super@test.fr').asSuperAdmin().build();
+    const otherSuperAdmin = new UserBuilder().withEmail('other-super@test.fr').asSuperAdmin().build();
+    userRepository.findByIdOrFail.mockResolvedValueOnce(otherSuperAdmin);
+
+    await expect(
+      useCase.execute({ currentUser: toCurrentUser(superAdmin), userId: otherSuperAdmin.id }),
+    ).rejects.toThrow(UnauthorizedException);
+    expect(userRepository.delete).not.toHaveBeenCalled();
+  });
+
+  it('should delete a regular user when requested by an admin', async () => {
+    await useCase.execute({ currentUser: toCurrentUser(admin), userId: target.id });
+
+    expect(userRepository.delete).toHaveBeenCalledWith(target.id);
+  });
+
+  it('should delete an admin when requested by a super-admin', async () => {
+    const superAdmin = new UserBuilder().withEmail('super@test.fr').asSuperAdmin().build();
+    const otherAdmin = new UserBuilder().withEmail('other-admin@test.fr').asAdmin().build();
+    userRepository.findByIdOrFail.mockResolvedValueOnce(otherAdmin);
+
+    await useCase.execute({ currentUser: toCurrentUser(superAdmin), userId: otherAdmin.id });
+
+    expect(userRepository.delete).toHaveBeenCalledWith(otherAdmin.id);
+  });
+});

--- a/apps/api/src/user/application/command/link-user-to-google.use-case.spec.ts
+++ b/apps/api/src/user/application/command/link-user-to-google.use-case.spec.ts
@@ -1,0 +1,102 @@
+import type { UserSocialId } from '@wishlist/common';
+import type { UserRepository } from '../../domain/repository/user.repository';
+import type { UserSocialRepository } from '../../domain/repository/user-social.repository';
+
+import { BadRequestException, Logger, UnauthorizedException } from '@nestjs/common';
+import { uuid } from '@wishlist/common';
+
+import { UserBuilder } from '../../../../test-utils/builders/user.builder';
+import { createMock } from '../../../../test-utils/mocks';
+import { GoogleAuthService } from '../../../auth/infrastructure/social/google-auth.service';
+import { TransactionManager } from '../../../core/database/transaction-manager';
+import { User } from '../../domain/model/user.model';
+import { UserSocial } from '../../domain/model/user-social.model';
+import { UserSocialType } from '../../domain/user-social-type.enum';
+import { LinkUserToGoogleUseCase } from './link-user-to-google.use-case';
+import { beforeAll, beforeEach, describe, expect, it, mock } from 'bun:test';
+
+describe('LinkUserToGoogleUseCase', () => {
+  const userRepository = createMock<UserRepository>();
+  const userSocialRepository = createMock<UserSocialRepository>();
+  const googleAuthService = createMock<GoogleAuthService>();
+  const transactionManager = createMock<TransactionManager>();
+
+  let useCase: LinkUserToGoogleUseCase;
+  let user: User;
+
+  const googlePayload = {
+    sub: 'google-sub',
+    email: 'jean@test.fr',
+    email_verified: true,
+    name: 'Jean Dupont',
+    picture: 'https://google/pic.png',
+  };
+
+  beforeAll(() => {
+    Logger.overrideLogger(false);
+  });
+
+  beforeEach(() => {
+    mock.clearAllMocks();
+
+    user = new UserBuilder().withEmail('jean@test.fr').build();
+    userRepository.findByIdOrFail.mockResolvedValue(user);
+    userSocialRepository.findByUserId.mockResolvedValue([]);
+    userSocialRepository.findBySocialId.mockResolvedValue(undefined);
+    userSocialRepository.newId.mockReturnValue(uuid() as UserSocialId);
+    googleAuthService.getGoogleAccountFromCode.mockResolvedValue(googlePayload);
+    transactionManager.runInTransaction.mockImplementation(async fn => fn({} as never));
+
+    useCase = new LinkUserToGoogleUseCase(userRepository, userSocialRepository, googleAuthService, transactionManager);
+  });
+
+  it('should reject when the user is already linked to Google', async () => {
+    userSocialRepository.findByUserId.mockResolvedValueOnce([
+      UserSocial.create({
+        id: uuid() as UserSocialId,
+        user,
+        email: user.email,
+        socialId: 'existing',
+        socialType: UserSocialType.GOOGLE,
+      }),
+    ]);
+
+    await expect(useCase.execute({ code: 'code', userId: user.id })).rejects.toThrow(BadRequestException);
+  });
+
+  it('should reject when the Google account is already linked to another user', async () => {
+    userSocialRepository.findBySocialId.mockResolvedValueOnce(
+      UserSocial.create({
+        id: uuid() as UserSocialId,
+        user: new UserBuilder().withEmail('other@test.fr').build(),
+        email: 'other@test.fr',
+        socialId: 'google-sub',
+        socialType: UserSocialType.GOOGLE,
+      }),
+    );
+
+    await expect(useCase.execute({ code: 'code', userId: user.id })).rejects.toThrow(BadRequestException);
+  });
+
+  it('should reject when the Google email is not verified', async () => {
+    googleAuthService.getGoogleAccountFromCode.mockResolvedValueOnce({ ...googlePayload, email_verified: false });
+
+    await expect(useCase.execute({ code: 'code', userId: user.id })).rejects.toThrow(UnauthorizedException);
+  });
+
+  it('should reject when Google does not provide an email', async () => {
+    googleAuthService.getGoogleAccountFromCode.mockResolvedValueOnce({ ...googlePayload, email: undefined });
+
+    await expect(useCase.execute({ code: 'code', userId: user.id })).rejects.toThrow(BadRequestException);
+  });
+
+  it('should link the Google account and copy the picture when the user has none', async () => {
+    const { userSocial } = await useCase.execute({ code: 'code', userId: user.id });
+
+    expect(userSocial.socialType).toBe(UserSocialType.GOOGLE);
+    expect(userSocial.socialId).toBe('google-sub');
+    expect(userRepository.save).toHaveBeenCalledTimes(1);
+    expect(userSocialRepository.save).toHaveBeenCalledTimes(1);
+    expect(userRepository.save.mock.calls[0]?.[0]?.pictureUrl).toBe('https://google/pic.png');
+  });
+});

--- a/apps/api/src/user/application/command/remove-user-picture.use-case.spec.ts
+++ b/apps/api/src/user/application/command/remove-user-picture.use-case.spec.ts
@@ -1,0 +1,39 @@
+import type { UserRepository } from '../../domain/repository/user.repository';
+
+import { Logger } from '@nestjs/common';
+
+import { UserBuilder } from '../../../../test-utils/builders/user.builder';
+import { createMock } from '../../../../test-utils/mocks';
+import { BucketService } from '../../../core/bucket/bucket.service';
+import { User } from '../../domain/model/user.model';
+import { RemoveUserPictureUseCase } from './remove-user-picture.use-case';
+import { beforeAll, beforeEach, describe, expect, it, mock } from 'bun:test';
+
+describe('RemoveUserPictureUseCase', () => {
+  const userRepository = createMock<UserRepository>();
+  const bucketService = createMock<BucketService>();
+
+  let useCase: RemoveUserPictureUseCase;
+  let user: User;
+
+  beforeAll(() => {
+    Logger.overrideLogger(false);
+  });
+
+  beforeEach(() => {
+    mock.clearAllMocks();
+
+    user = new UserBuilder().withEmail('jean@test.fr').build();
+    userRepository.findByIdOrFail.mockResolvedValue(user);
+
+    useCase = new RemoveUserPictureUseCase(userRepository, bucketService);
+  });
+
+  it('should remove pictures from the bucket and persist the user without a picture', async () => {
+    await useCase.execute({ userId: user.id });
+
+    expect(bucketService.removeIfExist).toHaveBeenCalledTimes(2);
+    expect(userRepository.save).toHaveBeenCalledTimes(1);
+    expect(userRepository.save.mock.calls[0]?.[0]?.pictureUrl).toBeUndefined();
+  });
+});

--- a/apps/api/src/user/application/command/reset-user-password.use-case.spec.ts
+++ b/apps/api/src/user/application/command/reset-user-password.use-case.spec.ts
@@ -1,0 +1,78 @@
+import type { UserRepository } from '../../domain/repository/user.repository';
+import type { UserPasswordVerificationRepository } from '../../domain/repository/user-password-verification.repository';
+
+import { Logger, NotFoundException, UnauthorizedException } from '@nestjs/common';
+
+import { UserBuilder } from '../../../../test-utils/builders/user.builder';
+import { UserPasswordVerificationBuilder } from '../../../../test-utils/builders/user-password-verification.builder';
+import { createMock } from '../../../../test-utils/mocks';
+import { PasswordManager } from '../../../auth/infrastructure/util/password-manager';
+import { TransactionManager } from '../../../core/database/transaction-manager';
+import { User } from '../../domain/model/user.model';
+import { UserPasswordVerification } from '../../domain/model/user-password-verification.model';
+import { ResetUserPasswordUseCase } from './reset-user-password.use-case';
+import { beforeAll, beforeEach, describe, expect, it, mock } from 'bun:test';
+
+describe('ResetUserPasswordUseCase', () => {
+  const userRepository = createMock<UserRepository>();
+  const passwordVerificationRepository = createMock<UserPasswordVerificationRepository>();
+  const transactionManager = createMock<TransactionManager>();
+
+  let useCase: ResetUserPasswordUseCase;
+  let user: User;
+  let verification: UserPasswordVerification;
+
+  beforeAll(() => {
+    Logger.overrideLogger(false);
+  });
+
+  beforeEach(() => {
+    mock.clearAllMocks();
+
+    user = new UserBuilder().withEmail('jean@test.fr').build();
+    verification = new UserPasswordVerificationBuilder().withUser(user).withToken('valid-token').build();
+
+    userRepository.findByEmail.mockResolvedValue(user);
+    passwordVerificationRepository.findByUserId.mockResolvedValue([verification]);
+    transactionManager.runInTransaction.mockImplementation(async callback => callback(undefined as never));
+
+    useCase = new ResetUserPasswordUseCase(userRepository, passwordVerificationRepository, transactionManager);
+  });
+
+  it('should reject when the user does not exist', async () => {
+    userRepository.findByEmail.mockResolvedValueOnce(undefined);
+
+    await expect(
+      useCase.execute({ email: 'unknown@test.fr', token: 'valid-token', newPassword: 'Secret123!' }),
+    ).rejects.toThrow(NotFoundException);
+    expect(transactionManager.runInTransaction).not.toHaveBeenCalled();
+  });
+
+  it('should reject when the reset token is not valid', async () => {
+    await expect(
+      useCase.execute({ email: user.email, token: 'wrong-token', newPassword: 'Secret123!' }),
+    ).rejects.toThrow(UnauthorizedException);
+    expect(transactionManager.runInTransaction).not.toHaveBeenCalled();
+  });
+
+  it('should reject when the reset token is expired', async () => {
+    passwordVerificationRepository.findByUserId.mockResolvedValueOnce([
+      new UserPasswordVerificationBuilder().withUser(user).withToken('valid-token').expired().build(),
+    ]);
+
+    await expect(
+      useCase.execute({ email: user.email, token: 'valid-token', newPassword: 'Secret123!' }),
+    ).rejects.toThrow(UnauthorizedException);
+    expect(transactionManager.runInTransaction).not.toHaveBeenCalled();
+  });
+
+  it('should update the password and delete the verification', async () => {
+    await useCase.execute({ email: user.email, token: 'valid-token', newPassword: 'NewSecret456!' });
+
+    expect(userRepository.save).toHaveBeenCalledTimes(1);
+    const savedUser = userRepository.save.mock.calls[0]?.[0];
+    expect(savedUser?.passwordEnc).toBeDefined();
+    expect(await PasswordManager.verify({ hash: savedUser?.passwordEnc, plainPassword: 'NewSecret456!' })).toBe(true);
+    expect(passwordVerificationRepository.delete).toHaveBeenCalledWith(verification.id, undefined);
+  });
+});

--- a/apps/api/src/user/application/command/unlink-user-social.use-case.spec.ts
+++ b/apps/api/src/user/application/command/unlink-user-social.use-case.spec.ts
@@ -1,0 +1,54 @@
+import type { UserSocialId } from '@wishlist/common';
+import type { UserSocialRepository } from '../../domain/repository/user-social.repository';
+
+import { Logger, NotFoundException } from '@nestjs/common';
+import { uuid } from '@wishlist/common';
+
+import { UserBuilder } from '../../../../test-utils/builders/user.builder';
+import { createMock } from '../../../../test-utils/mocks';
+import { User } from '../../domain/model/user.model';
+import { UserSocial } from '../../domain/model/user-social.model';
+import { UserSocialType } from '../../domain/user-social-type.enum';
+import { UnlinkUserSocialUseCase } from './unlink-user-social.use-case';
+import { beforeAll, beforeEach, describe, expect, it, mock } from 'bun:test';
+
+describe('UnlinkUserSocialUseCase', () => {
+  const userSocialRepository = createMock<UserSocialRepository>();
+
+  let useCase: UnlinkUserSocialUseCase;
+  let user: User;
+  let social: UserSocial;
+
+  beforeAll(() => {
+    Logger.overrideLogger(false);
+  });
+
+  beforeEach(() => {
+    mock.clearAllMocks();
+
+    user = new UserBuilder().withEmail('jean@test.fr').build();
+    social = UserSocial.create({
+      id: uuid() as UserSocialId,
+      user,
+      email: user.email,
+      socialId: 'google-123',
+      socialType: UserSocialType.GOOGLE,
+    });
+    userSocialRepository.findByUserId.mockResolvedValue([social]);
+
+    useCase = new UnlinkUserSocialUseCase(userSocialRepository);
+  });
+
+  it('should reject when the social id does not exist', async () => {
+    await expect(useCase.execute({ userId: user.id, socialId: uuid() as UserSocialId })).rejects.toThrow(
+      NotFoundException,
+    );
+    expect(userSocialRepository.delete).not.toHaveBeenCalled();
+  });
+
+  it('should delete the social account', async () => {
+    await useCase.execute({ userId: user.id, socialId: social.id });
+
+    expect(userSocialRepository.delete).toHaveBeenCalledWith(social.id);
+  });
+});

--- a/apps/api/src/user/application/command/update-user-email-setting.use-case.spec.ts
+++ b/apps/api/src/user/application/command/update-user-email-setting.use-case.spec.ts
@@ -1,0 +1,52 @@
+import type { UserEmailSettingRepository } from '../../domain/repository/user-email-setting.repository';
+
+import { Logger, NotFoundException } from '@nestjs/common';
+
+import { toCurrentUser, UserBuilder } from '../../../../test-utils/builders/user.builder';
+import { UserEmailSettingBuilder } from '../../../../test-utils/builders/user-email-setting.builder';
+import { createMock } from '../../../../test-utils/mocks';
+import { User } from '../../domain/model/user.model';
+import { UserEmailSetting } from '../../domain/model/user-email-setting.model';
+import { UpdateUserEmailSettingUseCase } from './update-user-email-setting.use-case';
+import { beforeAll, beforeEach, describe, expect, it, mock } from 'bun:test';
+
+describe('UpdateUserEmailSettingUseCase', () => {
+  const userEmailSettingRepository = createMock<UserEmailSettingRepository>();
+
+  let useCase: UpdateUserEmailSettingUseCase;
+  let user: User;
+  let userEmailSetting: UserEmailSetting;
+
+  beforeAll(() => {
+    Logger.overrideLogger(false);
+  });
+
+  beforeEach(() => {
+    mock.clearAllMocks();
+
+    user = new UserBuilder().withEmail('jean@test.fr').build();
+    userEmailSetting = new UserEmailSettingBuilder().withUser(user).withDailyNewItemNotification(true).build();
+    userEmailSettingRepository.findByUserId.mockResolvedValue(userEmailSetting);
+
+    useCase = new UpdateUserEmailSettingUseCase(userEmailSettingRepository);
+  });
+
+  it('should reject when the email setting does not exist', async () => {
+    userEmailSettingRepository.findByUserId.mockResolvedValueOnce(undefined);
+
+    await expect(
+      useCase.execute({ currentUser: toCurrentUser(user), dailyNewItemNotification: false }),
+    ).rejects.toThrow(NotFoundException);
+    expect(userEmailSettingRepository.save).not.toHaveBeenCalled();
+  });
+
+  it('should update and persist the email setting', async () => {
+    const { userEmailSetting: updated } = await useCase.execute({
+      currentUser: toCurrentUser(user),
+      dailyNewItemNotification: false,
+    });
+
+    expect(updated.dailyNewItemNotification).toBe(false);
+    expect(userEmailSettingRepository.save).toHaveBeenCalledWith(updated);
+  });
+});

--- a/apps/api/src/user/application/command/update-user-full.use-case.spec.ts
+++ b/apps/api/src/user/application/command/update-user-full.use-case.spec.ts
@@ -1,0 +1,130 @@
+import type { UserRepository } from '../../domain/repository/user.repository';
+
+import { BadRequestException, Logger, UnauthorizedException } from '@nestjs/common';
+
+import { toCurrentUser, UserBuilder } from '../../../../test-utils/builders/user.builder';
+import { createMock } from '../../../../test-utils/mocks';
+import { PasswordManager } from '../../../auth/infrastructure/util/password-manager';
+import { User } from '../../domain/model/user.model';
+import { UpdateUserFullUseCase } from './update-user-full.use-case';
+import { beforeAll, beforeEach, describe, expect, it, mock } from 'bun:test';
+
+describe('UpdateUserFullUseCase', () => {
+  const userRepository = createMock<UserRepository>();
+
+  let useCase: UpdateUserFullUseCase;
+  let admin: User;
+  let target: User;
+
+  beforeAll(() => {
+    Logger.overrideLogger(false);
+  });
+
+  beforeEach(() => {
+    mock.clearAllMocks();
+
+    admin = new UserBuilder().withEmail('admin@test.fr').asAdmin().build();
+    target = new UserBuilder().withEmail('target@test.fr').withName({ firstName: 'Jean', lastName: 'Dupont' }).build();
+    userRepository.findByIdOrFail.mockResolvedValue(target);
+    userRepository.findByEmail.mockResolvedValue(undefined);
+
+    useCase = new UpdateUserFullUseCase(userRepository);
+  });
+
+  it('should reject when the current user tries to update themselves', async () => {
+    await expect(
+      useCase.execute({
+        currentUser: toCurrentUser(admin),
+        userId: admin.id,
+        updateUser: { firstname: 'Paul' },
+      }),
+    ).rejects.toThrow(UnauthorizedException);
+    expect(userRepository.findByIdOrFail).not.toHaveBeenCalled();
+    expect(userRepository.save).not.toHaveBeenCalled();
+  });
+
+  it('should reject when an admin tries to update another admin', async () => {
+    const otherAdmin = new UserBuilder().withEmail('other-admin@test.fr').asAdmin().build();
+    userRepository.findByIdOrFail.mockResolvedValueOnce(otherAdmin);
+
+    await expect(
+      useCase.execute({
+        currentUser: toCurrentUser(admin),
+        userId: otherAdmin.id,
+        updateUser: { firstname: 'Paul' },
+      }),
+    ).rejects.toThrow(UnauthorizedException);
+    expect(userRepository.save).not.toHaveBeenCalled();
+  });
+
+  it('should reject when a super-admin tries to update another super-admin', async () => {
+    const superAdmin = new UserBuilder().withEmail('super@test.fr').asSuperAdmin().build();
+    const otherSuperAdmin = new UserBuilder().withEmail('other-super@test.fr').asSuperAdmin().build();
+    userRepository.findByIdOrFail.mockResolvedValueOnce(otherSuperAdmin);
+
+    await expect(
+      useCase.execute({
+        currentUser: toCurrentUser(superAdmin),
+        userId: otherSuperAdmin.id,
+        updateUser: { firstname: 'Paul' },
+      }),
+    ).rejects.toThrow(UnauthorizedException);
+    expect(userRepository.save).not.toHaveBeenCalled();
+  });
+
+  it('should reject when the new email is already taken', async () => {
+    userRepository.findByEmail.mockResolvedValueOnce(new UserBuilder().withEmail('taken@test.fr').build());
+
+    await expect(
+      useCase.execute({
+        currentUser: toCurrentUser(admin),
+        userId: target.id,
+        updateUser: { email: 'taken@test.fr' },
+      }),
+    ).rejects.toThrow(BadRequestException);
+    expect(userRepository.save).not.toHaveBeenCalled();
+  });
+
+  it('should update the user when requested by an admin', async () => {
+    const birthday = new Date('1990-01-01');
+
+    await useCase.execute({
+      currentUser: toCurrentUser(admin),
+      userId: target.id,
+      updateUser: {
+        email: 'new@test.fr',
+        newPassword: 'Secret123!',
+        firstname: 'Paul',
+        lastname: 'Martin',
+        birthday,
+        isEnabled: false,
+      },
+    });
+
+    expect(userRepository.save).toHaveBeenCalledTimes(1);
+    const savedUser = userRepository.save.mock.calls[0]?.[0];
+    expect(savedUser?.email).toBe('new@test.fr');
+    expect(savedUser?.firstName).toBe('Paul');
+    expect(savedUser?.lastName).toBe('Martin');
+    expect(savedUser?.birthday).toEqual(birthday);
+    expect(savedUser?.isEnabled).toBe(false);
+    expect(savedUser?.passwordEnc).toBeDefined();
+    expect(await PasswordManager.verify({ hash: savedUser?.passwordEnc, plainPassword: 'Secret123!' })).toBe(true);
+  });
+
+  it('should update an admin when requested by a super-admin', async () => {
+    const superAdmin = new UserBuilder().withEmail('super@test.fr').asSuperAdmin().build();
+    const otherAdmin = new UserBuilder().withEmail('other-admin@test.fr').asAdmin().build();
+    userRepository.findByIdOrFail.mockResolvedValueOnce(otherAdmin);
+
+    await useCase.execute({
+      currentUser: toCurrentUser(superAdmin),
+      userId: otherAdmin.id,
+      updateUser: { firstname: 'Paul' },
+    });
+
+    expect(userRepository.save).toHaveBeenCalledTimes(1);
+    const savedUser = userRepository.save.mock.calls[0]?.[0];
+    expect(savedUser?.firstName).toBe('Paul');
+  });
+});

--- a/apps/api/src/user/application/command/update-user-password.use-case.spec.ts
+++ b/apps/api/src/user/application/command/update-user-password.use-case.spec.ts
@@ -1,0 +1,52 @@
+import type { UserRepository } from '../../domain/repository/user.repository';
+
+import { Logger } from '@nestjs/common';
+
+import { UserBuilder } from '../../../../test-utils/builders/user.builder';
+import { createMock } from '../../../../test-utils/mocks';
+import { PasswordManager } from '../../../auth/infrastructure/util/password-manager';
+import { BusinessRuleException } from '../../../core/common/business-rule.exception';
+import { User } from '../../domain/model/user.model';
+import { UpdateUserPasswordUseCase } from './update-user-password.use-case';
+import { beforeAll, beforeEach, describe, expect, it, mock } from 'bun:test';
+
+const OLD_PASSWORD = 'Secret123!';
+const NEW_PASSWORD = 'NewSecret456!';
+
+describe('UpdateUserPasswordUseCase', () => {
+  const userRepository = createMock<UserRepository>();
+
+  let useCase: UpdateUserPasswordUseCase;
+  let user: User;
+
+  beforeAll(() => {
+    Logger.overrideLogger(false);
+  });
+
+  beforeEach(async () => {
+    mock.clearAllMocks();
+
+    const passwordHash = await PasswordManager.hash(OLD_PASSWORD);
+    user = new UserBuilder().withEmail('jean@test.fr').withPasswordEnc(passwordHash).build();
+    userRepository.findByIdOrFail.mockResolvedValue(user);
+
+    useCase = new UpdateUserPasswordUseCase(userRepository);
+  });
+
+  it('should reject when the old password does not match', async () => {
+    await expect(
+      useCase.execute({ userId: user.id, oldPassword: 'WrongPassword1!', newPassword: NEW_PASSWORD }),
+    ).rejects.toThrow(BusinessRuleException);
+    expect(userRepository.save).not.toHaveBeenCalled();
+  });
+
+  it('should update the password when the old password matches', async () => {
+    await useCase.execute({ userId: user.id, oldPassword: OLD_PASSWORD, newPassword: NEW_PASSWORD });
+
+    expect(userRepository.save).toHaveBeenCalledTimes(1);
+    const savedUser = userRepository.save.mock.calls[0]?.[0];
+    expect(savedUser?.passwordEnc).toBeDefined();
+    expect(savedUser?.passwordEnc).not.toBe(user.passwordEnc);
+    expect(await PasswordManager.verify({ hash: savedUser?.passwordEnc, plainPassword: NEW_PASSWORD })).toBe(true);
+  });
+});

--- a/apps/api/src/user/application/command/update-user-picture-from-social.use-case.spec.ts
+++ b/apps/api/src/user/application/command/update-user-picture-from-social.use-case.spec.ts
@@ -1,0 +1,71 @@
+import type { UserSocialId } from '@wishlist/common';
+import type { UserRepository } from '../../domain/repository/user.repository';
+import type { UserSocialRepository } from '../../domain/repository/user-social.repository';
+
+import { Logger, NotFoundException } from '@nestjs/common';
+import { uuid } from '@wishlist/common';
+
+import { UserBuilder } from '../../../../test-utils/builders/user.builder';
+import { createMock } from '../../../../test-utils/mocks';
+import { BucketService } from '../../../core/bucket/bucket.service';
+import { User } from '../../domain/model/user.model';
+import { UserSocial } from '../../domain/model/user-social.model';
+import { UserSocialType } from '../../domain/user-social-type.enum';
+import { UpdateUserPictureFromSocialUseCase } from './update-user-picture-from-social.use-case';
+import { beforeAll, beforeEach, describe, expect, it, mock } from 'bun:test';
+
+describe('UpdateUserPictureFromSocialUseCase', () => {
+  const userRepository = createMock<UserRepository>();
+  const userSocialRepository = createMock<UserSocialRepository>();
+  const bucketService = createMock<BucketService>();
+
+  let useCase: UpdateUserPictureFromSocialUseCase;
+  let user: User;
+  let social: UserSocial;
+
+  beforeAll(() => {
+    Logger.overrideLogger(false);
+  });
+
+  beforeEach(() => {
+    mock.clearAllMocks();
+
+    user = new UserBuilder().withEmail('jean@test.fr').build();
+    social = UserSocial.create({
+      id: uuid() as UserSocialId,
+      user,
+      email: user.email,
+      socialId: 'google-123',
+      socialType: UserSocialType.GOOGLE,
+      pictureUrl: 'https://google/pic.png',
+    });
+    userRepository.findByIdOrFail.mockResolvedValue(user);
+    userSocialRepository.findByUserId.mockResolvedValue([social]);
+
+    useCase = new UpdateUserPictureFromSocialUseCase(userRepository, userSocialRepository, bucketService);
+  });
+
+  it('should reject when the social id does not exist', async () => {
+    await expect(useCase.execute({ userId: user.id, socialId: uuid() as UserSocialId })).rejects.toThrow(
+      NotFoundException,
+    );
+    expect(userRepository.save).not.toHaveBeenCalled();
+  });
+
+  it('should copy the social picture onto the user', async () => {
+    await useCase.execute({ userId: user.id, socialId: social.id });
+
+    expect(bucketService.removeIfExist).not.toHaveBeenCalled();
+    expect(userRepository.save.mock.calls[0]?.[0]?.pictureUrl).toBe('https://google/pic.png');
+  });
+
+  it('should remove the existing picture from the bucket when the user already has one', async () => {
+    const userWithPicture = user.updatePicture('https://cdn/old.png');
+    userRepository.findByIdOrFail.mockResolvedValueOnce(userWithPicture);
+
+    await useCase.execute({ userId: userWithPicture.id, socialId: social.id });
+
+    expect(bucketService.removeIfExist).toHaveBeenCalledTimes(2);
+    expect(userRepository.save).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/api/src/user/application/command/update-user-picture.use-case.spec.ts
+++ b/apps/api/src/user/application/command/update-user-picture.use-case.spec.ts
@@ -1,0 +1,50 @@
+import type { UserRepository } from '../../domain/repository/user.repository';
+
+import { Logger } from '@nestjs/common';
+
+import { UserBuilder } from '../../../../test-utils/builders/user.builder';
+import { createMock } from '../../../../test-utils/mocks';
+import { BucketService } from '../../../core/bucket/bucket.service';
+import { User } from '../../domain/model/user.model';
+import { UpdateUserPictureUseCase } from './update-user-picture.use-case';
+import { beforeAll, beforeEach, describe, expect, it, mock } from 'bun:test';
+
+describe('UpdateUserPictureUseCase', () => {
+  const userRepository = createMock<UserRepository>();
+  const bucketService = createMock<BucketService>();
+
+  let useCase: UpdateUserPictureUseCase;
+  let user: User;
+  const file = { buffer: Buffer.from('img'), mimetype: 'image/png' } as Express.Multer.File;
+
+  beforeAll(() => {
+    Logger.overrideLogger(false);
+  });
+
+  beforeEach(() => {
+    mock.clearAllMocks();
+
+    user = new UserBuilder().withEmail('jean@test.fr').build();
+    userRepository.findByIdOrFail.mockResolvedValue(user);
+    bucketService.upload.mockResolvedValue('https://cdn/picture.png');
+
+    useCase = new UpdateUserPictureUseCase(userRepository, bucketService);
+  });
+
+  it('should upload the picture and persist the public url', async () => {
+    const result = await useCase.execute({ userId: user.id, file });
+
+    expect(result.pictureUrl).toBe('https://cdn/picture.png');
+    expect(bucketService.upload).toHaveBeenCalledTimes(1);
+    expect(userRepository.save.mock.calls[0]?.[0]?.pictureUrl).toBe('https://cdn/picture.png');
+  });
+
+  it('should still upload when removing the existing picture fails', async () => {
+    bucketService.removeIfExist.mockRejectedValueOnce(new Error('bucket down'));
+
+    const result = await useCase.execute({ userId: user.id, file });
+
+    expect(result.pictureUrl).toBe('https://cdn/picture.png');
+    expect(userRepository.save).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/api/src/user/application/command/update-user.use-case.spec.ts
+++ b/apps/api/src/user/application/command/update-user.use-case.spec.ts
@@ -1,0 +1,44 @@
+import type { UserRepository } from '../../domain/repository/user.repository';
+
+import { Logger } from '@nestjs/common';
+
+import { UserBuilder } from '../../../../test-utils/builders/user.builder';
+import { createMock } from '../../../../test-utils/mocks';
+import { User } from '../../domain/model/user.model';
+import { UpdateUserUseCase } from './update-user.use-case';
+import { beforeAll, beforeEach, describe, expect, it, mock } from 'bun:test';
+
+describe('UpdateUserUseCase', () => {
+  const userRepository = createMock<UserRepository>();
+
+  let useCase: UpdateUserUseCase;
+  let user: User;
+
+  beforeAll(() => {
+    Logger.overrideLogger(false);
+  });
+
+  beforeEach(() => {
+    mock.clearAllMocks();
+
+    user = new UserBuilder().withEmail('jean@test.fr').withName({ firstName: 'Jean', lastName: 'Dupont' }).build();
+    userRepository.findByIdOrFail.mockResolvedValue(user);
+
+    useCase = new UpdateUserUseCase(userRepository);
+  });
+
+  it('should update first name, last name and birthday', async () => {
+    const birthday = new Date('1990-01-01');
+
+    await useCase.execute({
+      userId: user.id,
+      updateUser: { firstname: 'Paul', lastname: 'Martin', birthday },
+    });
+
+    expect(userRepository.save).toHaveBeenCalledTimes(1);
+    const savedUser = userRepository.save.mock.calls[0]?.[0];
+    expect(savedUser?.firstName).toBe('Paul');
+    expect(savedUser?.lastName).toBe('Martin');
+    expect(savedUser?.birthday).toEqual(birthday);
+  });
+});

--- a/apps/api/src/user/application/query/get-closest-friends.use-case.spec.ts
+++ b/apps/api/src/user/application/query/get-closest-friends.use-case.spec.ts
@@ -1,0 +1,43 @@
+import type { UserRepository } from '../../domain/repository/user.repository';
+
+import { BadRequestException, Logger } from '@nestjs/common';
+
+import { UserBuilder } from '../../../../test-utils/builders/user.builder';
+import { createMock } from '../../../../test-utils/mocks';
+import { User } from '../../domain/model/user.model';
+import { GetClosestFriendsUseCase } from './get-closest-friends.use-case';
+import { beforeAll, beforeEach, describe, expect, it, mock } from 'bun:test';
+
+describe('GetClosestFriendsUseCase', () => {
+  const userRepository = createMock<UserRepository>();
+
+  let useCase: GetClosestFriendsUseCase;
+  let user: User;
+  let friend: User;
+
+  beforeAll(() => {
+    Logger.overrideLogger(false);
+  });
+
+  beforeEach(() => {
+    mock.clearAllMocks();
+
+    user = new UserBuilder().withEmail('jean@test.fr').build();
+    friend = new UserBuilder().withEmail('paul@test.fr').build();
+    userRepository.findClosestFriends.mockResolvedValue([friend]);
+
+    useCase = new GetClosestFriendsUseCase(userRepository);
+  });
+
+  it('should reject when the limit is greater than 50', async () => {
+    await expect(useCase.execute({ userId: user.id, limit: 51 })).rejects.toThrow(BadRequestException);
+    expect(userRepository.findClosestFriends).not.toHaveBeenCalled();
+  });
+
+  it('should return the closest friends', async () => {
+    const { users } = await useCase.execute({ userId: user.id, limit: 10 });
+
+    expect(users).toEqual([friend]);
+    expect(userRepository.findClosestFriends).toHaveBeenCalledWith(user.id, 10);
+  });
+});

--- a/apps/api/src/user/application/query/get-pending-email-change.use-case.spec.ts
+++ b/apps/api/src/user/application/query/get-pending-email-change.use-case.spec.ts
@@ -1,0 +1,58 @@
+import type { UserEmailChangeVerificationRepository } from '../../domain/repository/user-email-change-verification.repository';
+
+import { Logger } from '@nestjs/common';
+
+import { toCurrentUser, UserBuilder } from '../../../../test-utils/builders/user.builder';
+import { UserEmailChangeVerificationBuilder } from '../../../../test-utils/builders/user-email-change-verification.builder';
+import { createMock } from '../../../../test-utils/mocks';
+import { User } from '../../domain/model/user.model';
+import { GetPendingEmailChangeUseCase } from './get-pending-email-change.use-case';
+import { beforeAll, beforeEach, describe, expect, it, mock } from 'bun:test';
+
+describe('GetPendingEmailChangeUseCase', () => {
+  const emailChangeVerificationRepository = createMock<UserEmailChangeVerificationRepository>();
+
+  let useCase: GetPendingEmailChangeUseCase;
+  let user: User;
+
+  beforeAll(() => {
+    Logger.overrideLogger(false);
+  });
+
+  beforeEach(() => {
+    mock.clearAllMocks();
+
+    user = new UserBuilder().withEmail('jean@test.fr').build();
+    emailChangeVerificationRepository.findByUserId.mockResolvedValue([]);
+
+    useCase = new GetPendingEmailChangeUseCase(emailChangeVerificationRepository);
+  });
+
+  it('should return undefined when there is no pending verification', async () => {
+    const result = await useCase.execute({ currentUser: toCurrentUser(user) });
+
+    expect(result).toBeUndefined();
+  });
+
+  it('should return undefined when all verifications are expired', async () => {
+    emailChangeVerificationRepository.findByUserId.mockResolvedValueOnce([
+      new UserEmailChangeVerificationBuilder().withUser(user).expired().build(),
+    ]);
+
+    const result = await useCase.execute({ currentUser: toCurrentUser(user) });
+
+    expect(result).toBeUndefined();
+  });
+
+  it('should return the active pending email change', async () => {
+    const verification = new UserEmailChangeVerificationBuilder().withUser(user).withNewEmail('new@test.fr').build();
+    emailChangeVerificationRepository.findByUserId.mockResolvedValueOnce([verification]);
+
+    const result = await useCase.execute({ currentUser: toCurrentUser(user) });
+
+    expect(result).toEqual({
+      newEmail: 'new@test.fr',
+      expiredAt: verification.expiredAt.toISOString(),
+    });
+  });
+});

--- a/apps/api/src/user/application/query/get-user-email-setting.use-case.spec.ts
+++ b/apps/api/src/user/application/query/get-user-email-setting.use-case.spec.ts
@@ -1,0 +1,46 @@
+import type { UserEmailSettingRepository } from '../../domain/repository/user-email-setting.repository';
+
+import { Logger, NotFoundException } from '@nestjs/common';
+
+import { toCurrentUser, UserBuilder } from '../../../../test-utils/builders/user.builder';
+import { UserEmailSettingBuilder } from '../../../../test-utils/builders/user-email-setting.builder';
+import { createMock } from '../../../../test-utils/mocks';
+import { User } from '../../domain/model/user.model';
+import { UserEmailSetting } from '../../domain/model/user-email-setting.model';
+import { GetUserEmailSettingUseCase } from './get-user-email-setting.use-case';
+import { beforeAll, beforeEach, describe, expect, it, mock } from 'bun:test';
+
+describe('GetUserEmailSettingUseCase', () => {
+  const userEmailSettingRepository = createMock<UserEmailSettingRepository>();
+
+  let useCase: GetUserEmailSettingUseCase;
+  let user: User;
+  let userEmailSetting: UserEmailSetting;
+
+  beforeAll(() => {
+    Logger.overrideLogger(false);
+  });
+
+  beforeEach(() => {
+    mock.clearAllMocks();
+
+    user = new UserBuilder().withEmail('jean@test.fr').build();
+    userEmailSetting = new UserEmailSettingBuilder().withUser(user).build();
+    userEmailSettingRepository.findByUserId.mockResolvedValue(userEmailSetting);
+
+    useCase = new GetUserEmailSettingUseCase(userEmailSettingRepository);
+  });
+
+  it('should reject when the email setting does not exist', async () => {
+    userEmailSettingRepository.findByUserId.mockResolvedValueOnce(undefined);
+
+    await expect(useCase.execute({ currentUser: toCurrentUser(user) })).rejects.toThrow(NotFoundException);
+  });
+
+  it('should return the user email setting', async () => {
+    const result = await useCase.execute({ currentUser: toCurrentUser(user) });
+
+    expect(result).toEqual({ userEmailSetting });
+    expect(userEmailSettingRepository.findByUserId).toHaveBeenCalledWith(user.id);
+  });
+});

--- a/apps/api/src/user/application/query/get-user-socials-by-ids.use-case.spec.ts
+++ b/apps/api/src/user/application/query/get-user-socials-by-ids.use-case.spec.ts
@@ -1,0 +1,37 @@
+import type { UserSocialId } from '@wishlist/common';
+import type { UserSocialRepository } from '../../domain/repository/user-social.repository';
+
+import { uuid } from '@wishlist/common';
+
+import { UserBuilder } from '../../../../test-utils/builders/user.builder';
+import { createMock } from '../../../../test-utils/mocks';
+import { UserSocial } from '../../domain/model/user-social.model';
+import { UserSocialType } from '../../domain/user-social-type.enum';
+import { GetUserSocialsByIdsUseCase } from './get-user-socials-by-ids.use-case';
+import { beforeEach, describe, expect, it, mock } from 'bun:test';
+
+describe('GetUserSocialsByIdsUseCase', () => {
+  const userSocialRepository = createMock<UserSocialRepository>();
+  let useCase: GetUserSocialsByIdsUseCase;
+
+  beforeEach(() => {
+    mock.clearAllMocks();
+    useCase = new GetUserSocialsByIdsUseCase(userSocialRepository);
+  });
+
+  it('should return socials matching the given ids', async () => {
+    const user = new UserBuilder().build();
+    const social = UserSocial.create({
+      id: uuid() as UserSocialId,
+      user,
+      email: user.email,
+      socialId: 'google-1',
+      socialType: UserSocialType.GOOGLE,
+    });
+    userSocialRepository.findByIds.mockResolvedValueOnce([social]);
+
+    const result = await useCase.execute({ userSocialIds: [social.id] });
+
+    expect(result).toEqual([social]);
+  });
+});

--- a/apps/api/src/user/application/query/get-user-socials-by-user-ids.use-case.spec.ts
+++ b/apps/api/src/user/application/query/get-user-socials-by-user-ids.use-case.spec.ts
@@ -1,0 +1,37 @@
+import type { UserSocialId } from '@wishlist/common';
+import type { UserSocialRepository } from '../../domain/repository/user-social.repository';
+
+import { uuid } from '@wishlist/common';
+
+import { UserBuilder } from '../../../../test-utils/builders/user.builder';
+import { createMock } from '../../../../test-utils/mocks';
+import { UserSocial } from '../../domain/model/user-social.model';
+import { UserSocialType } from '../../domain/user-social-type.enum';
+import { GetUserSocialsByUserIdsUseCase } from './get-user-socials-by-user-ids.use-case';
+import { beforeEach, describe, expect, it, mock } from 'bun:test';
+
+describe('GetUserSocialsByUserIdsUseCase', () => {
+  const userSocialRepository = createMock<UserSocialRepository>();
+  let useCase: GetUserSocialsByUserIdsUseCase;
+
+  beforeEach(() => {
+    mock.clearAllMocks();
+    useCase = new GetUserSocialsByUserIdsUseCase(userSocialRepository);
+  });
+
+  it('should group socials by user id', async () => {
+    const user = new UserBuilder().build();
+    const social = UserSocial.create({
+      id: uuid() as UserSocialId,
+      user,
+      email: user.email,
+      socialId: 'google-1',
+      socialType: UserSocialType.GOOGLE,
+    });
+    userSocialRepository.findByUserIds.mockResolvedValueOnce([social]);
+
+    const result = await useCase.execute({ userIds: [user.id] });
+
+    expect(result.get(user.id)).toEqual([social]);
+  });
+});

--- a/apps/api/src/user/application/query/get-users-by-criteria.use-case.spec.ts
+++ b/apps/api/src/user/application/query/get-users-by-criteria.use-case.spec.ts
@@ -1,0 +1,56 @@
+import type { UserRepository } from '../../domain/repository/user.repository';
+
+import { BadRequestException, Logger } from '@nestjs/common';
+
+import { toCurrentUser, UserBuilder } from '../../../../test-utils/builders/user.builder';
+import { createMock } from '../../../../test-utils/mocks';
+import { User } from '../../domain/model/user.model';
+import { GetUsersByCriteriaUseCase } from './get-users-by-criteria.use-case';
+import { beforeAll, beforeEach, describe, expect, it, mock } from 'bun:test';
+
+describe('GetUsersByCriteriaUseCase', () => {
+  const userRepository = createMock<UserRepository>();
+
+  let useCase: GetUsersByCriteriaUseCase;
+  let currentUser: User;
+  let matchingUser: User;
+
+  beforeAll(() => {
+    Logger.overrideLogger(false);
+  });
+
+  beforeEach(() => {
+    mock.clearAllMocks();
+
+    currentUser = new UserBuilder().withEmail('jean@test.fr').build();
+    matchingUser = new UserBuilder().withEmail('paul@test.fr').build();
+    userRepository.findAllByCriteria.mockResolvedValue([matchingUser]);
+
+    useCase = new GetUsersByCriteriaUseCase(userRepository);
+  });
+
+  it('should reject when the criteria is empty', async () => {
+    await expect(useCase.execute({ currentUser: toCurrentUser(currentUser), criteria: '' })).rejects.toThrow(
+      BadRequestException,
+    );
+    expect(userRepository.findAllByCriteria).not.toHaveBeenCalled();
+  });
+
+  it('should reject when the criteria is shorter than 2 characters', async () => {
+    await expect(useCase.execute({ currentUser: toCurrentUser(currentUser), criteria: ' a ' })).rejects.toThrow(
+      BadRequestException,
+    );
+    expect(userRepository.findAllByCriteria).not.toHaveBeenCalled();
+  });
+
+  it('should return users matching the criteria', async () => {
+    const { users } = await useCase.execute({ currentUser: toCurrentUser(currentUser), criteria: 'pa' });
+
+    expect(users).toEqual([matchingUser]);
+    expect(userRepository.findAllByCriteria).toHaveBeenCalledWith({
+      criteria: 'pa',
+      ignoreUserId: currentUser.id,
+      limit: 10,
+    });
+  });
+});

--- a/apps/api/src/user/application/query/get-users-by-ids.use-case.spec.ts
+++ b/apps/api/src/user/application/query/get-users-by-ids.use-case.spec.ts
@@ -1,0 +1,26 @@
+import type { UserRepository } from '../../domain/repository/user.repository';
+
+import { UserBuilder } from '../../../../test-utils/builders/user.builder';
+import { createMock } from '../../../../test-utils/mocks';
+import { GetUsersByIdsUseCase } from './get-users-by-ids.use-case';
+import { beforeEach, describe, expect, it, mock } from 'bun:test';
+
+describe('GetUsersByIdsUseCase', () => {
+  const userRepository = createMock<UserRepository>();
+  let useCase: GetUsersByIdsUseCase;
+
+  beforeEach(() => {
+    mock.clearAllMocks();
+    useCase = new GetUsersByIdsUseCase(userRepository);
+  });
+
+  it('should return users matching the given ids', async () => {
+    const users = [new UserBuilder().build(), new UserBuilder().build()];
+    userRepository.findByIds.mockResolvedValueOnce(users);
+
+    const result = await useCase.execute({ userIds: users.map(user => user.id) });
+
+    expect(result).toEqual(users);
+    expect(userRepository.findByIds).toHaveBeenCalledWith(users.map(user => user.id));
+  });
+});

--- a/apps/api/src/user/application/query/get-users-paginated.use-case.spec.ts
+++ b/apps/api/src/user/application/query/get-users-paginated.use-case.spec.ts
@@ -1,0 +1,54 @@
+import type { UserRepository } from '../../domain/repository/user.repository';
+
+import { BadRequestException, Logger } from '@nestjs/common';
+
+import { UserBuilder } from '../../../../test-utils/builders/user.builder';
+import { createMock } from '../../../../test-utils/mocks';
+import { User } from '../../domain/model/user.model';
+import { GetUsersPaginatedUseCase } from './get-users-paginated.use-case';
+import { beforeAll, beforeEach, describe, expect, it, mock } from 'bun:test';
+
+describe('GetUsersPaginatedUseCase', () => {
+  const userRepository = createMock<UserRepository>();
+
+  let useCase: GetUsersPaginatedUseCase;
+  let user: User;
+
+  beforeAll(() => {
+    Logger.overrideLogger(false);
+  });
+
+  beforeEach(() => {
+    mock.clearAllMocks();
+
+    user = new UserBuilder().withEmail('jean@test.fr').build();
+    userRepository.findAllPaginated.mockResolvedValue({ users: [user], totalCount: 1 });
+
+    useCase = new GetUsersPaginatedUseCase(userRepository);
+  });
+
+  it('should reject when the criteria is shorter than 2 characters', async () => {
+    await expect(useCase.execute({ criteria: 'a', pageNumber: 1, pageSize: 10 })).rejects.toThrow(BadRequestException);
+    expect(userRepository.findAllPaginated).not.toHaveBeenCalled();
+  });
+
+  it('should return paginated users without criteria', async () => {
+    const result = await useCase.execute({ pageNumber: 2, pageSize: 10 });
+
+    expect(result).toEqual({ users: [user], totalCount: 1 });
+    expect(userRepository.findAllPaginated).toHaveBeenCalledWith({
+      criteria: undefined,
+      pagination: { take: 10, skip: 10 },
+    });
+  });
+
+  it('should return paginated users matching the criteria', async () => {
+    const result = await useCase.execute({ criteria: 'je', pageNumber: 1, pageSize: 20 });
+
+    expect(result).toEqual({ users: [user], totalCount: 1 });
+    expect(userRepository.findAllPaginated).toHaveBeenCalledWith({
+      criteria: 'je',
+      pagination: { take: 20, skip: 0 },
+    });
+  });
+});

--- a/apps/api/src/wishlist/application/command/add-co-owner.use-case.spec.ts
+++ b/apps/api/src/wishlist/application/command/add-co-owner.use-case.spec.ts
@@ -1,0 +1,94 @@
+import type { EventBus } from '@nestjs/cqrs';
+import type { UserRepository } from '../../../user/domain/repository/user.repository';
+import type { WishlistRepository } from '../../domain/wishlist.repository';
+
+import { BadRequestException, Logger, UnauthorizedException } from '@nestjs/common';
+
+import { toCurrentUser, UserBuilder } from '../../../../test-utils/builders/user.builder';
+import { WishlistBuilder } from '../../../../test-utils/builders/wishlist.builder';
+import { createMock } from '../../../../test-utils/mocks';
+import { User } from '../../../user/domain/model/user.model';
+import { UserAddedAsCoOwnerToWishlistEvent } from '../../domain/event/user-added-as-co-owner-to-wishlist.event';
+import { Wishlist } from '../../domain/wishlist.model';
+import { AddCoOwnerUseCase } from './add-co-owner.use-case';
+import { beforeAll, beforeEach, describe, expect, it, mock } from 'bun:test';
+
+describe('AddCoOwnerUseCase', () => {
+  const wishlistRepository = createMock<WishlistRepository>();
+  const userRepository = createMock<UserRepository>();
+  const eventBus = createMock<EventBus>();
+
+  let useCase: AddCoOwnerUseCase;
+  let owner: User;
+  let coOwner: User;
+  let wishlist: Wishlist;
+
+  beforeAll(() => {
+    Logger.overrideLogger(false);
+  });
+
+  beforeEach(() => {
+    mock.clearAllMocks();
+
+    owner = new UserBuilder().withEmail('owner@test.fr').build();
+    coOwner = new UserBuilder().withEmail('coowner@test.fr').build();
+    wishlist = new WishlistBuilder().withOwner(owner).withHideItems(false).build();
+
+    wishlistRepository.findByIdOrFail.mockResolvedValue(wishlist);
+    userRepository.findByIdOrFail.mockResolvedValue(coOwner);
+
+    useCase = new AddCoOwnerUseCase(wishlistRepository, userRepository, eventBus);
+  });
+
+  it('should reject when the current user is not the owner', async () => {
+    await expect(
+      useCase.execute({
+        currentUser: toCurrentUser(coOwner),
+        wishlistId: wishlist.id,
+        coOwnerId: coOwner.id,
+      }),
+    ).rejects.toThrow(UnauthorizedException);
+    expect(wishlistRepository.save).not.toHaveBeenCalled();
+    expect(eventBus.publish).not.toHaveBeenCalled();
+  });
+
+  it('should reject when the wishlist is private', async () => {
+    wishlistRepository.findByIdOrFail.mockResolvedValueOnce(
+      new WishlistBuilder().withOwner(owner).withHideItems(true).build(),
+    );
+
+    await expect(
+      useCase.execute({
+        currentUser: toCurrentUser(owner),
+        wishlistId: wishlist.id,
+        coOwnerId: coOwner.id,
+      }),
+    ).rejects.toThrow(BadRequestException);
+    expect(wishlistRepository.save).not.toHaveBeenCalled();
+  });
+
+  it('should reject when adding the owner as co-owner', async () => {
+    await expect(
+      useCase.execute({
+        currentUser: toCurrentUser(owner),
+        wishlistId: wishlist.id,
+        coOwnerId: owner.id,
+      }),
+    ).rejects.toThrow(BadRequestException);
+    expect(wishlistRepository.save).not.toHaveBeenCalled();
+  });
+
+  it('should add the co-owner, persist and publish an event', async () => {
+    await useCase.execute({
+      currentUser: toCurrentUser(owner),
+      wishlistId: wishlist.id,
+      coOwnerId: coOwner.id,
+    });
+
+    expect(wishlistRepository.save).toHaveBeenCalledTimes(1);
+    const savedWishlist = wishlistRepository.save.mock.calls[0]?.[0];
+    expect(savedWishlist?.coOwner?.id).toBe(coOwner.id);
+    expect(eventBus.publish).toHaveBeenCalledTimes(1);
+    expect(eventBus.publish.mock.calls[0]?.[0]).toBeInstanceOf(UserAddedAsCoOwnerToWishlistEvent);
+  });
+});

--- a/apps/api/src/wishlist/application/command/create-wishlist.use-case.spec.ts
+++ b/apps/api/src/wishlist/application/command/create-wishlist.use-case.spec.ts
@@ -1,0 +1,116 @@
+import type { WishlistId } from '@wishlist/common';
+import type { BucketService } from '../../../core/bucket/bucket.service';
+import type { EventRepository } from '../../../event/domain/repository/event.repository';
+import type { UserRepository } from '../../../user/domain/repository/user.repository';
+import type { WishlistRepository } from '../../domain/wishlist.repository';
+
+import { Logger, NotFoundException, UnauthorizedException } from '@nestjs/common';
+import { uuid } from '@wishlist/common';
+
+import { EventBuilder } from '../../../../test-utils/builders/event.builder';
+import { toCurrentUser, UserBuilder } from '../../../../test-utils/builders/user.builder';
+import { createMock } from '../../../../test-utils/mocks';
+import { Event } from '../../../event/domain/model/event.model';
+import { User } from '../../../user/domain/model/user.model';
+import { CreateWishlistUseCase } from './create-wishlist.use-case';
+import { beforeAll, beforeEach, describe, expect, it, mock } from 'bun:test';
+
+describe('CreateWishlistUseCase', () => {
+  const wishlistRepository = createMock<WishlistRepository>();
+  const eventRepository = createMock<EventRepository>();
+  const userRepository = createMock<UserRepository>();
+  const bucketService = createMock<BucketService>();
+
+  let useCase: CreateWishlistUseCase;
+  let owner: User;
+  let event: Event;
+  let wishlistId: WishlistId;
+
+  beforeAll(() => {
+    Logger.overrideLogger(false);
+  });
+
+  beforeEach(() => {
+    mock.clearAllMocks();
+
+    owner = new UserBuilder().withEmail('owner@test.fr').build();
+    event = new EventBuilder().withCreator(owner).build();
+    wishlistId = uuid() as WishlistId;
+
+    eventRepository.findByIds.mockResolvedValue([event]);
+    userRepository.findByIdOrFail.mockResolvedValue(owner);
+    wishlistRepository.newId.mockReturnValue(wishlistId);
+    bucketService.getLogoDestination.mockReturnValue(`pictures/wishlists/${wishlistId}/logo`);
+    bucketService.uploadFile.mockResolvedValue('https://cdn.example.com/logo.png');
+
+    useCase = new CreateWishlistUseCase(wishlistRepository, eventRepository, userRepository, bucketService);
+  });
+
+  it('should reject when one or more events are not found', async () => {
+    eventRepository.findByIds.mockResolvedValueOnce([]);
+
+    await expect(
+      useCase.execute({
+        currentUser: toCurrentUser(owner),
+        newWishlist: { title: 'Ma liste', eventIds: [event.id] },
+      }),
+    ).rejects.toThrow(NotFoundException);
+    expect(wishlistRepository.save).not.toHaveBeenCalled();
+  });
+
+  it('should reject when the current user cannot add a wishlist to an event', async () => {
+    const stranger = new UserBuilder().withEmail('stranger@test.fr').build();
+    eventRepository.findByIds.mockResolvedValueOnce([new EventBuilder().withCreator(stranger).build()]);
+
+    await expect(
+      useCase.execute({
+        currentUser: toCurrentUser(owner),
+        newWishlist: { title: 'Ma liste', eventIds: [event.id] },
+      }),
+    ).rejects.toThrow(UnauthorizedException);
+    expect(wishlistRepository.save).not.toHaveBeenCalled();
+  });
+
+  it('should create a wishlist with hideItems defaulting to true', async () => {
+    const wishlist = await useCase.execute({
+      currentUser: toCurrentUser(owner),
+      newWishlist: { title: 'Ma liste', description: 'Anniversaire', eventIds: [event.id] },
+    });
+
+    expect(wishlist.id).toBe(wishlistId);
+    expect(wishlist.title).toBe('Ma liste');
+    expect(wishlist.description).toBe('Anniversaire');
+    expect(wishlist.hideItems).toBe(true);
+    expect(wishlist.eventIds).toEqual([event.id]);
+    expect(wishlist.logoUrl).toBeUndefined();
+    expect(wishlistRepository.save).toHaveBeenCalledWith(wishlist);
+    expect(bucketService.uploadFile).not.toHaveBeenCalled();
+  });
+
+  it('should create a wishlist with hideItems set to false when provided', async () => {
+    const wishlist = await useCase.execute({
+      currentUser: toCurrentUser(owner),
+      newWishlist: { title: 'Liste publique', eventIds: [event.id], hideItems: false },
+    });
+
+    expect(wishlist.hideItems).toBe(false);
+    expect(wishlistRepository.save).toHaveBeenCalledWith(wishlist);
+  });
+
+  it('should upload the logo and persist its url when an image file is provided', async () => {
+    const imageFile = { originalname: 'logo.png' } as Express.Multer.File;
+
+    const wishlist = await useCase.execute({
+      currentUser: toCurrentUser(owner),
+      newWishlist: { title: 'Ma liste', eventIds: [event.id], imageFile },
+    });
+
+    expect(bucketService.getLogoDestination).toHaveBeenCalledWith(wishlistId);
+    expect(bucketService.uploadFile).toHaveBeenCalledWith({
+      destination: `pictures/wishlists/${wishlistId}/logo`,
+      file: imageFile,
+    });
+    expect(wishlist.logoUrl).toBe('https://cdn.example.com/logo.png');
+    expect(wishlistRepository.save).toHaveBeenCalledWith(wishlist);
+  });
+});

--- a/apps/api/src/wishlist/application/command/delete-wishlist.use-case.spec.ts
+++ b/apps/api/src/wishlist/application/command/delete-wishlist.use-case.spec.ts
@@ -1,0 +1,87 @@
+import type { BucketService } from '../../../core/bucket/bucket.service';
+import type { WishlistRepository } from '../../domain/wishlist.repository';
+
+import { Logger, UnauthorizedException } from '@nestjs/common';
+
+import { toCurrentUser, UserBuilder } from '../../../../test-utils/builders/user.builder';
+import { WishlistBuilder } from '../../../../test-utils/builders/wishlist.builder';
+import { createMock } from '../../../../test-utils/mocks';
+import { User } from '../../../user/domain/model/user.model';
+import { Wishlist } from '../../domain/wishlist.model';
+import { DeleteWishlistUseCase } from './delete-wishlist.use-case';
+import { beforeAll, beforeEach, describe, expect, it, mock } from 'bun:test';
+
+describe('DeleteWishlistUseCase', () => {
+  const wishlistRepository = createMock<WishlistRepository>();
+  const bucketService = createMock<BucketService>();
+
+  let useCase: DeleteWishlistUseCase;
+  let owner: User;
+  let coOwner: User;
+  let stranger: User;
+  let wishlist: Wishlist;
+
+  beforeAll(() => {
+    Logger.overrideLogger(false);
+  });
+
+  beforeEach(() => {
+    mock.clearAllMocks();
+
+    owner = new UserBuilder().withEmail('owner@test.fr').build();
+    coOwner = new UserBuilder().withEmail('coowner@test.fr').build();
+    stranger = new UserBuilder().withEmail('stranger@test.fr').build();
+    wishlist = new WishlistBuilder().withOwner(owner).withCoOwner(coOwner).build();
+
+    wishlistRepository.findByIdOrFail.mockResolvedValue(wishlist);
+    bucketService.getLogoDestination.mockReturnValue(`pictures/wishlists/${wishlist.id}/logo`);
+
+    useCase = new DeleteWishlistUseCase(wishlistRepository, bucketService);
+  });
+
+  it('should reject when the current user is not owner, co-owner or admin', async () => {
+    await expect(
+      useCase.execute({
+        currentUser: toCurrentUser(stranger),
+        wishlistId: wishlist.id,
+      }),
+    ).rejects.toThrow(UnauthorizedException);
+    expect(wishlistRepository.delete).not.toHaveBeenCalled();
+    expect(bucketService.removeIfExist).not.toHaveBeenCalled();
+  });
+
+  it('should delete the wishlist and remove the logo when the owner requests it', async () => {
+    await useCase.execute({
+      currentUser: toCurrentUser(owner),
+      wishlistId: wishlist.id,
+    });
+
+    expect(wishlistRepository.delete).toHaveBeenCalledWith(wishlist.id);
+    expect(bucketService.getLogoDestination).toHaveBeenCalledWith(wishlist.id);
+    expect(bucketService.removeIfExist).toHaveBeenCalledWith({
+      destination: `pictures/wishlists/${wishlist.id}/logo`,
+    });
+  });
+
+  it('should delete the wishlist when the co-owner requests it', async () => {
+    await useCase.execute({
+      currentUser: toCurrentUser(coOwner),
+      wishlistId: wishlist.id,
+    });
+
+    expect(wishlistRepository.delete).toHaveBeenCalledWith(wishlist.id);
+    expect(bucketService.removeIfExist).toHaveBeenCalledTimes(1);
+  });
+
+  it('should delete the wishlist when an admin requests it', async () => {
+    const admin = new UserBuilder().withEmail('admin@test.fr').asAdmin().build();
+
+    await useCase.execute({
+      currentUser: toCurrentUser(admin),
+      wishlistId: wishlist.id,
+    });
+
+    expect(wishlistRepository.delete).toHaveBeenCalledWith(wishlist.id);
+    expect(bucketService.removeIfExist).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/api/src/wishlist/application/command/link-wishlist-to-event.use-case.spec.ts
+++ b/apps/api/src/wishlist/application/command/link-wishlist-to-event.use-case.spec.ts
@@ -1,0 +1,127 @@
+import type { EventId } from '@wishlist/common';
+import type { EventRepository } from '../../../event/domain/repository/event.repository';
+import type { WishlistRepository } from '../../domain/wishlist.repository';
+
+import { BadRequestException, Logger, UnauthorizedException } from '@nestjs/common';
+import { MAX_EVENTS_BY_LIST, uuid } from '@wishlist/common';
+
+import { EventBuilder } from '../../../../test-utils/builders/event.builder';
+import { toCurrentUser, UserBuilder } from '../../../../test-utils/builders/user.builder';
+import { WishlistBuilder } from '../../../../test-utils/builders/wishlist.builder';
+import { createMock } from '../../../../test-utils/mocks';
+import { Event } from '../../../event/domain/model/event.model';
+import { User } from '../../../user/domain/model/user.model';
+import { Wishlist } from '../../domain/wishlist.model';
+import { LinkWishlistToEventUseCase } from './link-wishlist-to-event.use-case';
+import { beforeAll, beforeEach, describe, expect, it, mock } from 'bun:test';
+
+describe('LinkWishlistToEventUseCase', () => {
+  const wishlistRepository = createMock<WishlistRepository>();
+  const eventRepository = createMock<EventRepository>();
+
+  let useCase: LinkWishlistToEventUseCase;
+  let owner: User;
+  let coOwner: User;
+  let stranger: User;
+  let wishlist: Wishlist;
+  let event: Event;
+
+  beforeAll(() => {
+    Logger.overrideLogger(false);
+  });
+
+  beforeEach(() => {
+    mock.clearAllMocks();
+
+    owner = new UserBuilder().withEmail('owner@test.fr').build();
+    coOwner = new UserBuilder().withEmail('coowner@test.fr').build();
+    stranger = new UserBuilder().withEmail('stranger@test.fr').build();
+    wishlist = new WishlistBuilder().withOwner(owner).withCoOwner(coOwner).build();
+    event = new EventBuilder().withCreator(owner).withAttendee(coOwner).build();
+
+    wishlistRepository.findByIdOrFail.mockResolvedValue(wishlist);
+    eventRepository.findByIdOrFail.mockResolvedValue(event);
+
+    useCase = new LinkWishlistToEventUseCase(wishlistRepository, eventRepository);
+  });
+
+  it('should reject when the current user is neither owner nor co-owner', async () => {
+    await expect(
+      useCase.execute({
+        currentUser: toCurrentUser(stranger),
+        wishlistId: wishlist.id,
+        eventId: event.id,
+      }),
+    ).rejects.toThrow(UnauthorizedException);
+    expect(eventRepository.findByIdOrFail).not.toHaveBeenCalled();
+    expect(wishlistRepository.save).not.toHaveBeenCalled();
+  });
+
+  it('should reject when the current user cannot add a wishlist to the event', async () => {
+    eventRepository.findByIdOrFail.mockResolvedValueOnce(new EventBuilder().withCreator(stranger).build());
+
+    await expect(
+      useCase.execute({
+        currentUser: toCurrentUser(owner),
+        wishlistId: wishlist.id,
+        eventId: event.id,
+      }),
+    ).rejects.toThrow(UnauthorizedException);
+    expect(wishlistRepository.save).not.toHaveBeenCalled();
+  });
+
+  it('should reject when the wishlist is already linked to the maximum number of events', async () => {
+    const eventIds = Array.from({ length: MAX_EVENTS_BY_LIST }, () => uuid() as EventId);
+    wishlistRepository.findByIdOrFail.mockResolvedValueOnce(
+      new WishlistBuilder().withOwner(owner).withEventIds(eventIds).build(),
+    );
+
+    await expect(
+      useCase.execute({
+        currentUser: toCurrentUser(owner),
+        wishlistId: wishlist.id,
+        eventId: event.id,
+      }),
+    ).rejects.toThrow(UnauthorizedException);
+    expect(wishlistRepository.save).not.toHaveBeenCalled();
+  });
+
+  it('should reject when the wishlist is already linked to the event', async () => {
+    wishlistRepository.findByIdOrFail.mockResolvedValueOnce(
+      new WishlistBuilder().withOwner(owner).withEventIds([event.id]).build(),
+    );
+
+    await expect(
+      useCase.execute({
+        currentUser: toCurrentUser(owner),
+        wishlistId: wishlist.id,
+        eventId: event.id,
+      }),
+    ).rejects.toThrow(BadRequestException);
+    expect(wishlistRepository.save).not.toHaveBeenCalled();
+  });
+
+  it('should link the event when the owner requests it', async () => {
+    await useCase.execute({
+      currentUser: toCurrentUser(owner),
+      wishlistId: wishlist.id,
+      eventId: event.id,
+    });
+
+    expect(wishlistRepository.save).toHaveBeenCalledTimes(1);
+    const savedWishlist = wishlistRepository.save.mock.calls[0]?.[0];
+    expect(savedWishlist?.eventIds).toContain(event.id);
+  });
+
+  it('should link the event when the co-owner requests it', async () => {
+    await useCase.execute({
+      currentUser: toCurrentUser(coOwner),
+      wishlistId: wishlist.id,
+      eventId: event.id,
+    });
+
+    expect(wishlistRepository.save).toHaveBeenCalledTimes(1);
+    const savedWishlist = wishlistRepository.save.mock.calls[0]?.[0];
+    expect(savedWishlist?.eventIds).toContain(event.id);
+  });
+});

--- a/apps/api/src/wishlist/application/command/remove-co-owner.use-case.spec.ts
+++ b/apps/api/src/wishlist/application/command/remove-co-owner.use-case.spec.ts
@@ -1,0 +1,57 @@
+import type { WishlistRepository } from '../../domain/wishlist.repository';
+
+import { Logger, UnauthorizedException } from '@nestjs/common';
+
+import { toCurrentUser, UserBuilder } from '../../../../test-utils/builders/user.builder';
+import { WishlistBuilder } from '../../../../test-utils/builders/wishlist.builder';
+import { createMock } from '../../../../test-utils/mocks';
+import { User } from '../../../user/domain/model/user.model';
+import { Wishlist } from '../../domain/wishlist.model';
+import { RemoveCoOwnerUseCase } from './remove-co-owner.use-case';
+import { beforeAll, beforeEach, describe, expect, it, mock } from 'bun:test';
+
+describe('RemoveCoOwnerUseCase', () => {
+  const wishlistRepository = createMock<WishlistRepository>();
+
+  let useCase: RemoveCoOwnerUseCase;
+  let owner: User;
+  let coOwner: User;
+  let wishlist: Wishlist;
+
+  beforeAll(() => {
+    Logger.overrideLogger(false);
+  });
+
+  beforeEach(() => {
+    mock.clearAllMocks();
+
+    owner = new UserBuilder().withEmail('owner@test.fr').build();
+    coOwner = new UserBuilder().withEmail('coowner@test.fr').build();
+    wishlist = new WishlistBuilder().withOwner(owner).withCoOwner(coOwner).build();
+
+    wishlistRepository.findByIdOrFail.mockResolvedValue(wishlist);
+
+    useCase = new RemoveCoOwnerUseCase(wishlistRepository);
+  });
+
+  it('should reject when the current user is not the owner', async () => {
+    await expect(
+      useCase.execute({
+        currentUser: toCurrentUser(coOwner),
+        wishlistId: wishlist.id,
+      }),
+    ).rejects.toThrow(UnauthorizedException);
+    expect(wishlistRepository.save).not.toHaveBeenCalled();
+  });
+
+  it('should remove the co-owner and persist the wishlist', async () => {
+    await useCase.execute({
+      currentUser: toCurrentUser(owner),
+      wishlistId: wishlist.id,
+    });
+
+    expect(wishlistRepository.save).toHaveBeenCalledTimes(1);
+    const savedWishlist = wishlistRepository.save.mock.calls[0]?.[0];
+    expect(savedWishlist?.coOwner).toBeUndefined();
+  });
+});

--- a/apps/api/src/wishlist/application/command/remove-wishlist-logo.use-case.spec.ts
+++ b/apps/api/src/wishlist/application/command/remove-wishlist-logo.use-case.spec.ts
@@ -1,0 +1,76 @@
+import type { BucketService } from '../../../core/bucket/bucket.service';
+import type { WishlistRepository } from '../../domain/wishlist.repository';
+
+import { Logger, UnauthorizedException } from '@nestjs/common';
+
+import { toCurrentUser, UserBuilder } from '../../../../test-utils/builders/user.builder';
+import { WishlistBuilder } from '../../../../test-utils/builders/wishlist.builder';
+import { createMock } from '../../../../test-utils/mocks';
+import { User } from '../../../user/domain/model/user.model';
+import { Wishlist } from '../../domain/wishlist.model';
+import { RemoveWishlistLogoUseCase } from './remove-wishlist-logo.use-case';
+import { beforeAll, beforeEach, describe, expect, it, mock } from 'bun:test';
+
+describe('RemoveWishlistLogoUseCase', () => {
+  const wishlistRepository = createMock<WishlistRepository>();
+  const bucketService = createMock<BucketService>();
+
+  let useCase: RemoveWishlistLogoUseCase;
+  let owner: User;
+  let coOwner: User;
+  let stranger: User;
+  let wishlist: Wishlist;
+
+  beforeAll(() => {
+    Logger.overrideLogger(false);
+  });
+
+  beforeEach(() => {
+    mock.clearAllMocks();
+
+    owner = new UserBuilder().withEmail('owner@test.fr').build();
+    coOwner = new UserBuilder().withEmail('coowner@test.fr').build();
+    stranger = new UserBuilder().withEmail('stranger@test.fr').build();
+    wishlist = new WishlistBuilder().withOwner(owner).withCoOwner(coOwner).build();
+
+    wishlistRepository.findByIdOrFail.mockResolvedValue(wishlist);
+    bucketService.getLogoDestination.mockReturnValue(`pictures/wishlists/${wishlist.id}/logo`);
+
+    useCase = new RemoveWishlistLogoUseCase(wishlistRepository, bucketService);
+  });
+
+  it('should reject when the current user is neither owner nor co-owner', async () => {
+    await expect(
+      useCase.execute({
+        currentUser: toCurrentUser(stranger),
+        wishlistId: wishlist.id,
+      }),
+    ).rejects.toThrow(UnauthorizedException);
+    expect(bucketService.removeIfExist).not.toHaveBeenCalled();
+    expect(wishlistRepository.save).not.toHaveBeenCalled();
+  });
+
+  it('should remove the logo from the bucket and persist an empty url', async () => {
+    await useCase.execute({
+      currentUser: toCurrentUser(owner),
+      wishlistId: wishlist.id,
+    });
+
+    expect(bucketService.removeIfExist).toHaveBeenCalledWith({
+      destination: `pictures/wishlists/${wishlist.id}/logo`,
+    });
+    expect(wishlistRepository.save).toHaveBeenCalledTimes(1);
+    const savedWishlist = wishlistRepository.save.mock.calls[0]?.[0];
+    expect(savedWishlist?.logoUrl).toBeUndefined();
+  });
+
+  it('should allow the co-owner to remove the logo', async () => {
+    await useCase.execute({
+      currentUser: toCurrentUser(coOwner),
+      wishlistId: wishlist.id,
+    });
+
+    expect(bucketService.removeIfExist).toHaveBeenCalledTimes(1);
+    expect(wishlistRepository.save).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/api/src/wishlist/application/command/unlink-wishlist-from-event.use-case.spec.ts
+++ b/apps/api/src/wishlist/application/command/unlink-wishlist-from-event.use-case.spec.ts
@@ -1,0 +1,111 @@
+import type { EventId } from '@wishlist/common';
+import type { WishlistRepository } from '../../domain/wishlist.repository';
+
+import { BadRequestException, Logger, UnauthorizedException } from '@nestjs/common';
+import { uuid } from '@wishlist/common';
+
+import { toCurrentUser, UserBuilder } from '../../../../test-utils/builders/user.builder';
+import { WishlistBuilder } from '../../../../test-utils/builders/wishlist.builder';
+import { createMock } from '../../../../test-utils/mocks';
+import { User } from '../../../user/domain/model/user.model';
+import { Wishlist } from '../../domain/wishlist.model';
+import { UnlinkWishlistFromEventUseCase } from './unlink-wishlist-from-event.use-case';
+import { beforeAll, beforeEach, describe, expect, it, mock } from 'bun:test';
+
+describe('UnlinkWishlistFromEventUseCase', () => {
+  const wishlistRepository = createMock<WishlistRepository>();
+
+  let useCase: UnlinkWishlistFromEventUseCase;
+  let owner: User;
+  let coOwner: User;
+  let stranger: User;
+  let eventId: EventId;
+  let otherEventId: EventId;
+  let wishlist: Wishlist;
+
+  beforeAll(() => {
+    Logger.overrideLogger(false);
+  });
+
+  beforeEach(() => {
+    mock.clearAllMocks();
+
+    owner = new UserBuilder().withEmail('owner@test.fr').build();
+    coOwner = new UserBuilder().withEmail('coowner@test.fr').build();
+    stranger = new UserBuilder().withEmail('stranger@test.fr').build();
+    eventId = uuid() as EventId;
+    otherEventId = uuid() as EventId;
+    wishlist = new WishlistBuilder()
+      .withOwner(owner)
+      .withCoOwner(coOwner)
+      .withEventIds([eventId, otherEventId])
+      .build();
+
+    wishlistRepository.findByIdOrFail.mockResolvedValue(wishlist);
+
+    useCase = new UnlinkWishlistFromEventUseCase(wishlistRepository);
+  });
+
+  it('should reject when the current user is neither owner nor co-owner', async () => {
+    await expect(
+      useCase.execute({
+        currentUser: toCurrentUser(stranger),
+        wishlistId: wishlist.id,
+        eventId,
+      }),
+    ).rejects.toThrow(UnauthorizedException);
+    expect(wishlistRepository.save).not.toHaveBeenCalled();
+  });
+
+  it('should reject when the wishlist is not linked to the event', async () => {
+    const unlinkedEventId = uuid() as EventId;
+
+    await expect(
+      useCase.execute({
+        currentUser: toCurrentUser(owner),
+        wishlistId: wishlist.id,
+        eventId: unlinkedEventId,
+      }),
+    ).rejects.toThrow(BadRequestException);
+    expect(wishlistRepository.save).not.toHaveBeenCalled();
+  });
+
+  it('should reject when the wishlist is linked to only one event', async () => {
+    wishlistRepository.findByIdOrFail.mockResolvedValueOnce(
+      new WishlistBuilder().withOwner(owner).withEventIds([eventId]).build(),
+    );
+
+    await expect(
+      useCase.execute({
+        currentUser: toCurrentUser(owner),
+        wishlistId: wishlist.id,
+        eventId,
+      }),
+    ).rejects.toThrow(BadRequestException);
+    expect(wishlistRepository.save).not.toHaveBeenCalled();
+  });
+
+  it('should unlink the event when the owner requests it', async () => {
+    await useCase.execute({
+      currentUser: toCurrentUser(owner),
+      wishlistId: wishlist.id,
+      eventId,
+    });
+
+    expect(wishlistRepository.save).toHaveBeenCalledTimes(1);
+    const savedWishlist = wishlistRepository.save.mock.calls[0]?.[0];
+    expect(savedWishlist?.eventIds).toEqual([otherEventId]);
+  });
+
+  it('should unlink the event when the co-owner requests it', async () => {
+    await useCase.execute({
+      currentUser: toCurrentUser(coOwner),
+      wishlistId: wishlist.id,
+      eventId,
+    });
+
+    expect(wishlistRepository.save).toHaveBeenCalledTimes(1);
+    const savedWishlist = wishlistRepository.save.mock.calls[0]?.[0];
+    expect(savedWishlist?.isLinkedToEvent(eventId)).toBe(false);
+  });
+});

--- a/apps/api/src/wishlist/application/command/update-wishlist.use-case.spec.ts
+++ b/apps/api/src/wishlist/application/command/update-wishlist.use-case.spec.ts
@@ -1,0 +1,74 @@
+import type { WishlistRepository } from '../../domain/wishlist.repository';
+
+import { Logger, UnauthorizedException } from '@nestjs/common';
+
+import { toCurrentUser, UserBuilder } from '../../../../test-utils/builders/user.builder';
+import { WishlistBuilder } from '../../../../test-utils/builders/wishlist.builder';
+import { createMock } from '../../../../test-utils/mocks';
+import { User } from '../../../user/domain/model/user.model';
+import { Wishlist } from '../../domain/wishlist.model';
+import { UpdateWishlistUseCase } from './update-wishlist.use-case';
+import { beforeAll, beforeEach, describe, expect, it, mock } from 'bun:test';
+
+describe('UpdateWishlistUseCase', () => {
+  const wishlistRepository = createMock<WishlistRepository>();
+
+  let useCase: UpdateWishlistUseCase;
+  let owner: User;
+  let coOwner: User;
+  let stranger: User;
+  let wishlist: Wishlist;
+
+  beforeAll(() => {
+    Logger.overrideLogger(false);
+  });
+
+  beforeEach(() => {
+    mock.clearAllMocks();
+
+    owner = new UserBuilder().withEmail('owner@test.fr').build();
+    coOwner = new UserBuilder().withEmail('coowner@test.fr').build();
+    stranger = new UserBuilder().withEmail('stranger@test.fr').build();
+    wishlist = new WishlistBuilder().withOwner(owner).withCoOwner(coOwner).build();
+
+    wishlistRepository.findByIdOrFail.mockResolvedValue(wishlist);
+
+    useCase = new UpdateWishlistUseCase(wishlistRepository);
+  });
+
+  it('should reject when the current user is neither owner nor co-owner', async () => {
+    await expect(
+      useCase.execute({
+        currentUser: toCurrentUser(stranger),
+        wishlistId: wishlist.id,
+        updateWishlist: { title: 'Nouveau titre' },
+      }),
+    ).rejects.toThrow(UnauthorizedException);
+    expect(wishlistRepository.save).not.toHaveBeenCalled();
+  });
+
+  it('should update the wishlist when the owner requests it', async () => {
+    await useCase.execute({
+      currentUser: toCurrentUser(owner),
+      wishlistId: wishlist.id,
+      updateWishlist: { title: 'Nouveau titre', description: 'Une description' },
+    });
+
+    expect(wishlistRepository.save).toHaveBeenCalledTimes(1);
+    const savedWishlist = wishlistRepository.save.mock.calls[0]?.[0];
+    expect(savedWishlist?.title).toBe('Nouveau titre');
+    expect(savedWishlist?.description).toBe('Une description');
+  });
+
+  it('should update the wishlist when the co-owner requests it', async () => {
+    await useCase.execute({
+      currentUser: toCurrentUser(coOwner),
+      wishlistId: wishlist.id,
+      updateWishlist: { title: 'Titre co-owner' },
+    });
+
+    expect(wishlistRepository.save).toHaveBeenCalledTimes(1);
+    const savedWishlist = wishlistRepository.save.mock.calls[0]?.[0];
+    expect(savedWishlist?.title).toBe('Titre co-owner');
+  });
+});

--- a/apps/api/src/wishlist/application/command/upload-wishlist-logo.use-case.spec.ts
+++ b/apps/api/src/wishlist/application/command/upload-wishlist-logo.use-case.spec.ts
@@ -1,0 +1,90 @@
+import type { BucketService } from '../../../core/bucket/bucket.service';
+import type { WishlistRepository } from '../../domain/wishlist.repository';
+
+import { Logger, UnauthorizedException } from '@nestjs/common';
+
+import { toCurrentUser, UserBuilder } from '../../../../test-utils/builders/user.builder';
+import { WishlistBuilder } from '../../../../test-utils/builders/wishlist.builder';
+import { createMock } from '../../../../test-utils/mocks';
+import { User } from '../../../user/domain/model/user.model';
+import { Wishlist } from '../../domain/wishlist.model';
+import { UploadWishlistLogoUseCase } from './upload-wishlist-logo.use-case';
+import { beforeAll, beforeEach, describe, expect, it, mock } from 'bun:test';
+
+describe('UploadWishlistLogoUseCase', () => {
+  const wishlistRepository = createMock<WishlistRepository>();
+  const bucketService = createMock<BucketService>();
+
+  let useCase: UploadWishlistLogoUseCase;
+  let owner: User;
+  let coOwner: User;
+  let stranger: User;
+  let wishlist: Wishlist;
+  let file: Express.Multer.File;
+
+  beforeAll(() => {
+    Logger.overrideLogger(false);
+  });
+
+  beforeEach(() => {
+    mock.clearAllMocks();
+
+    owner = new UserBuilder().withEmail('owner@test.fr').build();
+    coOwner = new UserBuilder().withEmail('coowner@test.fr').build();
+    stranger = new UserBuilder().withEmail('stranger@test.fr').build();
+    wishlist = new WishlistBuilder().withOwner(owner).withCoOwner(coOwner).build();
+    file = { originalname: 'logo.png' } as Express.Multer.File;
+
+    wishlistRepository.findByIdOrFail.mockResolvedValue(wishlist);
+    bucketService.getLogoDestination.mockReturnValue(`pictures/wishlists/${wishlist.id}/logo`);
+    bucketService.uploadFile.mockResolvedValue('https://cdn.example.com/logo.png');
+
+    useCase = new UploadWishlistLogoUseCase(wishlistRepository, bucketService);
+  });
+
+  it('should reject when the current user is neither owner nor co-owner', async () => {
+    await expect(
+      useCase.execute({
+        currentUser: toCurrentUser(stranger),
+        wishlistId: wishlist.id,
+        file,
+      }),
+    ).rejects.toThrow(UnauthorizedException);
+    expect(bucketService.uploadFile).not.toHaveBeenCalled();
+    expect(wishlistRepository.save).not.toHaveBeenCalled();
+  });
+
+  it('should replace the logo and persist the new url', async () => {
+    const result = await useCase.execute({
+      currentUser: toCurrentUser(owner),
+      wishlistId: wishlist.id,
+      file,
+    });
+
+    expect(result.logoUrl).toBe('https://cdn.example.com/logo.png');
+    expect(bucketService.removeIfExist).toHaveBeenCalledWith({
+      destination: `pictures/wishlists/${wishlist.id}/logo`,
+    });
+    expect(bucketService.uploadFile).toHaveBeenCalledWith({
+      destination: `pictures/wishlists/${wishlist.id}/logo`,
+      file,
+    });
+    expect(wishlistRepository.save).toHaveBeenCalledTimes(1);
+    const savedWishlist = wishlistRepository.save.mock.calls[0]?.[0];
+    expect(savedWishlist?.logoUrl).toBe('https://cdn.example.com/logo.png');
+  });
+
+  it('should still upload the new logo when removing the existing one fails', async () => {
+    bucketService.removeIfExist.mockRejectedValueOnce(new Error('storage down'));
+
+    const result = await useCase.execute({
+      currentUser: toCurrentUser(coOwner),
+      wishlistId: wishlist.id,
+      file,
+    });
+
+    expect(result.logoUrl).toBe('https://cdn.example.com/logo.png');
+    expect(bucketService.uploadFile).toHaveBeenCalledTimes(1);
+    expect(wishlistRepository.save).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/api/src/wishlist/application/query/get-wishlists-by-ids.use-case.spec.ts
+++ b/apps/api/src/wishlist/application/query/get-wishlists-by-ids.use-case.spec.ts
@@ -1,0 +1,57 @@
+import type { WishlistRepository } from '../../domain/wishlist.repository';
+
+import { Logger } from '@nestjs/common';
+
+import { toCurrentUser, UserBuilder } from '../../../../test-utils/builders/user.builder';
+import { WishlistBuilder } from '../../../../test-utils/builders/wishlist.builder';
+import { createMock } from '../../../../test-utils/mocks';
+import { User } from '../../../user/domain/model/user.model';
+import { Wishlist } from '../../domain/wishlist.model';
+import { GetWishlistsByIdsUseCase } from './get-wishlists-by-ids.use-case';
+import { beforeAll, beforeEach, describe, expect, it, mock } from 'bun:test';
+
+describe('GetWishlistsByIdsUseCase', () => {
+  const wishlistRepository = createMock<WishlistRepository>();
+
+  let useCase: GetWishlistsByIdsUseCase;
+  let user: User;
+  let wishlist: Wishlist;
+
+  beforeAll(() => {
+    Logger.overrideLogger(false);
+  });
+
+  beforeEach(() => {
+    mock.clearAllMocks();
+
+    user = new UserBuilder().withEmail('jean@test.fr').build();
+    wishlist = new WishlistBuilder().withOwner(user).build();
+    wishlistRepository.hasAccess.mockResolvedValue(true);
+    wishlistRepository.findByIds.mockResolvedValue([wishlist]);
+
+    useCase = new GetWishlistsByIdsUseCase(wishlistRepository);
+  });
+
+  it('should return wishlists the current user can access', async () => {
+    const wishlistIds = [wishlist.id];
+
+    const result = await useCase.execute({ currentUser: toCurrentUser(user), wishlistIds });
+
+    expect(wishlistRepository.hasAccess).toHaveBeenCalledWith({ wishlistId: wishlist.id, userId: user.id });
+    expect(wishlistRepository.findByIds).toHaveBeenCalledWith(wishlistIds);
+    expect(result).toEqual([wishlist]);
+  });
+
+  it('should not load wishlists the current user cannot access', async () => {
+    wishlistRepository.hasAccess.mockResolvedValueOnce(false);
+    wishlistRepository.findByIds.mockResolvedValueOnce([]);
+
+    const result = await useCase.execute({
+      currentUser: toCurrentUser(user),
+      wishlistIds: [wishlist.id],
+    });
+
+    expect(wishlistRepository.findByIds).toHaveBeenCalledWith([]);
+    expect(result).toEqual([]);
+  });
+});

--- a/apps/api/src/wishlist/application/query/get-wishlists-by-user.use-case.spec.ts
+++ b/apps/api/src/wishlist/application/query/get-wishlists-by-user.use-case.spec.ts
@@ -1,0 +1,43 @@
+import type { WishlistRepository } from '../../domain/wishlist.repository';
+
+import { Logger } from '@nestjs/common';
+
+import { UserBuilder } from '../../../../test-utils/builders/user.builder';
+import { WishlistBuilder } from '../../../../test-utils/builders/wishlist.builder';
+import { createMock } from '../../../../test-utils/mocks';
+import { User } from '../../../user/domain/model/user.model';
+import { Wishlist } from '../../domain/wishlist.model';
+import { GetWishlistsByUserUseCase } from './get-wishlists-by-user.use-case';
+import { beforeAll, beforeEach, describe, expect, it, mock } from 'bun:test';
+
+describe('GetWishlistsByUserUseCase', () => {
+  const wishlistRepository = createMock<WishlistRepository>();
+
+  let useCase: GetWishlistsByUserUseCase;
+  let user: User;
+  let wishlist: Wishlist;
+
+  beforeAll(() => {
+    Logger.overrideLogger(false);
+  });
+
+  beforeEach(() => {
+    mock.clearAllMocks();
+
+    user = new UserBuilder().withEmail('jean@test.fr').build();
+    wishlist = new WishlistBuilder().withOwner(user).build();
+    wishlistRepository.findByUserPaginated.mockResolvedValue({ wishlists: [wishlist], totalCount: 1 });
+
+    useCase = new GetWishlistsByUserUseCase(wishlistRepository);
+  });
+
+  it('should return paginated wishlists for the user', async () => {
+    const result = await useCase.execute({ userId: user.id, pageNumber: 2, pageSize: 10 });
+
+    expect(result).toEqual({ wishlists: [wishlist], totalCount: 1 });
+    expect(wishlistRepository.findByUserPaginated).toHaveBeenCalledWith({
+      userId: user.id,
+      pagination: { take: 10, skip: 10 },
+    });
+  });
+});

--- a/apps/api/test-utils/builders/event-attendee.builder.ts
+++ b/apps/api/test-utils/builders/event-attendee.builder.ts
@@ -1,0 +1,76 @@
+import type { AttendeeId, EventId } from '@wishlist/common';
+
+import { uuid } from '@wishlist/common';
+
+import { AttendeeRole } from '../../src/event/domain/attendee-role.enum';
+import { EventAttendee } from '../../src/event/domain/model/event-attendee.model';
+import { User } from '../../src/user/domain/model/user.model';
+
+type EventAttendeeBuilderData = {
+  eventId: EventId;
+  user?: User;
+  pendingEmail?: string;
+  role: AttendeeRole;
+};
+
+export class EventAttendeeBuilder {
+  private readonly data: EventAttendeeBuilderData = {
+    eventId: uuid() as EventId,
+    role: AttendeeRole.PARTICIPANT,
+  };
+
+  withEventId(eventId: EventId): this {
+    this.data.eventId = eventId;
+    return this;
+  }
+
+  withUser(user: User): this {
+    this.data.user = user;
+    this.data.pendingEmail = undefined;
+    return this;
+  }
+
+  withPendingEmail(email: string): this {
+    this.data.pendingEmail = email;
+    this.data.user = undefined;
+    return this;
+  }
+
+  asCreator(): this {
+    this.data.role = AttendeeRole.CREATOR;
+    return this;
+  }
+
+  asAdmin(): this {
+    this.data.role = AttendeeRole.ADMIN;
+    return this;
+  }
+
+  asParticipant(): this {
+    this.data.role = AttendeeRole.PARTICIPANT;
+    return this;
+  }
+
+  withRole(role: AttendeeRole): this {
+    this.data.role = role;
+    return this;
+  }
+
+  build(): EventAttendee {
+    if (this.data.user) {
+      return EventAttendee.createFromExistingUser({
+        id: uuid() as AttendeeId,
+        eventId: this.data.eventId,
+        user: this.data.user,
+        role: this.data.role,
+      });
+    }
+
+    return EventAttendee.createFromNonExistingUser({
+      id: uuid() as AttendeeId,
+      eventId: this.data.eventId,
+      pendingEmail: this.data.pendingEmail ?? 'pending@test.fr',
+      role: this.data.role,
+    });
+  }
+}

--- a/apps/api/test-utils/builders/event.builder.ts
+++ b/apps/api/test-utils/builders/event.builder.ts
@@ -1,0 +1,77 @@
+import type { EventId } from '@wishlist/common';
+
+import { uuid } from '@wishlist/common';
+
+import { AttendeeRole } from '../../src/event/domain/attendee-role.enum';
+import { Event } from '../../src/event/domain/model/event.model';
+import { EventAttendee } from '../../src/event/domain/model/event-attendee.model';
+import { User } from '../../src/user/domain/model/user.model';
+import { EventAttendeeBuilder } from './event-attendee.builder';
+import { UserBuilder } from './user.builder';
+
+type EventBuilderData = {
+  id: EventId;
+  title: string;
+  eventDate: Date;
+  creator: User;
+  extraAttendees: EventAttendee[];
+};
+
+export class EventBuilder {
+  private readonly data: EventBuilderData = {
+    id: uuid() as EventId,
+    title: 'Anniversaire',
+    eventDate: new Date(Date.now() + 86_400_000),
+    creator: new UserBuilder().build(),
+    extraAttendees: [],
+  };
+
+  withTitle(title: string): this {
+    this.data.title = title;
+    return this;
+  }
+
+  withCreator(creator: User): this {
+    this.data.creator = creator;
+    return this;
+  }
+
+  withEventDate(eventDate: Date): this {
+    this.data.eventDate = eventDate;
+    return this;
+  }
+
+  finished(): this {
+    this.data.eventDate = new Date(Date.now() - 86_400_000);
+    return this;
+  }
+
+  withAttendee(user: User, role: AttendeeRole = AttendeeRole.PARTICIPANT): this {
+    this.data.extraAttendees.push(
+      new EventAttendeeBuilder().withEventId(this.data.id).withUser(user).withRole(role).build(),
+    );
+    return this;
+  }
+
+  withPendingAttendee(email: string, role: AttendeeRole = AttendeeRole.PARTICIPANT): this {
+    this.data.extraAttendees.push(
+      new EventAttendeeBuilder().withEventId(this.data.id).withPendingEmail(email).withRole(role).build(),
+    );
+    return this;
+  }
+
+  build(): Event {
+    const creatorAttendee = new EventAttendeeBuilder()
+      .withEventId(this.data.id)
+      .withUser(this.data.creator)
+      .asCreator()
+      .build();
+
+    return Event.create({
+      id: this.data.id,
+      title: this.data.title,
+      eventDate: this.data.eventDate,
+      attendees: [creatorAttendee, ...this.data.extraAttendees],
+    });
+  }
+}

--- a/apps/api/test-utils/builders/secret-santa-user.builder.ts
+++ b/apps/api/test-utils/builders/secret-santa-user.builder.ts
@@ -1,0 +1,42 @@
+import type { AttendeeId, SecretSantaId, SecretSantaUserId } from '@wishlist/common';
+
+import { uuid } from '@wishlist/common';
+
+import { SecretSantaUser } from '../../src/secret-santa/domain/model/secret-santa-user.model';
+
+type SecretSantaUserBuilderData = {
+  attendeeId: AttendeeId;
+  secretSantaId: SecretSantaId;
+  exclusions: SecretSantaUserId[];
+};
+
+export class SecretSantaUserBuilder {
+  private readonly data: SecretSantaUserBuilderData = {
+    attendeeId: uuid() as AttendeeId,
+    secretSantaId: uuid() as SecretSantaId,
+    exclusions: [],
+  };
+
+  withAttendeeId(attendeeId: AttendeeId): this {
+    this.data.attendeeId = attendeeId;
+    return this;
+  }
+
+  withSecretSantaId(secretSantaId: SecretSantaId): this {
+    this.data.secretSantaId = secretSantaId;
+    return this;
+  }
+
+  withExclusions(exclusions: SecretSantaUserId[]): this {
+    this.data.exclusions = exclusions;
+    return this;
+  }
+
+  build(): SecretSantaUser {
+    return SecretSantaUser.create({
+      id: uuid() as SecretSantaUserId,
+      attendeeId: this.data.attendeeId,
+      secretSantaId: this.data.secretSantaId,
+    }).updateExclusions(this.data.exclusions);
+  }
+}

--- a/apps/api/test-utils/builders/secret-santa.builder.ts
+++ b/apps/api/test-utils/builders/secret-santa.builder.ts
@@ -1,0 +1,66 @@
+import type { EventId, SecretSantaId } from '@wishlist/common';
+
+import { uuid } from '@wishlist/common';
+
+import { SecretSanta } from '../../src/secret-santa/domain/model/secret-santa.model';
+import { SecretSantaUser } from '../../src/secret-santa/domain/model/secret-santa-user.model';
+import { SecretSantaStatus } from '../../src/secret-santa/domain/secret-santa-status.enum';
+
+type SecretSantaBuilderData = {
+  eventId: EventId;
+  description?: string;
+  budget?: number;
+  status: SecretSantaStatus;
+  users: SecretSantaUser[];
+};
+
+export class SecretSantaBuilder {
+  private readonly data: SecretSantaBuilderData = {
+    eventId: uuid() as EventId,
+    status: SecretSantaStatus.CREATED,
+    users: [],
+  };
+
+  withEventId(eventId: EventId): this {
+    this.data.eventId = eventId;
+    return this;
+  }
+
+  withDescription(description: string): this {
+    this.data.description = description;
+    return this;
+  }
+
+  withBudget(budget: number): this {
+    this.data.budget = budget;
+    return this;
+  }
+
+  withUsers(users: SecretSantaUser[]): this {
+    this.data.users = users;
+    return this;
+  }
+
+  started(): this {
+    this.data.status = SecretSantaStatus.STARTED;
+    return this;
+  }
+
+  build(): SecretSanta {
+    const now = new Date();
+    const created = SecretSanta.create({
+      id: uuid() as SecretSantaId,
+      description: this.data.description,
+      budget: this.data.budget,
+      eventId: this.data.eventId,
+    });
+
+    return new SecretSanta({
+      ...created,
+      status: this.data.status,
+      users: this.data.users,
+      createdAt: now,
+      updatedAt: now,
+    });
+  }
+}

--- a/apps/api/test-utils/builders/user-email-change-verification.builder.ts
+++ b/apps/api/test-utils/builders/user-email-change-verification.builder.ts
@@ -1,0 +1,53 @@
+import type { UserEmailChangeVerificationId } from '@wishlist/common';
+
+import { uuid } from '@wishlist/common';
+
+import { User } from '../../src/user/domain/model/user.model';
+import { UserEmailChangeVerification } from '../../src/user/domain/model/user-email-change-verification.model';
+import { UserBuilder } from './user.builder';
+
+type UserEmailChangeVerificationBuilderData = {
+  user: User;
+  newEmail: string;
+  token: string;
+  expiredAt: Date;
+};
+
+export class UserEmailChangeVerificationBuilder {
+  private readonly data: UserEmailChangeVerificationBuilderData = {
+    user: new UserBuilder().build(),
+    newEmail: 'new@test.fr',
+    token: 'email-change-token',
+    expiredAt: new Date(Date.now() + 3_600_000),
+  };
+
+  withUser(user: User): this {
+    this.data.user = user;
+    return this;
+  }
+
+  withNewEmail(newEmail: string): this {
+    this.data.newEmail = newEmail;
+    return this;
+  }
+
+  withToken(token: string): this {
+    this.data.token = token;
+    return this;
+  }
+
+  expired(): this {
+    this.data.expiredAt = new Date(Date.now() - 1000);
+    return this;
+  }
+
+  build(): UserEmailChangeVerification {
+    return UserEmailChangeVerification.create({
+      id: uuid() as UserEmailChangeVerificationId,
+      user: this.data.user,
+      newEmail: this.data.newEmail,
+      token: this.data.token,
+      expiredAt: this.data.expiredAt,
+    });
+  }
+}

--- a/apps/api/test-utils/builders/user-email-setting.builder.ts
+++ b/apps/api/test-utils/builders/user-email-setting.builder.ts
@@ -1,0 +1,37 @@
+import type { UserEmailSettingId } from '@wishlist/common';
+
+import { uuid } from '@wishlist/common';
+
+import { User } from '../../src/user/domain/model/user.model';
+import { UserEmailSetting } from '../../src/user/domain/model/user-email-setting.model';
+import { UserBuilder } from './user.builder';
+
+type UserEmailSettingBuilderData = {
+  user: User;
+  dailyNewItemNotification: boolean;
+};
+
+export class UserEmailSettingBuilder {
+  private readonly data: UserEmailSettingBuilderData = {
+    user: new UserBuilder().build(),
+    dailyNewItemNotification: true,
+  };
+
+  withUser(user: User): this {
+    this.data.user = user;
+    return this;
+  }
+
+  withDailyNewItemNotification(dailyNewItemNotification: boolean): this {
+    this.data.dailyNewItemNotification = dailyNewItemNotification;
+    return this;
+  }
+
+  build(): UserEmailSetting {
+    return UserEmailSetting.create({
+      id: uuid() as UserEmailSettingId,
+      user: this.data.user,
+      dailyNewItemNotification: this.data.dailyNewItemNotification,
+    });
+  }
+}

--- a/apps/api/test-utils/builders/user-password-verification.builder.ts
+++ b/apps/api/test-utils/builders/user-password-verification.builder.ts
@@ -1,0 +1,45 @@
+import type { UserPasswordVerificationId } from '@wishlist/common';
+
+import { uuid } from '@wishlist/common';
+
+import { User } from '../../src/user/domain/model/user.model';
+import { UserPasswordVerification } from '../../src/user/domain/model/user-password-verification.model';
+import { UserBuilder } from './user.builder';
+
+type UserPasswordVerificationBuilderData = {
+  user: User;
+  token: string;
+  expiredAt: Date;
+};
+
+export class UserPasswordVerificationBuilder {
+  private readonly data: UserPasswordVerificationBuilderData = {
+    user: new UserBuilder().build(),
+    token: 'reset-token',
+    expiredAt: new Date(Date.now() + 3_600_000),
+  };
+
+  withUser(user: User): this {
+    this.data.user = user;
+    return this;
+  }
+
+  withToken(token: string): this {
+    this.data.token = token;
+    return this;
+  }
+
+  expired(): this {
+    this.data.expiredAt = new Date(Date.now() - 1000);
+    return this;
+  }
+
+  build(): UserPasswordVerification {
+    return UserPasswordVerification.create({
+      id: uuid() as UserPasswordVerificationId,
+      user: this.data.user,
+      token: this.data.token,
+      expiredAt: this.data.expiredAt,
+    });
+  }
+}

--- a/apps/api/test-utils/builders/user.builder.ts
+++ b/apps/api/test-utils/builders/user.builder.ts
@@ -1,0 +1,92 @@
+import type { ICurrentUser, UserId } from '@wishlist/common';
+
+import { uuid } from '@wishlist/common';
+
+import { Authorities } from '../../src/user/domain/authorities.enum';
+import { User } from '../../src/user/domain/model/user.model';
+import { generateEmail } from '../data-generator.utils';
+
+type UserBuilderData = {
+  email: string;
+  firstName: string;
+  lastName: string;
+  authorities: Authorities[];
+  passwordEnc?: string;
+  isEnabled: boolean;
+};
+
+export class UserBuilder {
+  private readonly data: UserBuilderData = {
+    email: generateEmail(),
+    firstName: 'Jean',
+    lastName: 'Dupont',
+    authorities: [Authorities.ROLE_USER],
+    isEnabled: true,
+  };
+
+  withEmail(email: string): this {
+    this.data.email = email;
+    return this;
+  }
+
+  withName(params: { firstName: string; lastName: string }): this {
+    this.data.firstName = params.firstName;
+    this.data.lastName = params.lastName;
+    return this;
+  }
+
+  withPasswordEnc(passwordEnc: string): this {
+    this.data.passwordEnc = passwordEnc;
+    return this;
+  }
+
+  disabled(): this {
+    this.data.isEnabled = false;
+    return this;
+  }
+
+  asAdmin(): this {
+    this.data.authorities = [Authorities.ROLE_ADMIN];
+    return this;
+  }
+
+  asSuperAdmin(): this {
+    this.data.authorities = [Authorities.ROLE_SUPERADMIN];
+    return this;
+  }
+
+  build(): User {
+    const user = User.create({
+      id: uuid() as UserId,
+      email: this.data.email,
+      firstName: this.data.firstName,
+      lastName: this.data.lastName,
+      passwordEnc: this.data.passwordEnc,
+      ip: '127.0.0.1',
+    });
+
+    if (
+      this.data.isEnabled &&
+      this.data.authorities.length === 1 &&
+      this.data.authorities[0] === Authorities.ROLE_USER
+    ) {
+      return user;
+    }
+
+    return new User({
+      ...user,
+      authorities: this.data.authorities,
+      isEnabled: this.data.isEnabled,
+    });
+  }
+}
+
+export function toCurrentUser(user: User): ICurrentUser {
+  return {
+    id: user.id,
+    email: user.email,
+    authorities: user.authorities,
+    isAdmin: user.isAdmin(),
+    isSuperAdmin: user.isSuperAdmin(),
+  };
+}

--- a/apps/api/test-utils/builders/wishlist-item.builder.ts
+++ b/apps/api/test-utils/builders/wishlist-item.builder.ts
@@ -1,0 +1,52 @@
+import type { ItemId, WishlistId } from '@wishlist/common';
+
+import { uuid } from '@wishlist/common';
+
+import { type ItemTaker, WishlistItem } from '../../src/item/domain/wishlist-item.model';
+import { User } from '../../src/user/domain/model/user.model';
+
+type WishlistItemBuilderData = {
+  wishlistId: WishlistId;
+  name: string;
+  isSuggested: boolean;
+  takers: ItemTaker[];
+};
+
+export class WishlistItemBuilder {
+  private readonly data: WishlistItemBuilderData = {
+    wishlistId: uuid() as WishlistId,
+    name: 'Un livre',
+    isSuggested: false,
+    takers: [],
+  };
+
+  withWishlistId(wishlistId: WishlistId): this {
+    this.data.wishlistId = wishlistId;
+    return this;
+  }
+
+  withName(name: string): this {
+    this.data.name = name;
+    return this;
+  }
+
+  asSuggested(): this {
+    this.data.isSuggested = true;
+    return this;
+  }
+
+  takenBy(user: User): this {
+    this.data.takers = [...this.data.takers, { user, takenAt: new Date() }];
+    return this;
+  }
+
+  build(): WishlistItem {
+    return WishlistItem.create({
+      id: uuid() as ItemId,
+      name: this.data.name,
+      wishlistId: this.data.wishlistId,
+      isSuggested: this.data.isSuggested,
+      takers: this.data.takers,
+    });
+  }
+}

--- a/apps/api/test-utils/builders/wishlist.builder.ts
+++ b/apps/api/test-utils/builders/wishlist.builder.ts
@@ -1,0 +1,61 @@
+import type { EventId, WishlistId } from '@wishlist/common';
+
+import { uuid } from '@wishlist/common';
+
+import { User } from '../../src/user/domain/model/user.model';
+import { Wishlist } from '../../src/wishlist/domain/wishlist.model';
+import { UserBuilder } from './user.builder';
+
+type WishlistBuilderData = {
+  title: string;
+  owner: User;
+  coOwner?: User;
+  hideItems: boolean;
+  eventIds: EventId[];
+};
+
+export class WishlistBuilder {
+  private readonly data: WishlistBuilderData = {
+    title: 'Ma liste',
+    owner: new UserBuilder().build(),
+    hideItems: true,
+    eventIds: [],
+  };
+
+  withOwner(owner: User): this {
+    this.data.owner = owner;
+    return this;
+  }
+
+  withCoOwner(coOwner: User): this {
+    this.data.coOwner = coOwner;
+    return this;
+  }
+
+  withTitle(title: string): this {
+    this.data.title = title;
+    return this;
+  }
+
+  withHideItems(hideItems: boolean): this {
+    this.data.hideItems = hideItems;
+    return this;
+  }
+
+  withEventIds(eventIds: EventId[]): this {
+    this.data.eventIds = eventIds;
+    return this;
+  }
+
+  build(): Wishlist {
+    const wishlist = Wishlist.create({
+      id: uuid() as WishlistId,
+      title: this.data.title,
+      eventIds: this.data.eventIds,
+      owner: this.data.owner,
+      hideItems: this.data.hideItems,
+    });
+
+    return this.data.coOwner ? wishlist.addCoOwner(this.data.coOwner) : wishlist;
+  }
+}

--- a/apps/api/test-utils/data-generator.utils.ts
+++ b/apps/api/test-utils/data-generator.utils.ts
@@ -1,0 +1,3 @@
+import { faker } from '@faker-js/faker';
+
+export const generateEmail = (): string => faker.internet.exampleEmail().toLowerCase();

--- a/apps/api/test-utils/mocks.ts
+++ b/apps/api/test-utils/mocks.ts
@@ -1,0 +1,93 @@
+import type { Mock } from 'bun:test';
+
+import { jest } from 'bun:test';
+
+type DeepPartial<T> = {
+  [P in keyof T]?: T[P] extends (infer U)[]
+    ? DeepPartial<U>[]
+    : T[P] extends readonly (infer U)[]
+      ? readonly DeepPartial<U>[]
+      : unknown extends T[P]
+        ? T[P]
+        : DeepPartial<T[P]>;
+};
+
+export type PartialFuncReturn<T> = {
+  [K in keyof T]?: T[K] extends (...args: infer A) => infer U
+    ? (...args: A) => PartialFuncReturn<U>
+    : DeepPartial<T[K]>;
+};
+
+type IsExactlyUnknown<T> = unknown extends T ? (T extends object ? false : true) : false;
+
+export type DeepMocked<T> = {
+  [K in keyof T]: IsExactlyUnknown<T[K]> extends true
+    ? // biome-ignore lint/suspicious/noExplicitAny: deep mock utility
+      any
+    : NonNullable<T[K]> extends (...args: infer A) => infer U
+      ? Mock<(...args: A) => U> & ((...args: A) => DeepMocked<U>)
+      : NonNullable<T[K]> extends object
+        ? undefined extends T[K]
+          ? DeepMocked<NonNullable<T[K]>> | undefined
+          : DeepMocked<T[K]>
+        : T[K];
+} & T;
+
+const createObjectProxy = <T extends object>(partial: T): T => {
+  // biome-ignore lint/suspicious/noExplicitAny: deep mock utility
+  const cache = new Map<string | number | symbol, any>();
+  return new Proxy(partial, {
+    get: (obj, prop) => {
+      if (
+        prop === 'inspect' ||
+        prop === 'then' ||
+        prop === 'asymmetricMatch' ||
+        (typeof prop === 'symbol' && prop.toString() === 'Symbol(util.inspect.custom)')
+      ) {
+        return;
+      }
+
+      if (cache.has(prop)) {
+        return cache.get(prop);
+      }
+
+      // biome-ignore lint/suspicious/noExplicitAny: deep mock utility
+      let value: any;
+
+      if (prop in obj) {
+        const existing = Reflect.get(obj, prop);
+        if (typeof existing === 'function') {
+          // biome-ignore lint/suspicious/noExplicitAny: deep mock utility
+          value = jest.fn(existing as (...args: any[]) => any);
+        } else if (typeof existing === 'object' && existing !== null) {
+          value = createObjectProxy(existing);
+        } else {
+          value = existing;
+        }
+      } else if (prop === 'constructor') {
+        value = () => undefined;
+      } else {
+        // Auto-create jest.fn() for unknown properties (methods on the mocked interface).
+        // Uses real jest.fn() — not a Proxy — so Bun's expect matchers work.
+        value = jest.fn();
+      }
+
+      cache.set(prop, value);
+      return value;
+    },
+    set: (_obj, prop, newValue) => {
+      cache.set(prop, newValue);
+      return true;
+    },
+  });
+};
+
+export type MockOptions = {
+  readonly name?: string;
+  readonly strict?: boolean;
+};
+
+export const createMock = <T extends object>(
+  partial: PartialFuncReturn<T> = {},
+  _options: MockOptions = {},
+): DeepMocked<T> => createObjectProxy(partial as T) as DeepMocked<T>;


### PR DESCRIPTION
## Summary
- Add a unit-test stack for API use cases: `createMock`, fluent domain builders, and specs colocated next to each use case.
- Cover authorization and domain branches for toggle/create/delete item, add co-owner, and add attendee.
- Document the pattern in `apps/api/CLAUDE.md` so future use-case tests follow the same style (`it()`, mocked repos, real domain models).

## Test plan
- [ ] `bun nx run api:test` — unit tests pass (including the new `*.use-case.spec.ts` files)
- [ ] Spot-check one spec (e.g. `toggle-item.use-case.spec.ts`) for `it()`, `createMock`, and builder usage


Made with [Cursor](https://cursor.com)