### PR TITLE
feat(mail): restyle transactional emails as gift stationery

### DIFF
--- a/libs/mail/src/components/layout.tsx
+++ b/libs/mail/src/components/layout.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react';
 
-import { Body, Container, Head, Html, Img, Preview, Section, Text } from 'react-email';
+import { Body, Container, Head, Html, Img, Link, Preview, Section, Text } from 'react-email';
 
 import * as styles from '../styles';
 
@@ -11,29 +11,43 @@ interface EmailLayoutProps {
 }
 
 /**
- * Outer shell shared by every Wishlist email: html/head, inbox preview,
- * logo header and the legal footer. Templates only provide their content
- * sections as `children`.
+ * Outer shell shared by every Wishlist email: cream canvas, horizontal logo,
+ * single stationery card with a navy ribbon, and a quiet legal footer.
  */
 export function EmailLayout({ preview, children }: EmailLayoutProps) {
   return (
-    <Html lang="fr">
-      <Head />
+    <Html lang="fr" style={{ width: '100%' }}>
+      <Head>
+        <meta content="width=device-width, initial-scale=1" name="viewport" />
+        <meta content="light" name="color-scheme" />
+        <meta content="light" name="supported-color-schemes" />
+        <style>{styles.responsiveCss}</style>
+      </Head>
       <Preview>{preview}</Preview>
       <Body style={styles.main}>
-        <Container style={styles.container}>
-          <Section style={styles.logoSection}>
-            <Img alt="Wishlist" src="https://wishlistapp.fr/icon.png" style={styles.logo} width="80" />
-            <Img alt="Wishlist" src="https://wishlistapp.fr/logo_text.png" style={styles.logo} width="160" />
-          </Section>
+        <Section className="wl-outer" style={styles.bodyInner}>
+          <Container style={styles.container}>
+            <Section style={styles.logoSection}>
+              <Img alt="" height="36" src="https://wishlistapp.fr/icon.png" style={styles.logoIcon} width="36" />
+              <Img alt="Wishlist" src="https://wishlistapp.fr/logo_text.png" style={styles.logoWordmark} width="148" />
+            </Section>
 
-          {children}
+            <Section className="wl-card" style={styles.card}>
+              <Section style={styles.ribbon}>&nbsp;</Section>
+              {children}
+            </Section>
 
-          <Section style={styles.footerSection}>
-            <Text style={styles.footerText}>Ce mail a été envoyé automatiquement, merci de ne pas y répondre.</Text>
-            <Text style={styles.footerText}>© Wishlist App - Partagez vos souhaits avec simplicité</Text>
-          </Section>
-        </Container>
+            <Section className="wl-pad" style={styles.footerSection}>
+              <Text style={styles.footerText}>Ce mail a été envoyé automatiquement, merci de ne pas y répondre.</Text>
+              <Text style={styles.footerText}>© Wishlist App — Partagez vos souhaits avec simplicité</Text>
+              <Text style={styles.footerText}>
+                <Link href="https://wishlistapp.fr" style={styles.footerLink}>
+                  wishlistapp.fr
+                </Link>
+              </Text>
+            </Section>
+          </Container>
+        </Section>
       </Body>
     </Html>
   );

--- a/libs/mail/src/components/ui.tsx
+++ b/libs/mail/src/components/ui.tsx
@@ -1,12 +1,22 @@
 import type { CSSProperties, ReactNode } from 'react';
+import type { CalloutVariant } from '../styles';
 
-import { Button, Link, Section, Text } from 'react-email';
+import { Button, Hr, Link, Section, Text } from 'react-email';
 
 import * as styles from '../styles';
 
-/** Centered page title. */
+/** Small gold label above the page title. */
+export function Eyebrow({ children }: { readonly children: ReactNode }) {
+  return <Text style={styles.eyebrow}>{children}</Text>;
+}
+
+/** Centered serif page title. */
 export function Heading({ children, style }: { readonly children: ReactNode; readonly style?: CSSProperties }) {
-  return <Text style={{ ...styles.heading, ...style }}>{children}</Text>;
+  return (
+    <Text className="wl-h" style={{ ...styles.heading, ...style }}>
+      {children}
+    </Text>
+  );
 }
 
 /** Body paragraph (left aligned by default). */
@@ -14,41 +24,153 @@ export function Paragraph({ children, style }: { readonly children: ReactNode; r
   return <Text style={{ ...styles.paragraph, ...style }}>{children}</Text>;
 }
 
-/** White content block. */
-export function ContentSection({ children, style }: { readonly children: ReactNode; readonly style?: CSSProperties }) {
-  return <Section style={{ ...styles.contentSection, ...style }}>{children}</Section>;
+/** Serif subsection title. */
+export function SectionTitle({ children, style }: { readonly children: ReactNode; readonly style?: CSSProperties }) {
+  return <Text style={{ ...styles.sectionTitle, ...style }}>{children}</Text>;
 }
 
-/** Colored highlight block (warning / success / info / ...). */
+/** Padded block inside the stationery card. */
+export function ContentSection({
+  children,
+  compact,
+  style,
+}: {
+  readonly children: ReactNode;
+  readonly compact?: boolean;
+  readonly style?: CSSProperties;
+}) {
+  return (
+    <Section
+      className="wl-pad"
+      style={{ ...(compact ? styles.contentSectionCompact : styles.contentSection), ...style }}
+    >
+      {children}
+    </Section>
+  );
+}
+
+/** Event / wishlist title shown as a navy-tinted card. */
+export function HighlightCard({
+  children,
+  detail,
+  count,
+}: {
+  readonly children: ReactNode;
+  readonly detail?: ReactNode;
+  readonly count?: ReactNode;
+}) {
+  return (
+    <Section className="wl-pad" style={styles.highlightWrap}>
+      <Section style={styles.highlightInner}>
+        <Text className="wl-highlight-title" style={styles.highlightTitle}>
+          {children}
+        </Text>
+        {count !== undefined && <Text style={styles.highlightCount}>{count}</Text>}
+        {detail !== undefined && <Text style={styles.highlightDetail}>{detail}</Text>}
+      </Section>
+    </Section>
+  );
+}
+
+/** Tinted note with a left accent bar. */
 export function Callout({
-  background,
+  variant,
+  title,
+  children,
+}: {
+  readonly variant: CalloutVariant;
+  readonly title?: ReactNode;
+  readonly children: ReactNode;
+}) {
+  return (
+    <Section className="wl-pad" style={styles.calloutWrap}>
+      <Section style={styles.calloutBox(variant)}>
+        {title !== undefined && <Text style={styles.calloutTitle(variant)}>{title}</Text>}
+        {typeof children === 'string' ? <Text style={styles.calloutText(variant)}>{children}</Text> : children}
+      </Section>
+    </Section>
+  );
+}
+
+/** Body copy inside a Callout (use when the callout has several paragraphs). */
+export function CalloutText({
+  variant,
   children,
   style,
 }: {
-  readonly background: string;
+  readonly variant: CalloutVariant;
   readonly children: ReactNode;
   readonly style?: CSSProperties;
 }) {
-  return <Section style={{ ...styles.callout(background), ...style }}>{children}</Section>;
+  return <Text style={{ ...styles.calloutText(variant), ...style }}>{children}</Text>;
 }
 
-/** Primary call-to-action button rendered inside a white section. */
+/** Gold-bullet list row. */
+export function FeatureItem({ children }: { readonly children: ReactNode }) {
+  return (
+    <Text style={styles.listItem}>
+      <span style={styles.featureMark}>•</span>
+      {children}
+    </Text>
+  );
+}
+
+/** Numbered step row (onboarding / checklists). */
+export function Step({ n, children }: { readonly n: number; readonly children: ReactNode }) {
+  return (
+    <Text style={styles.listItem}>
+      <span style={styles.stepNumber}>{n}.</span>
+      {children}
+    </Text>
+  );
+}
+
+/** Label + value line (budget, description, …). */
+export function DetailRow({ label, value }: { readonly label: string; readonly value: string }) {
+  return (
+    <Text style={styles.listItem}>
+      <span style={styles.detailLabel}>{label}</span>
+      {value}
+    </Text>
+  );
+}
+
+/** Hairline separator inside the card. */
+export function Divider() {
+  return (
+    <Section className="wl-pad" style={styles.dividerWrap}>
+      <Hr style={styles.divider} />
+    </Section>
+  );
+}
+
+/** Primary call-to-action button. */
 export function PrimaryButton({ href, children }: { readonly href: string; readonly children: ReactNode }) {
   return (
-    <Button href={href} style={styles.button}>
+    <Button className="wl-btn" href={href} style={styles.button}>
       {children}
     </Button>
   );
 }
 
-/** "If the button does not work, copy this link" helper shown under a button. */
+/** "If the button does not work, copy this link" helper. */
 export function ButtonFallback({ href }: { readonly href: string }) {
   return (
     <Text style={styles.buttonHint}>
       Si le bouton ne fonctionne pas, copiez ce lien :{' '}
-      <Link href={href} style={{ color: styles.colors.primary, textDecoration: 'none' }}>
+      <Link href={href} style={styles.fallbackLink}>
         {href}
       </Link>
     </Text>
+  );
+}
+
+/** Centered CTA: pill button + fallback link. */
+export function CtaBlock({ href, children }: { readonly href: string; readonly children: ReactNode }) {
+  return (
+    <Section className="wl-pad" style={styles.ctaSection}>
+      <PrimaryButton href={href}>{children}</PrimaryButton>
+      <ButtonFallback href={href} />
+    </Section>
   );
 }

--- a/libs/mail/src/index.ts
+++ b/libs/mail/src/index.ts
@@ -4,7 +4,23 @@
 export { render } from 'react-email';
 
 export { EmailLayout } from './components/layout';
-export { ButtonFallback, Callout, ContentSection, Heading, Paragraph, PrimaryButton } from './components/ui';
+export {
+  ButtonFallback,
+  Callout,
+  CalloutText,
+  ContentSection,
+  CtaBlock,
+  DetailRow,
+  Divider,
+  Eyebrow,
+  FeatureItem,
+  Heading,
+  HighlightCard,
+  Paragraph,
+  PrimaryButton,
+  SectionTitle,
+  Step,
+} from './components/ui';
 // Shared building blocks (exposed so the preview server and consumers can reuse them).
 export * from './styles';
 export { type AddedToEventEmailProps, default as AddedToEventEmail } from './templates/added-to-event';

--- a/libs/mail/src/styles.ts
+++ b/libs/mail/src/styles.ts
@@ -1,171 +1,349 @@
 import type { CSSProperties } from 'react';
 
 /**
- * Shared email styles for Wishlist transactional emails.
+ * Shared email styles — “gift stationery” identity.
  *
- * Palette mirrors the previous MJML templates so the visual identity stays
- * unchanged after the migration to react-email:
- *   - primary:    #224158 (deep blue, headings & buttons)
- *   - text:       #55575d (body copy)
- *   - footer:     #9d9d9d (legal footer)
- *   - body bg:    #F4F4F4
+ * Navy from the Wishlist landing, cream canvas, gold hairline accents.
+ * Typography is email-safe: Georgia for titles, system sans for body.
  */
 export const colors = {
-  primary: '#224158',
-  text: '#55575d',
-  hint: '#888888',
-  footer: '#9d9d9d',
+  navy: '#255376',
+  navyDeep: '#1a3a52',
+  gold: '#C4A574',
+  cream: '#F3EEE6',
+  card: '#FFFCFA',
+  ink: '#243040',
+  muted: '#5C6570',
+  hint: '#8A847A',
+  footer: '#8A847A',
   white: '#ffffff',
-  bodyBackground: '#F4F4F4',
+  rule: '#E8E0D4',
 } as const;
 
-export const fontFamily = 'Arial, sans-serif';
+export const headingFont = "Georgia, 'Iowan Old Style', Palatino, 'Palatino Linotype', serif";
+export const bodyFont = "-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif";
+
+export const calloutVariants = {
+  warning: { background: '#F8F1E4', accent: '#C4A574', text: '#6B5428' },
+  success: { background: '#E8F0E9', accent: '#4A7C59', text: '#2F5D3A' },
+  danger: { background: '#F8E8E6', accent: '#C47070', text: '#8B3A3A' },
+  info: { background: '#E8EEF3', accent: '#255376', text: '#1a3a52' },
+  tip: { background: '#F7F3EC', accent: '#C4A574', text: '#243040' },
+  highlight: { background: '#EEF3F7', accent: '#255376', text: '#1a3a52' },
+} as const;
+
+export type CalloutVariant = keyof typeof calloutVariants;
 
 export const main: CSSProperties = {
-  backgroundColor: colors.bodyBackground,
-  fontFamily,
+  backgroundColor: colors.cream,
+  fontFamily: bodyFont,
   margin: 0,
   padding: 0,
+  width: '100%',
+  WebkitTextSizeAdjust: '100%',
+};
+
+export const bodyInner: CSSProperties = {
+  backgroundColor: colors.cream,
+  padding: '32px 16px 40px 16px',
 };
 
 export const container: CSSProperties = {
-  width: '600px',
-  maxWidth: '100%',
+  width: '100%',
+  maxWidth: '600px',
   margin: '0 auto',
 };
 
 export const logoSection: CSSProperties = {
-  padding: '20px 0',
+  padding: '8px 8px 28px 8px',
   textAlign: 'center',
 };
 
-export const logo: CSSProperties = {
-  margin: '0 auto',
+export const logoIcon: CSSProperties = {
+  display: 'inline-block',
+  verticalAlign: 'middle',
+  marginRight: '12px',
+};
+
+export const logoWordmark: CSSProperties = {
+  display: 'inline-block',
+  verticalAlign: 'middle',
+};
+
+export const card: CSSProperties = {
+  backgroundColor: colors.card,
+  borderRadius: '16px',
+  overflow: 'hidden',
+  border: `1px solid ${colors.rule}`,
+  boxShadow: '0 12px 32px rgba(26, 58, 82, 0.08)',
+  width: '100%',
+};
+
+export const ribbon: CSSProperties = {
+  backgroundColor: colors.navy,
+  height: '6px',
+  lineHeight: '6px',
+  fontSize: '1px',
 };
 
 export const contentSection: CSSProperties = {
-  backgroundColor: colors.white,
-  padding: '40px 30px 25px 30px',
+  backgroundColor: colors.card,
+  padding: '36px 40px 8px 40px',
+};
+
+export const contentSectionCompact: CSSProperties = {
+  backgroundColor: colors.card,
+  padding: '12px 40px 8px 40px',
+};
+
+export const eyebrow: CSSProperties = {
+  color: colors.gold,
+  fontFamily: bodyFont,
+  fontSize: '11px',
+  lineHeight: '16px',
+  fontWeight: 700,
+  letterSpacing: '0.18em',
+  textTransform: 'uppercase',
+  textAlign: 'center',
+  margin: '0 0 12px 0',
 };
 
 export const heading: CSSProperties = {
-  color: colors.primary,
-  fontFamily,
-  fontSize: '26px',
-  lineHeight: '32px',
-  fontWeight: 'bold',
+  color: colors.navyDeep,
+  fontFamily: headingFont,
+  fontSize: '28px',
+  lineHeight: '36px',
+  fontWeight: 'normal',
   textAlign: 'center',
-  margin: '0 0 20px 0',
+  margin: '0 0 16px 0',
 };
 
 export const paragraph: CSSProperties = {
-  color: colors.text,
-  fontFamily,
+  color: colors.ink,
+  fontFamily: bodyFont,
   fontSize: '16px',
-  lineHeight: '24px',
-  margin: '0 0 15px 0',
+  lineHeight: '26px',
+  margin: '0 0 14px 0',
 };
 
 export const sectionTitle: CSSProperties = {
-  color: colors.primary,
-  fontFamily,
+  color: colors.navyDeep,
+  fontFamily: headingFont,
   fontSize: '18px',
-  lineHeight: '24px',
-  fontWeight: 'bold',
-  margin: '0 0 15px 0',
+  lineHeight: '26px',
+  fontWeight: 'normal',
+  margin: '8px 0 14px 0',
 };
 
 export const listItem: CSSProperties = {
-  color: colors.text,
-  fontFamily,
+  color: colors.ink,
+  fontFamily: bodyFont,
   fontSize: '15px',
-  lineHeight: '22px',
+  lineHeight: '24px',
   margin: '0 0 10px 0',
 };
 
-export const accent: CSSProperties = {
-  color: colors.primary,
-  fontWeight: 'bold',
+export const featureMark: CSSProperties = {
+  color: colors.gold,
+  fontFamily: headingFont,
+  fontSize: '14px',
+  lineHeight: '24px',
+  paddingRight: '10px',
 };
 
-export const buttonSection: CSSProperties = {
-  backgroundColor: colors.white,
-  padding: '30px 30px 40px 30px',
+export const stepNumber: CSSProperties = {
+  color: colors.navy,
+  fontFamily: headingFont,
+  fontSize: '16px',
+  lineHeight: '24px',
+  fontWeight: 'bold',
+  paddingRight: '10px',
+};
+
+export const detailLabel: CSSProperties = {
+  color: colors.navy,
+  fontFamily: bodyFont,
+  fontSize: '15px',
+  fontWeight: 700,
+  paddingRight: '6px',
+};
+
+export const highlightWrap: CSSProperties = {
+  backgroundColor: colors.card,
+  padding: '12px 40px 20px 40px',
+};
+
+export const highlightInner: CSSProperties = {
+  backgroundColor: calloutVariants.highlight.background,
+  borderLeft: `4px solid ${colors.navy}`,
+  borderRadius: '10px',
+  padding: '20px 24px',
+  textAlign: 'center',
+};
+
+export const highlightTitle: CSSProperties = {
+  color: colors.navyDeep,
+  fontFamily: headingFont,
+  fontSize: '22px',
+  lineHeight: '30px',
+  fontWeight: 'normal',
+  textAlign: 'center',
+  margin: 0,
+};
+
+export const highlightDetail: CSSProperties = {
+  color: colors.navy,
+  fontFamily: bodyFont,
+  fontSize: '14px',
+  lineHeight: '20px',
+  fontWeight: 600,
+  textAlign: 'center',
+  margin: '8px 0 0 0',
+};
+
+export const highlightCount: CSSProperties = {
+  color: colors.navyDeep,
+  fontFamily: headingFont,
+  fontSize: '36px',
+  lineHeight: '42px',
+  textAlign: 'center',
+  margin: '10px 0 0 0',
+};
+
+export const calloutWrap: CSSProperties = {
+  backgroundColor: colors.card,
+  padding: '8px 40px 12px 40px',
+};
+
+export const calloutBox = (variant: CalloutVariant): CSSProperties => {
+  const v = calloutVariants[variant];
+  return {
+    backgroundColor: v.background,
+    borderLeft: `4px solid ${v.accent}`,
+    borderRadius: '10px',
+    padding: '16px 20px',
+  };
+};
+
+export const calloutTitle = (variant: CalloutVariant): CSSProperties => ({
+  color: calloutVariants[variant].text,
+  fontFamily: bodyFont,
+  fontSize: '13px',
+  lineHeight: '18px',
+  fontWeight: 700,
+  letterSpacing: '0.04em',
+  textTransform: 'uppercase',
+  margin: '0 0 8px 0',
+});
+
+export const calloutText = (variant: CalloutVariant): CSSProperties => ({
+  color: calloutVariants[variant].text,
+  fontFamily: bodyFont,
+  fontSize: '14px',
+  lineHeight: '22px',
+  margin: 0,
+});
+
+export const ctaSection: CSSProperties = {
+  backgroundColor: colors.card,
+  padding: '24px 40px 40px 40px',
   textAlign: 'center',
 };
 
 export const button: CSSProperties = {
-  backgroundColor: colors.primary,
+  backgroundColor: colors.navy,
   color: colors.white,
-  fontFamily,
-  fontSize: '16px',
-  fontWeight: 'bold',
-  borderRadius: '6px',
-  padding: '15px 40px',
+  fontFamily: bodyFont,
+  fontSize: '15px',
+  fontWeight: 600,
+  letterSpacing: '0.02em',
+  borderRadius: '999px',
+  padding: '14px 32px',
   textDecoration: 'none',
   textAlign: 'center',
   display: 'inline-block',
+  lineHeight: '20px',
+  maxWidth: '100%',
+  boxSizing: 'border-box',
 };
 
 export const buttonHint: CSSProperties = {
   color: colors.hint,
-  fontFamily,
-  fontSize: '13px',
-  lineHeight: '20px',
+  fontFamily: bodyFont,
+  fontSize: '12px',
+  lineHeight: '18px',
   textAlign: 'center',
-  margin: '15px 0 0 0',
+  margin: '16px 0 0 0',
+};
+
+export const fallbackLink: CSSProperties = {
+  color: colors.navy,
+  textDecoration: 'underline',
+  wordBreak: 'break-all',
 };
 
 export const footerSection: CSSProperties = {
-  padding: '5px 0 10px 0',
+  padding: '28px 24px 8px 24px',
   textAlign: 'center',
 };
 
 export const footerText: CSSProperties = {
   color: colors.footer,
-  fontFamily,
-  fontSize: '11px',
+  fontFamily: bodyFont,
+  fontSize: '12px',
   lineHeight: '18px',
+  margin: '0 0 6px 0',
+};
+
+export const footerLink: CSSProperties = {
+  color: colors.navy,
+  fontFamily: bodyFont,
+  fontSize: '12px',
+  lineHeight: '18px',
+  textDecoration: 'none',
+  fontWeight: 600,
+};
+
+export const dividerWrap: CSSProperties = {
+  backgroundColor: colors.card,
+  padding: '8px 40px',
+};
+
+export const divider: CSSProperties = {
+  border: 'none',
+  borderTop: `1px solid ${colors.rule}`,
   margin: 0,
-  padding: '15px 25px',
 };
 
 /**
- * Colored highlight blocks reused across templates (warning, success, info, ...).
- * Build one with `callout(backgroundColor)` and pair it with a matching text color.
+ * Media queries for clients that honor `<style>` (Apple Mail, Gmail web, the
+ * react-email preview). Inline styles stay as the desktop/Outlook fallback.
+ * Selectors target the `<td>` that react-email `Section` puts padding on.
  */
-export const callout = (backgroundColor: string): CSSProperties => ({
-  backgroundColor,
-  padding: '20px 30px',
-});
-
-export const calloutTitle = (color: string): CSSProperties => ({
-  color,
-  fontFamily,
-  fontSize: '14px',
-  lineHeight: '20px',
-  fontWeight: 'bold',
-  textAlign: 'center',
-  margin: '0 0 8px 0',
-});
-
-export const calloutText = (color: string): CSSProperties => ({
-  color,
-  fontFamily,
-  fontSize: '13px',
-  lineHeight: '19px',
-  textAlign: 'center',
-  margin: 0,
-});
-
-/** Highlight background/text color pairs used by the templates. */
-export const palette = {
-  warning: { background: '#fff3cd', text: '#856404' },
-  success: { background: '#d4edda', text: '#155724' },
-  danger: { background: '#f8d7da', text: '#721c24' },
-  info: { background: '#d1ecf1', text: '#0c5460' },
-  neutral: { background: '#f8f9fa', text: colors.primary },
-  blue: { background: '#e7f3ff', text: '#004085' },
-  event: { background: '#f0f4f8', text: colors.primary },
-  reminder: { background: '#fff9e6', text: '#856404' },
-} as const;
+export const responsiveCss = `
+  html, body { width: 100% !important; margin: 0 !important; padding: 0 !important; }
+  img { max-width: 100% !important; height: auto !important; }
+  @media only screen and (max-width: 620px) {
+    .wl-outer > tbody > tr > td {
+      padding: 16px 8px 24px 8px !important;
+    }
+    .wl-pad > tbody > tr > td {
+      padding-left: 20px !important;
+      padding-right: 20px !important;
+    }
+    .wl-card { width: 100% !important; max-width: 100% !important; }
+    .wl-h {
+      font-size: 24px !important;
+      line-height: 30px !important;
+    }
+    .wl-highlight-title {
+      font-size: 18px !important;
+      line-height: 26px !important;
+    }
+    .wl-btn {
+      display: block !important;
+      padding-left: 16px !important;
+      padding-right: 16px !important;
+    }
+  }
+`;

--- a/libs/mail/src/templates/added-to-event-new-user.tsx
+++ b/libs/mail/src/templates/added-to-event-new-user.tsx
@@ -1,8 +1,15 @@
-import { Section, Text } from 'react-email';
-
 import { EmailLayout } from '../components/layout';
-import { ButtonFallback, Callout, ContentSection, Heading, Paragraph, PrimaryButton } from '../components/ui';
-import * as styles from '../styles';
+import {
+  Callout,
+  ContentSection,
+  CtaBlock,
+  Eyebrow,
+  FeatureItem,
+  Heading,
+  HighlightCard,
+  Paragraph,
+  SectionTitle,
+} from '../components/ui';
 
 export interface AddedToEventNewUserEmailProps {
   readonly eventTitle: string;
@@ -18,62 +25,48 @@ export default function AddedToEventNewUserEmail({
   return (
     <EmailLayout preview={`${invitedBy} vous invite à rejoindre Wishlist`}>
       <ContentSection>
-        <Heading>Vous êtes invité(e) ! 🎉</Heading>
+        <Eyebrow>Invitation</Eyebrow>
+        <Heading>Vous êtes invité(e)</Heading>
         <Paragraph style={{ margin: 0 }}>
           <b>{invitedBy}</b> vous a ajouté(e) en tant que participant(e) à un événement sur Wishlist :
         </Paragraph>
       </ContentSection>
 
-      <Callout background={styles.palette.event.background}>
-        <Text
-          style={{ ...styles.calloutTitle(styles.palette.event.text), fontSize: '22px', lineHeight: '28px', margin: 0 }}
-        >
-          📅 {eventTitle}
-        </Text>
-      </Callout>
+      <HighlightCard>{eventTitle}</HighlightCard>
 
-      <ContentSection style={{ padding: '25px 30px 20px 30px' }}>
-        <Text style={styles.sectionTitle}>Qu'est-ce que Wishlist ?</Text>
-        <Paragraph style={{ fontSize: '15px', lineHeight: '22px' }}>
+      <ContentSection compact>
+        <SectionTitle>Qu'est-ce que Wishlist ?</SectionTitle>
+        <Paragraph style={{ fontSize: '15px', lineHeight: '24px' }}>
           Wishlist est une plateforme gratuite qui vous permet de partager vos souhaits avec vos proches et de découvrir
           les leurs. Plus besoin de se demander quoi offrir !
         </Paragraph>
-        <Text style={styles.listItem}>
-          <span style={styles.accent}>✓</span> <b>Créez vos listes de souhaits</b> pour chaque événement
-        </Text>
-        <Text style={styles.listItem}>
-          <span style={styles.accent}>✓</span> <b>Consultez les listes</b> de vos amis et famille
-        </Text>
-        <Text style={styles.listItem}>
-          <span style={styles.accent}>✓</span> <b>Réservez des cadeaux</b> en toute discrétion
-        </Text>
-        <Text style={{ ...styles.listItem, margin: 0 }}>
-          <span style={styles.accent}>✓</span> <b>Organisez des Secret Santa</b> facilement
-        </Text>
+        <FeatureItem>
+          <b>Créez vos listes de souhaits</b> pour chaque événement
+        </FeatureItem>
+        <FeatureItem>
+          <b>Consultez les listes</b> de vos amis et famille
+        </FeatureItem>
+        <FeatureItem>
+          <b>Réservez des cadeaux</b> en toute discrétion
+        </FeatureItem>
+        <FeatureItem>
+          <b>Organisez des Secret Santa</b> facilement
+        </FeatureItem>
       </ContentSection>
 
-      <Section style={{ ...styles.callout(styles.palette.neutral.background) }}>
-        <Text style={{ ...styles.sectionTitle, fontSize: '16px', lineHeight: '22px', margin: '0 0 10px 0' }}>
-          🎁 Pourquoi rejoindre ?
-        </Text>
-        <Text style={{ ...styles.listItem, fontSize: '14px', lineHeight: '21px', margin: '0 0 8px 0' }}>
-          • <b>Gratuit et sans publicité</b>
-        </Text>
-        <Text style={{ ...styles.listItem, fontSize: '14px', lineHeight: '21px', margin: '0 0 8px 0' }}>
-          • <b>Simple et rapide</b> à utiliser
-        </Text>
-        <Text style={{ ...styles.listItem, fontSize: '14px', lineHeight: '21px', margin: 0 }}>
-          • <b>Vos proches sauront</b> exactement quoi vous offrir
-        </Text>
-      </Section>
+      <Callout title="Pourquoi rejoindre ?" variant="tip">
+        <FeatureItem>
+          <b>Gratuit et sans publicité</b>
+        </FeatureItem>
+        <FeatureItem>
+          <b>Simple et rapide</b> à utiliser
+        </FeatureItem>
+        <FeatureItem>
+          <b>Vos proches sauront</b> exactement quoi vous offrir
+        </FeatureItem>
+      </Callout>
 
-      <Section style={styles.buttonSection}>
-        <Paragraph style={{ textAlign: 'center', fontSize: '15px', lineHeight: '22px', margin: '0 0 20px 0' }}>
-          Créez votre compte gratuitement pour participer à cet événement :
-        </Paragraph>
-        <PrimaryButton href={registerUrl}>Créer mon compte gratuitement</PrimaryButton>
-        <ButtonFallback href={registerUrl} />
-      </Section>
+      <CtaBlock href={registerUrl}>Créer mon compte gratuitement</CtaBlock>
     </EmailLayout>
   );
 }

--- a/libs/mail/src/templates/added-to-event.tsx
+++ b/libs/mail/src/templates/added-to-event.tsx
@@ -1,8 +1,15 @@
-import { Section, Text } from 'react-email';
-
 import { EmailLayout } from '../components/layout';
-import { ButtonFallback, Callout, ContentSection, Heading, Paragraph, PrimaryButton } from '../components/ui';
-import * as styles from '../styles';
+import {
+  Callout,
+  ContentSection,
+  CtaBlock,
+  Eyebrow,
+  FeatureItem,
+  Heading,
+  HighlightCard,
+  Paragraph,
+  SectionTitle,
+} from '../components/ui';
 
 export interface AddedToEventEmailProps {
   readonly eventTitle: string;
@@ -14,50 +21,37 @@ export default function AddedToEventEmail({ eventTitle, eventUrl, invitedBy }: A
   return (
     <EmailLayout preview={`${invitedBy} vous a invité(e) à un événement sur Wishlist`}>
       <ContentSection>
-        <Heading>Nouvelle invitation à un événement ! 🎊</Heading>
+        <Eyebrow>Invitation</Eyebrow>
+        <Heading>Vous êtes invité(e) à un événement</Heading>
         <Paragraph style={{ margin: 0 }}>
           Bonne nouvelle ! <b>{invitedBy}</b> vous a ajouté(e) en tant que participant(e) à l'événement :
         </Paragraph>
       </ContentSection>
 
-      <Callout background={styles.palette.event.background}>
-        <Text
-          style={{ ...styles.calloutTitle(styles.palette.event.text), fontSize: '22px', lineHeight: '28px', margin: 0 }}
-        >
-          📅 {eventTitle}
-        </Text>
-      </Callout>
+      <HighlightCard>{eventTitle}</HighlightCard>
 
-      <ContentSection style={{ padding: '25px 30px 20px 30px' }}>
-        <Text style={styles.sectionTitle}>Ce que vous pouvez faire maintenant :</Text>
-        <Text style={styles.listItem}>
-          <span style={styles.accent}>✓</span> <b>Créer votre liste de souhaits</b> pour cet événement
-        </Text>
-        <Text style={styles.listItem}>
-          <span style={styles.accent}>✓</span> <b>Consulter les listes</b> des autres participants
-        </Text>
-        <Text style={styles.listItem}>
-          <span style={styles.accent}>✓</span> <b>Réserver des cadeaux</b> pour vos proches
-        </Text>
-        <Text style={{ ...styles.listItem, margin: 0 }}>
-          <span style={styles.accent}>✓</span> <b>Participer au Secret Santa</b> si organisé
-        </Text>
+      <ContentSection compact>
+        <SectionTitle>Ce que vous pouvez faire maintenant</SectionTitle>
+        <FeatureItem>
+          <b>Créer votre liste de souhaits</b> pour cet événement
+        </FeatureItem>
+        <FeatureItem>
+          <b>Consulter les listes</b> des autres participants
+        </FeatureItem>
+        <FeatureItem>
+          <b>Réserver des cadeaux</b> pour vos proches
+        </FeatureItem>
+        <FeatureItem>
+          <b>Participer au Secret Santa</b> si organisé
+        </FeatureItem>
       </ContentSection>
 
-      <Section style={{ ...styles.callout(styles.palette.neutral.background) }}>
-        <Text style={{ ...styles.sectionTitle, fontSize: '16px', lineHeight: '22px', margin: '0 0 10px 0' }}>
-          💡 Conseil :
-        </Text>
-        <Text style={{ ...styles.listItem, fontSize: '14px', lineHeight: '21px', margin: 0 }}>
-          Plus vous ajoutez d'éléments à votre liste, plus il sera facile pour vos proches de vous faire plaisir !
-          N'hésitez pas à varier les prix et à être précis dans vos descriptions.
-        </Text>
-      </Section>
+      <Callout title="Conseil" variant="tip">
+        Plus vous ajoutez d'éléments à votre liste, plus il sera facile pour vos proches de vous faire plaisir !
+        N'hésitez pas à varier les prix et à être précis dans vos descriptions.
+      </Callout>
 
-      <Section style={styles.buttonSection}>
-        <PrimaryButton href={eventUrl}>Accéder à l'événement</PrimaryButton>
-        <ButtonFallback href={eventUrl} />
-      </Section>
+      <CtaBlock href={eventUrl}>Accéder à l'événement</CtaBlock>
     </EmailLayout>
   );
 }

--- a/libs/mail/src/templates/added-to-wishlist-as-co-owner.tsx
+++ b/libs/mail/src/templates/added-to-wishlist-as-co-owner.tsx
@@ -1,8 +1,15 @@
-import { Section, Text } from 'react-email';
-
 import { EmailLayout } from '../components/layout';
-import { ButtonFallback, Callout, ContentSection, Heading, Paragraph, PrimaryButton } from '../components/ui';
-import * as styles from '../styles';
+import {
+  Callout,
+  ContentSection,
+  CtaBlock,
+  Eyebrow,
+  FeatureItem,
+  Heading,
+  HighlightCard,
+  Paragraph,
+  SectionTitle,
+} from '../components/ui';
 
 export interface AddedToWishlistAsCoOwnerEmailProps {
   readonly wishlistTitle: string;
@@ -18,68 +25,46 @@ export default function AddedToWishlistAsCoOwnerEmail({
   return (
     <EmailLayout preview={`${invitedBy} vous a ajouté(e) comme co-gestionnaire d'une liste`}>
       <ContentSection>
-        <Heading>Vous êtes co-gestionnaire ! 🤝</Heading>
+        <Eyebrow>Liste partagée</Eyebrow>
+        <Heading>Vous êtes co-gestionnaire</Heading>
         <Paragraph style={{ margin: 0 }}>
           <b>{invitedBy}</b> vous a ajouté(e) en tant que co-gestionnaire de la liste de souhaits :
         </Paragraph>
       </ContentSection>
 
-      <Callout background={styles.palette.blue.background}>
-        <Text
-          style={{ ...styles.calloutTitle(styles.palette.blue.text), fontSize: '22px', lineHeight: '28px', margin: 0 }}
-        >
-          📝 {wishlistTitle}
-        </Text>
-      </Callout>
+      <HighlightCard>{wishlistTitle}</HighlightCard>
 
-      <ContentSection style={{ padding: '25px 30px 20px 30px' }}>
-        <Text style={styles.sectionTitle}>Qu'est-ce qu'un co-gestionnaire ?</Text>
-        <Paragraph style={{ fontSize: '15px', lineHeight: '22px', margin: 0 }}>
+      <ContentSection compact>
+        <SectionTitle>Qu'est-ce qu'un co-gestionnaire ?</SectionTitle>
+        <Paragraph style={{ fontSize: '15px', lineHeight: '24px', margin: 0 }}>
           En tant que co-gestionnaire, vous partagez les mêmes droits que le propriétaire de la liste. Vous pouvez gérer
           cette liste de souhaits ensemble.
         </Paragraph>
       </ContentSection>
 
-      <Section style={{ ...styles.callout(styles.palette.neutral.background) }}>
-        <Text style={{ ...styles.sectionTitle, fontSize: '16px', lineHeight: '22px', margin: '0 0 12px 0' }}>
-          🔑 Vos droits en tant que co-gestionnaire :
-        </Text>
-        <Text style={{ ...styles.listItem, fontSize: '14px', lineHeight: '21px', margin: '0 0 8px 0' }}>
-          <span style={styles.accent}>✓</span> <b>Ajouter des articles</b> à la liste de souhaits
-        </Text>
-        <Text style={{ ...styles.listItem, fontSize: '14px', lineHeight: '21px', margin: '0 0 8px 0' }}>
-          <span style={styles.accent}>✓</span> <b>Modifier ou supprimer</b> les articles existants
-        </Text>
-        <Text style={{ ...styles.listItem, fontSize: '14px', lineHeight: '21px', margin: '0 0 8px 0' }}>
-          <span style={styles.accent}>✓</span> <b>Gérer les paramètres</b> de la liste
-        </Text>
-        <Text style={{ ...styles.listItem, fontSize: '14px', lineHeight: '21px', margin: 0 }}>
-          <span style={styles.accent}>✓</span> <b>Ajouter d'autres co-gestionnaires</b>
-        </Text>
-      </Section>
+      <Callout title="Vos droits" variant="info">
+        <FeatureItem>
+          <b>Ajouter des articles</b> à la liste de souhaits
+        </FeatureItem>
+        <FeatureItem>
+          <b>Modifier ou supprimer</b> les articles existants
+        </FeatureItem>
+        <FeatureItem>
+          <b>Gérer les paramètres</b> de la liste
+        </FeatureItem>
+        <FeatureItem>
+          <b>Ajouter d'autres co-gestionnaires</b>
+        </FeatureItem>
+      </Callout>
 
-      <ContentSection style={{ padding: '25px 30px 20px 30px' }}>
-        <Text style={{ ...styles.sectionTitle, fontSize: '16px', lineHeight: '22px', margin: '0 0 10px 0' }}>
-          💡 Cas d'usage typiques :
-        </Text>
-        <Text style={{ ...styles.listItem, fontSize: '14px', lineHeight: '21px', margin: '0 0 8px 0' }}>
-          • Liste partagée pour un couple
-        </Text>
-        <Text style={{ ...styles.listItem, fontSize: '14px', lineHeight: '21px', margin: '0 0 8px 0' }}>
-          • Liste commune pour des enfants gérée par les parents
-        </Text>
-        <Text style={{ ...styles.listItem, fontSize: '14px', lineHeight: '21px', margin: 0 }}>
-          • Liste collaborative pour un projet commun
-        </Text>
+      <ContentSection compact>
+        <SectionTitle>Cas d'usage typiques</SectionTitle>
+        <FeatureItem>Liste partagée pour un couple</FeatureItem>
+        <FeatureItem>Liste commune pour des enfants gérée par les parents</FeatureItem>
+        <FeatureItem>Liste collaborative pour un projet commun</FeatureItem>
       </ContentSection>
 
-      <Section style={styles.buttonSection}>
-        <Paragraph style={{ textAlign: 'center', fontSize: '15px', lineHeight: '22px', margin: '0 0 20px 0' }}>
-          Commencez dès maintenant à gérer cette liste :
-        </Paragraph>
-        <PrimaryButton href={wishlistUrl}>Gérer la liste</PrimaryButton>
-        <ButtonFallback href={wishlistUrl} />
-      </Section>
+      <CtaBlock href={wishlistUrl}>Gérer la liste</CtaBlock>
     </EmailLayout>
   );
 }

--- a/libs/mail/src/templates/confirm-email-change.tsx
+++ b/libs/mail/src/templates/confirm-email-change.tsx
@@ -1,8 +1,5 @@
-import { Link, Section, Text } from 'react-email';
-
 import { EmailLayout } from '../components/layout';
-import { Callout, ContentSection, Heading, Paragraph, PrimaryButton } from '../components/ui';
-import * as styles from '../styles';
+import { Callout, ContentSection, CtaBlock, Eyebrow, Heading, Paragraph, SectionTitle } from '../components/ui';
 
 export interface ConfirmEmailChangeEmailProps {
   readonly url: string;
@@ -12,45 +9,29 @@ export interface ConfirmEmailChangeEmailProps {
 export default function ConfirmEmailChangeEmail({ url, newEmail }: ConfirmEmailChangeEmailProps) {
   return (
     <EmailLayout preview="Confirmez le changement de votre adresse email">
-      <ContentSection style={{ padding: '40px 30px 30px 30px' }}>
-        <Heading>Confirmation de changement d'email 📧</Heading>
+      <ContentSection>
+        <Eyebrow>Compte</Eyebrow>
+        <Heading>Confirmez votre nouvelle adresse</Heading>
         <Paragraph>
           Vous avez demandé à changer l'adresse email de votre compte Wishlist pour <strong>{newEmail}</strong>.
         </Paragraph>
         <Paragraph style={{ margin: 0 }}>Pour confirmer ce changement, cliquez sur le bouton ci-dessous :</Paragraph>
       </ContentSection>
 
-      <Section style={{ backgroundColor: styles.colors.white, padding: '10px 30px 30px 30px', textAlign: 'center' }}>
-        <PrimaryButton href={url}>Confirmer le changement d'email</PrimaryButton>
-        <Text style={styles.buttonHint}>
-          Si le bouton ne fonctionne pas, copiez-collez ce lien dans votre navigateur :
-        </Text>
-        <Text style={{ ...styles.buttonHint, color: styles.colors.primary, margin: '5px 0 0 0' }}>
-          <Link href={url} style={{ color: styles.colors.primary, wordBreak: 'break-all' }}>
-            {url}
-          </Link>
-        </Text>
-      </Section>
+      <CtaBlock href={url}>Confirmer le changement d'email</CtaBlock>
 
-      <Callout background={styles.palette.warning.background}>
-        <Text style={styles.calloutTitle(styles.palette.warning.text)}>
-          ⏱️ Attention : Ce lien expire dans 15 minutes
-        </Text>
-        <Text style={styles.calloutText(styles.palette.warning.text)}>
-          Pour des raisons de sécurité, ce lien de confirmation n'est valide que pendant 15 minutes. Passé ce délai,
-          vous devrez faire une nouvelle demande.
-        </Text>
+      <Callout title="Ce lien expire dans 15 minutes" variant="warning">
+        Pour des raisons de sécurité, ce lien de confirmation n'est valide que pendant 15 minutes. Passé ce délai, vous
+        devrez faire une nouvelle demande.
       </Callout>
 
-      <ContentSection style={{ padding: '25px 30px 35px 30px' }}>
-        <Text style={{ ...styles.sectionTitle, fontSize: '16px', lineHeight: '22px' }}>
-          🔒 Vous n'avez pas demandé ce changement ?
-        </Text>
-        <Paragraph style={{ fontSize: '14px', lineHeight: '21px', margin: 0 }}>
+      <ContentSection compact style={{ paddingBottom: '36px' }}>
+        <SectionTitle>Vous n'avez pas demandé ce changement ?</SectionTitle>
+        <Paragraph style={{ fontSize: '14px', lineHeight: '22px', margin: 0 }}>
           Si vous n'êtes pas à l'origine de cette demande, vous pouvez ignorer cet e-mail en toute sécurité. Votre
           adresse email actuelle restera inchangée et votre compte est protégé.
         </Paragraph>
-        <Paragraph style={{ fontSize: '14px', lineHeight: '21px', margin: '10px 0 0 0' }}>
+        <Paragraph style={{ fontSize: '14px', lineHeight: '22px', margin: '10px 0 0 0' }}>
           Nous vous recommandons toutefois de vérifier l'activité récente de votre compte si vous recevez régulièrement
           ce type de message.
         </Paragraph>

--- a/libs/mail/src/templates/email-change-notification.tsx
+++ b/libs/mail/src/templates/email-change-notification.tsx
@@ -1,8 +1,5 @@
-import { Text } from 'react-email';
-
 import { EmailLayout } from '../components/layout';
-import { Callout, ContentSection, Heading, Paragraph } from '../components/ui';
-import * as styles from '../styles';
+import { Callout, ContentSection, Eyebrow, FeatureItem, Heading, Paragraph, SectionTitle } from '../components/ui';
 
 export interface EmailChangeNotificationEmailProps {
   readonly newEmail: string;
@@ -11,8 +8,9 @@ export interface EmailChangeNotificationEmailProps {
 export default function EmailChangeNotificationEmail({ newEmail }: EmailChangeNotificationEmailProps) {
   return (
     <EmailLayout preview="Une demande de changement d'email a été effectuée">
-      <ContentSection style={{ padding: '40px 30px 30px 30px' }}>
-        <Heading>Demande de changement d'email 🔔</Heading>
+      <ContentSection>
+        <Eyebrow>Sécurité</Eyebrow>
+        <Heading>Demande de changement d'email</Heading>
         <Paragraph>Une demande de changement d'adresse email a été effectuée sur votre compte Wishlist.</Paragraph>
         <Paragraph>
           La nouvelle adresse email demandée est : <strong>{newEmail}</strong>
@@ -23,28 +21,21 @@ export default function EmailChangeNotificationEmail({ newEmail }: EmailChangeNo
         </Paragraph>
       </ContentSection>
 
-      <Callout background={styles.palette.info.background}>
-        <Text style={styles.calloutTitle(styles.palette.info.text)}>ℹ️ Information</Text>
-        <Text style={styles.calloutText(styles.palette.info.text)}>
-          Votre adresse email actuelle reste active jusqu'à la confirmation du changement. Vous pouvez continuer à
-          utiliser votre compte normalement.
-        </Text>
+      <Callout title="Information" variant="info">
+        Votre adresse email actuelle reste active jusqu'à la confirmation du changement. Vous pouvez continuer à
+        utiliser votre compte normalement.
       </Callout>
 
-      <ContentSection style={{ padding: '25px 30px 35px 30px' }}>
-        <Text style={{ ...styles.sectionTitle, fontSize: '16px', lineHeight: '22px' }}>
-          🔒 Vous n'avez pas demandé ce changement ?
-        </Text>
-        <Paragraph style={{ fontSize: '14px', lineHeight: '21px', margin: 0 }}>
+      <ContentSection compact style={{ paddingBottom: '36px' }}>
+        <SectionTitle>Vous n'avez pas demandé ce changement ?</SectionTitle>
+        <Paragraph style={{ fontSize: '14px', lineHeight: '22px' }}>
           Si vous n'êtes pas à l'origine de cette demande, votre compte pourrait être compromis. Nous vous recommandons
           de :
         </Paragraph>
-        <Paragraph style={{ fontSize: '14px', lineHeight: '21px', margin: '10px 0 0 0' }}>
-          • Changer immédiatement votre mot de passe
-          <br />• Vérifier l'activité récente de votre compte
-          <br />• Ignorer l'email de confirmation (le changement ne sera pas effectué)
-        </Paragraph>
-        <Paragraph style={{ fontSize: '14px', lineHeight: '21px', margin: '10px 0 0 0' }}>
+        <FeatureItem>Changer immédiatement votre mot de passe</FeatureItem>
+        <FeatureItem>Vérifier l'activité récente de votre compte</FeatureItem>
+        <FeatureItem>Ignorer l'email de confirmation (le changement ne sera pas effectué)</FeatureItem>
+        <Paragraph style={{ fontSize: '14px', lineHeight: '22px', margin: '10px 0 0 0' }}>
           Si vous ignorez l'email de confirmation, votre adresse email actuelle ne sera jamais modifiée.
         </Paragraph>
       </ContentSection>

--- a/libs/mail/src/templates/email-changed-confirmation.tsx
+++ b/libs/mail/src/templates/email-changed-confirmation.tsx
@@ -1,8 +1,5 @@
-import { Text } from 'react-email';
-
 import { EmailLayout } from '../components/layout';
-import { Callout, ContentSection, Heading, Paragraph } from '../components/ui';
-import * as styles from '../styles';
+import { Callout, ContentSection, Eyebrow, Heading, Paragraph, SectionTitle } from '../components/ui';
 
 export interface EmailChangedConfirmationEmailProps {
   readonly newEmail: string;
@@ -11,8 +8,9 @@ export interface EmailChangedConfirmationEmailProps {
 export default function EmailChangedConfirmationEmail({ newEmail }: EmailChangedConfirmationEmailProps) {
   return (
     <EmailLayout preview="L'adresse email de votre compte a été modifiée">
-      <ContentSection style={{ padding: '40px 30px 30px 30px' }}>
-        <Heading>Votre email a été modifié ✅</Heading>
+      <ContentSection>
+        <Eyebrow>Compte</Eyebrow>
+        <Heading>Votre email a été modifié</Heading>
         <Paragraph>
           Nous vous confirmons que l'adresse email de votre compte Wishlist a été modifiée avec succès.
         </Paragraph>
@@ -24,23 +22,18 @@ export default function EmailChangedConfirmationEmail({ newEmail }: EmailChanged
         </Paragraph>
       </ContentSection>
 
-      <Callout background={styles.palette.success.background}>
-        <Text style={styles.calloutTitle(styles.palette.success.text)}>✅ Changement effectué</Text>
-        <Text style={styles.calloutText(styles.palette.success.text)}>
-          Cette adresse email n'est plus associée à votre compte Wishlist. Un email de confirmation a été envoyé à votre
-          nouvelle adresse.
-        </Text>
+      <Callout title="Changement effectué" variant="success">
+        Cette adresse email n'est plus associée à votre compte Wishlist. Un email de confirmation a été envoyé à votre
+        nouvelle adresse.
       </Callout>
 
-      <ContentSection style={{ padding: '25px 30px 35px 30px' }}>
-        <Text style={{ ...styles.sectionTitle, fontSize: '16px', lineHeight: '22px' }}>
-          🔒 Vous n'avez pas effectué ce changement ?
-        </Text>
-        <Paragraph style={{ fontSize: '14px', lineHeight: '21px', margin: 0 }}>
+      <ContentSection compact style={{ paddingBottom: '36px' }}>
+        <SectionTitle>Vous n'avez pas effectué ce changement ?</SectionTitle>
+        <Paragraph style={{ fontSize: '14px', lineHeight: '22px', margin: 0 }}>
           Si vous n'êtes pas à l'origine de ce changement, votre compte a été compromis. Contactez-nous immédiatement
           pour récupérer l'accès à votre compte.
         </Paragraph>
-        <Paragraph style={{ fontSize: '14px', lineHeight: '21px', margin: '10px 0 0 0' }}>
+        <Paragraph style={{ fontSize: '14px', lineHeight: '22px', margin: '10px 0 0 0' }}>
           Note : Cette ancienne adresse email ne recevra plus les notifications de votre compte Wishlist.
         </Paragraph>
       </ContentSection>

--- a/libs/mail/src/templates/email-changed-success.tsx
+++ b/libs/mail/src/templates/email-changed-success.tsx
@@ -1,8 +1,5 @@
-import { Text } from 'react-email';
-
 import { EmailLayout } from '../components/layout';
-import { Callout, ContentSection, Heading, Paragraph } from '../components/ui';
-import * as styles from '../styles';
+import { Callout, ContentSection, Eyebrow, FeatureItem, Heading, Paragraph, SectionTitle } from '../components/ui';
 
 export interface EmailChangedSuccessEmailProps {
   readonly email: string;
@@ -11,8 +8,9 @@ export interface EmailChangedSuccessEmailProps {
 export default function EmailChangedSuccessEmail({ email }: EmailChangedSuccessEmailProps) {
   return (
     <EmailLayout preview="Bienvenue sur votre nouvelle adresse email Wishlist">
-      <ContentSection style={{ padding: '40px 30px 30px 30px' }}>
-        <Heading>Bienvenue sur votre nouveau email ! 🎉</Heading>
+      <ContentSection>
+        <Eyebrow>Compte</Eyebrow>
+        <Heading>Votre nouvelle adresse est active</Heading>
         <Paragraph>Félicitations ! Votre adresse email a été mise à jour avec succès.</Paragraph>
         <Paragraph>
           Votre nouvelle adresse email : <strong>{email}</strong>
@@ -23,21 +21,16 @@ export default function EmailChangedSuccessEmail({ email }: EmailChangedSuccessE
         </Paragraph>
       </ContentSection>
 
-      <Callout background={styles.palette.success.background}>
-        <Text style={styles.calloutTitle(styles.palette.success.text)}>✅ Changement confirmé</Text>
-        <Text style={styles.calloutText(styles.palette.success.text)}>
-          Toutes les futures notifications et communications de Wishlist seront envoyées à cette nouvelle adresse email.
-        </Text>
+      <Callout title="Changement confirmé" variant="success">
+        Toutes les futures notifications et communications de Wishlist seront envoyées à cette nouvelle adresse email.
       </Callout>
 
-      <ContentSection style={{ padding: '25px 30px 35px 30px' }}>
-        <Text style={{ ...styles.sectionTitle, fontSize: '16px', lineHeight: '22px' }}>📌 À retenir</Text>
-        <Paragraph style={{ fontSize: '14px', lineHeight: '21px', margin: 0 }}>
-          • Votre ancien email n'est plus associé à votre compte
-          <br />• Utilisez votre nouvelle adresse pour vous connecter
-          <br />• Vos listes de souhaits et événements restent inchangés
-          <br />• Vos préférences de notification sont conservées
-        </Paragraph>
+      <ContentSection compact style={{ paddingBottom: '36px' }}>
+        <SectionTitle>À retenir</SectionTitle>
+        <FeatureItem>Votre ancien email n'est plus associé à votre compte</FeatureItem>
+        <FeatureItem>Utilisez votre nouvelle adresse pour vous connecter</FeatureItem>
+        <FeatureItem>Vos listes de souhaits et événements restent inchangés</FeatureItem>
+        <FeatureItem>Vos préférences de notification sont conservées</FeatureItem>
       </ContentSection>
     </EmailLayout>
   );

--- a/libs/mail/src/templates/new-items-reminder.tsx
+++ b/libs/mail/src/templates/new-items-reminder.tsx
@@ -1,8 +1,15 @@
-import { Section, Text } from 'react-email';
-
 import { EmailLayout } from '../components/layout';
-import { ButtonFallback, Callout, ContentSection, Heading, Paragraph, PrimaryButton } from '../components/ui';
-import * as styles from '../styles';
+import {
+  Callout,
+  ContentSection,
+  CtaBlock,
+  Eyebrow,
+  FeatureItem,
+  Heading,
+  HighlightCard,
+  Paragraph,
+  SectionTitle,
+} from '../components/ui';
 
 export interface NewItemsReminderEmailProps {
   readonly wishlistTitle: string;
@@ -22,66 +29,32 @@ export default function NewItemsReminderEmail({
   return (
     <EmailLayout preview={`${userName} a ajouté de nouveaux articles à sa liste`}>
       <ContentSection>
-        <Heading>Nouveautés sur une liste ! 🎁</Heading>
+        <Eyebrow>Nouveautés</Eyebrow>
+        <Heading>De nouveaux souhaits</Heading>
         <Paragraph style={{ margin: 0 }}>
           <b>{userName}</b> a ajouté de nouveaux articles à sa liste de souhaits depuis hier.
         </Paragraph>
       </ContentSection>
 
-      <Callout background={styles.palette.reminder.background} style={{ padding: '25px 30px' }}>
-        <Text
-          style={{
-            ...styles.calloutTitle(styles.palette.reminder.text),
-            fontSize: '20px',
-            lineHeight: '26px',
-            margin: '0 0 10px 0',
-          }}
-        >
-          📝 {wishlistTitle}
-        </Text>
-        <Text
-          style={{
-            ...styles.calloutTitle(styles.palette.reminder.text),
-            fontSize: '32px',
-            lineHeight: '38px',
-            margin: 0,
-          }}
-        >
-          {nbItems}
-          <span style={{ fontSize: '18px', display: 'block', marginTop: '5px' }}>{itemsLabel}</span>
-        </Text>
-      </Callout>
+      <HighlightCard count={nbItems} detail={itemsLabel}>
+        {wishlistTitle}
+      </HighlightCard>
 
-      <ContentSection style={{ padding: '25px 30px 20px 30px' }}>
-        <Text style={styles.sectionTitle}>Pourquoi est-ce important ?</Text>
-        <Text style={styles.listItem}>
-          <span style={styles.accent}>•</span> Découvrez les nouvelles idées de cadeaux de <b>{userName}</b>
-        </Text>
-        <Text style={styles.listItem}>
-          <span style={styles.accent}>•</span> Réservez rapidement avant que d'autres ne le fassent
-        </Text>
-        <Text style={{ ...styles.listItem, margin: 0 }}>
-          <span style={styles.accent}>•</span> Soyez sûr(e) de faire plaisir avec le bon cadeau
-        </Text>
+      <ContentSection compact>
+        <SectionTitle>Pourquoi est-ce important ?</SectionTitle>
+        <FeatureItem>
+          Découvrez les nouvelles idées de cadeaux de <b>{userName}</b>
+        </FeatureItem>
+        <FeatureItem>Réservez rapidement avant que d'autres ne le fassent</FeatureItem>
+        <FeatureItem>Soyez sûr(e) de faire plaisir avec le bon cadeau</FeatureItem>
       </ContentSection>
 
-      <Section style={{ ...styles.callout(styles.palette.neutral.background) }}>
-        <Text style={{ ...styles.sectionTitle, fontSize: '16px', lineHeight: '22px', margin: '0 0 10px 0' }}>
-          💡 Astuce :
-        </Text>
-        <Text style={{ ...styles.listItem, fontSize: '14px', lineHeight: '21px', margin: 0 }}>
-          Les articles les plus populaires peuvent être réservés rapidement ! Consultez la liste dès maintenant pour
-          avoir le plus grand choix de cadeaux disponibles.
-        </Text>
-      </Section>
+      <Callout title="Astuce" variant="tip">
+        Les articles les plus populaires peuvent être réservés rapidement ! Consultez la liste dès maintenant pour avoir
+        le plus grand choix de cadeaux disponibles.
+      </Callout>
 
-      <Section style={styles.buttonSection}>
-        <Paragraph style={{ textAlign: 'center', fontSize: '15px', lineHeight: '22px', margin: '0 0 20px 0' }}>
-          Cliquez ci-dessous pour découvrir les nouveaux articles ajoutés :
-        </Paragraph>
-        <PrimaryButton href={wishlistUrl}>Découvrir les nouveautés</PrimaryButton>
-        <ButtonFallback href={wishlistUrl} />
-      </Section>
+      <CtaBlock href={wishlistUrl}>Découvrir les nouveautés</CtaBlock>
     </EmailLayout>
   );
 }

--- a/libs/mail/src/templates/reset-password.tsx
+++ b/libs/mail/src/templates/reset-password.tsx
@@ -1,8 +1,5 @@
-import { Link, Section, Text } from 'react-email';
-
 import { EmailLayout } from '../components/layout';
-import { Callout, ContentSection, Heading, Paragraph, PrimaryButton } from '../components/ui';
-import * as styles from '../styles';
+import { Callout, ContentSection, CtaBlock, Eyebrow, Heading, Paragraph, SectionTitle } from '../components/ui';
 
 export interface ResetPasswordEmailProps {
   readonly url: string;
@@ -11,45 +8,29 @@ export interface ResetPasswordEmailProps {
 export default function ResetPasswordEmail({ url }: ResetPasswordEmailProps) {
   return (
     <EmailLayout preview="Réinitialisation de votre mot de passe Wishlist">
-      <ContentSection style={{ padding: '40px 30px 30px 30px' }}>
-        <Heading>Réinitialisation de mot de passe 🔑</Heading>
+      <ContentSection>
+        <Eyebrow>Sécurité</Eyebrow>
+        <Heading>Réinitialisation de mot de passe</Heading>
         <Paragraph style={{ margin: 0 }}>
           Vous avez demandé à réinitialiser votre mot de passe pour votre compte Wishlist. Cliquez sur le bouton
           ci-dessous pour créer un nouveau mot de passe.
         </Paragraph>
       </ContentSection>
 
-      <Section style={{ backgroundColor: styles.colors.white, padding: '10px 30px 30px 30px', textAlign: 'center' }}>
-        <PrimaryButton href={url}>Réinitialiser mon mot de passe</PrimaryButton>
-        <Text style={styles.buttonHint}>
-          Si le bouton ne fonctionne pas, copiez-collez ce lien dans votre navigateur :
-        </Text>
-        <Text style={{ ...styles.buttonHint, color: styles.colors.primary, margin: '5px 0 0 0' }}>
-          <Link href={url} style={{ color: styles.colors.primary, wordBreak: 'break-all' }}>
-            {url}
-          </Link>
-        </Text>
-      </Section>
+      <CtaBlock href={url}>Réinitialiser mon mot de passe</CtaBlock>
 
-      <Callout background={styles.palette.warning.background}>
-        <Text style={styles.calloutTitle(styles.palette.warning.text)}>
-          ⏱️ Attention : Ce lien expire dans 15 minutes
-        </Text>
-        <Text style={styles.calloutText(styles.palette.warning.text)}>
-          Pour des raisons de sécurité, ce lien de réinitialisation n'est valide que pendant 15 minutes. Passé ce délai,
-          vous devrez faire une nouvelle demande.
-        </Text>
+      <Callout title="Ce lien expire dans 15 minutes" variant="warning">
+        Pour des raisons de sécurité, ce lien de réinitialisation n'est valide que pendant 15 minutes. Passé ce délai,
+        vous devrez faire une nouvelle demande.
       </Callout>
 
-      <ContentSection style={{ padding: '25px 30px 35px 30px' }}>
-        <Text style={{ ...styles.sectionTitle, fontSize: '16px', lineHeight: '22px' }}>
-          🔒 Vous n'avez pas demandé cette réinitialisation ?
-        </Text>
-        <Paragraph style={{ fontSize: '14px', lineHeight: '21px', margin: 0 }}>
+      <ContentSection compact style={{ paddingBottom: '36px' }}>
+        <SectionTitle>Vous n'avez pas demandé cette réinitialisation ?</SectionTitle>
+        <Paragraph style={{ fontSize: '14px', lineHeight: '22px', margin: 0 }}>
           Si vous n'êtes pas à l'origine de cette demande, vous pouvez ignorer cet e-mail en toute sécurité. Votre mot
           de passe actuel restera inchangé et votre compte est protégé.
         </Paragraph>
-        <Paragraph style={{ fontSize: '14px', lineHeight: '21px', margin: '10px 0 0 0' }}>
+        <Paragraph style={{ fontSize: '14px', lineHeight: '22px', margin: '10px 0 0 0' }}>
           Nous vous recommandons toutefois de vérifier l'activité récente de votre compte si vous recevez régulièrement
           ce type de message.
         </Paragraph>

--- a/libs/mail/src/templates/secret-santa-cancel.tsx
+++ b/libs/mail/src/templates/secret-santa-cancel.tsx
@@ -1,8 +1,15 @@
-import { Section, Text } from 'react-email';
-
 import { EmailLayout } from '../components/layout';
-import { ButtonFallback, Callout, ContentSection, Heading, Paragraph, PrimaryButton } from '../components/ui';
-import * as styles from '../styles';
+import {
+  Callout,
+  ContentSection,
+  CtaBlock,
+  Eyebrow,
+  FeatureItem,
+  Heading,
+  HighlightCard,
+  Paragraph,
+  SectionTitle,
+} from '../components/ui';
 
 export interface SecretSantaCancelEmailProps {
   readonly eventTitle: string;
@@ -13,56 +20,28 @@ export default function SecretSantaCancelEmail({ eventTitle, eventUrl }: SecretS
   return (
     <EmailLayout preview="Le Secret Santa de votre événement a été annulé">
       <ContentSection>
+        <Eyebrow>Secret Santa</Eyebrow>
         <Heading>Annulation du Secret Santa</Heading>
         <Paragraph style={{ margin: 0 }}>
           Nous vous informons que l'organisateur de l'événement a décidé d'annuler le Secret Santa pour :
         </Paragraph>
       </ContentSection>
 
-      <Callout background={styles.palette.danger.background}>
-        <Text
-          style={{
-            ...styles.calloutTitle(styles.palette.danger.text),
-            fontSize: '22px',
-            lineHeight: '28px',
-            margin: 0,
-          }}
-        >
-          ❌ {eventTitle}
-        </Text>
-      </Callout>
+      <HighlightCard>{eventTitle}</HighlightCard>
 
-      <ContentSection style={{ padding: '25px 30px 20px 30px' }}>
-        <Text style={styles.sectionTitle}>Qu'est-ce que cela signifie ?</Text>
-        <Text style={styles.listItem}>
-          <span style={styles.accent}>•</span> Le tirage au sort Secret Santa a été annulé
-        </Text>
-        <Text style={styles.listItem}>
-          <span style={styles.accent}>•</span> Vous n'avez plus besoin d'acheter de cadeau dans le cadre du Secret Santa
-        </Text>
-        <Text style={{ ...styles.listItem, margin: 0 }}>
-          <span style={styles.accent}>•</span> L'événement reste actif et vous pouvez toujours consulter les listes de
-          souhaits
-        </Text>
+      <ContentSection compact>
+        <SectionTitle>Qu'est-ce que cela signifie ?</SectionTitle>
+        <FeatureItem>Le tirage au sort Secret Santa a été annulé</FeatureItem>
+        <FeatureItem>Vous n'avez plus besoin d'acheter de cadeau dans le cadre du Secret Santa</FeatureItem>
+        <FeatureItem>L'événement reste actif et vous pouvez toujours consulter les listes de souhaits</FeatureItem>
       </ContentSection>
 
-      <Section style={{ ...styles.callout(styles.palette.neutral.background) }}>
-        <Text style={{ ...styles.sectionTitle, fontSize: '16px', lineHeight: '22px', margin: '0 0 10px 0' }}>
-          ℹ️ Bon à savoir :
-        </Text>
-        <Text style={{ ...styles.listItem, fontSize: '14px', lineHeight: '21px', margin: 0 }}>
-          L'annulation du Secret Santa n'affecte pas l'événement en lui-même. Vous pouvez continuer à gérer vos listes
-          de souhaits, consulter celles des autres participants et réserver des cadeaux normalement.
-        </Text>
-      </Section>
+      <Callout title="Bon à savoir" variant="info">
+        L'annulation du Secret Santa n'affecte pas l'événement en lui-même. Vous pouvez continuer à gérer vos listes de
+        souhaits, consulter celles des autres participants et réserver des cadeaux normalement.
+      </Callout>
 
-      <Section style={styles.buttonSection}>
-        <Paragraph style={{ textAlign: 'center', fontSize: '15px', lineHeight: '22px', margin: '0 0 20px 0' }}>
-          Vous pouvez toujours accéder à votre événement et aux listes de souhaits :
-        </Paragraph>
-        <PrimaryButton href={eventUrl}>Accéder à l'événement</PrimaryButton>
-        <ButtonFallback href={eventUrl} />
-      </Section>
+      <CtaBlock href={eventUrl}>Accéder à l'événement</CtaBlock>
     </EmailLayout>
   );
 }

--- a/libs/mail/src/templates/secret-santa-draw.tsx
+++ b/libs/mail/src/templates/secret-santa-draw.tsx
@@ -1,8 +1,16 @@
-import { Section, Text } from 'react-email';
-
 import { EmailLayout } from '../components/layout';
-import { ButtonFallback, Callout, ContentSection, Heading, Paragraph, PrimaryButton } from '../components/ui';
-import * as styles from '../styles';
+import {
+  Callout,
+  ContentSection,
+  CtaBlock,
+  DetailRow,
+  Eyebrow,
+  FeatureItem,
+  Heading,
+  HighlightCard,
+  Paragraph,
+  SectionTitle,
+} from '../components/ui';
 
 export interface SecretSantaDrawEmailProps {
   readonly eventTitle: string;
@@ -15,69 +23,35 @@ export default function SecretSantaDrawEmail({ eventTitle, eventUrl, budget, des
   return (
     <EmailLayout preview="Le tirage Secret Santa a eu lieu — viens découvrir le tien">
       <ContentSection>
-        <Heading>🎅 Le tirage Secret Santa a eu lieu !</Heading>
-        <Paragraph style={{ textAlign: 'center' }}>Le tirage au sort a eu lieu pour l'événement :</Paragraph>
-        <Paragraph style={{ ...styles.accent, textAlign: 'center', fontSize: '18px', margin: 0 }}>
-          {eventTitle}
-        </Paragraph>
+        <Eyebrow>Secret Santa</Eyebrow>
+        <Heading>Le tirage a eu lieu</Heading>
+        <Paragraph style={{ textAlign: 'center', margin: 0 }}>Le tirage au sort a eu lieu pour l'événement :</Paragraph>
       </ContentSection>
 
-      <Callout background={styles.palette.success.background} style={{ padding: '30px' }}>
-        <Text
-          style={{
-            ...styles.calloutTitle(styles.palette.success.text),
-            fontSize: '22px',
-            lineHeight: '28px',
-            margin: '0 0 12px 0',
-          }}
-        >
-          Ton Secret Santa t'attend
-        </Text>
-        <Text style={{ ...styles.calloutText(styles.palette.success.text), fontSize: '16px', margin: 0 }}>
-          Rends-toi sur l'événement et gratte la boule de Noël pour découvrir à qui tu dois offrir un cadeau.
-        </Text>
+      <HighlightCard>{eventTitle}</HighlightCard>
+
+      <Callout title="Ton Secret Santa t'attend" variant="success">
+        Rends-toi sur l'événement et gratte la boule de Noël pour découvrir à qui tu dois offrir un cadeau.
       </Callout>
 
-      <ContentSection style={{ padding: '25px 30px 20px 30px' }}>
-        <Text style={styles.sectionTitle}>📋 Détails du Secret Santa :</Text>
-        <Text style={{ ...styles.listItem, fontSize: '15px', lineHeight: '24px', margin: '0 0 12px 0' }}>
-          <span style={styles.accent}>💰 Budget maximum :</span> {budget}
-        </Text>
-        <Text style={{ ...styles.listItem, fontSize: '15px', lineHeight: '24px', margin: 0 }}>
-          <span style={styles.accent}>📝 Description :</span> {description}
-        </Text>
+      <ContentSection compact>
+        <SectionTitle>Détails du Secret Santa</SectionTitle>
+        <DetailRow label="Budget maximum :" value={budget} />
+        <DetailRow label="Description :" value={description} />
       </ContentSection>
 
-      <Section style={{ ...styles.callout(styles.palette.neutral.background) }}>
-        <Text style={{ ...styles.sectionTitle, fontSize: '16px', lineHeight: '22px', margin: '0 0 12px 0' }}>
-          💡 Conseils pour votre cadeau :
-        </Text>
-        <Text style={{ ...styles.listItem, fontSize: '14px', lineHeight: '21px', margin: '0 0 8px 0' }}>
-          • Consultez la liste de souhaits de cette personne pour trouver l'inspiration
-        </Text>
-        <Text style={{ ...styles.listItem, fontSize: '14px', lineHeight: '21px', margin: '0 0 8px 0' }}>
-          • Respectez le budget maximum indiqué ci-dessus
-        </Text>
-        <Text style={{ ...styles.listItem, fontSize: '14px', lineHeight: '21px', margin: 0 }}>
-          • Gardez le secret jusqu'à l'échange des cadeaux !
-        </Text>
-      </Section>
-
-      <Callout background={styles.palette.warning.background}>
-        <Text style={styles.calloutTitle(styles.palette.warning.text)}>🤫 Rappel important</Text>
-        <Text style={styles.calloutText(styles.palette.warning.text)}>
-          Ne révélez à personne qui est votre Secret Santa ! C'est le principe du jeu. Consultez la liste de la personne
-          tirée au sort pour vous inspirer.
-        </Text>
+      <Callout title="Conseils pour votre cadeau" variant="tip">
+        <FeatureItem>Consultez la liste de souhaits de cette personne pour trouver l'inspiration</FeatureItem>
+        <FeatureItem>Respectez le budget maximum indiqué ci-dessus</FeatureItem>
+        <FeatureItem>Gardez le secret jusqu'à l'échange des cadeaux !</FeatureItem>
       </Callout>
 
-      <Section style={styles.buttonSection}>
-        <Paragraph style={{ textAlign: 'center', fontSize: '15px', lineHeight: '22px', margin: '0 0 20px 0' }}>
-          Cliquez sur le bouton ci-dessous pour découvrir votre tirage et consulter l'événement :
-        </Paragraph>
-        <PrimaryButton href={eventUrl}>Découvre ton Secret Santa ici</PrimaryButton>
-        <ButtonFallback href={eventUrl} />
-      </Section>
+      <Callout title="Rappel important" variant="warning">
+        Ne révélez à personne qui est votre Secret Santa ! C'est le principe du jeu. Consultez la liste de la personne
+        tirée au sort pour vous inspirer.
+      </Callout>
+
+      <CtaBlock href={eventUrl}>Découvre ton Secret Santa ici</CtaBlock>
     </EmailLayout>
   );
 }

--- a/libs/mail/src/templates/welcome-user.tsx
+++ b/libs/mail/src/templates/welcome-user.tsx
@@ -1,8 +1,15 @@
-import { Section, Text } from 'react-email';
-
 import { EmailLayout } from '../components/layout';
-import { ButtonFallback, ContentSection, Heading, Paragraph, PrimaryButton } from '../components/ui';
-import * as styles from '../styles';
+import {
+  Callout,
+  ContentSection,
+  CtaBlock,
+  Eyebrow,
+  FeatureItem,
+  Heading,
+  Paragraph,
+  SectionTitle,
+  Step,
+} from '../components/ui';
 
 export interface WelcomeUserEmailProps {
   readonly mainUrl: string;
@@ -11,9 +18,10 @@ export interface WelcomeUserEmailProps {
 export default function WelcomeUserEmail({ mainUrl }: WelcomeUserEmailProps) {
   return (
     <EmailLayout preview="Bienvenue sur Wishlist !">
-      <ContentSection style={{ padding: '40px 30px 20px 30px' }}>
-        <Heading style={{ fontSize: '28px', lineHeight: '34px' }}>Bienvenue sur Wishlist ! 🎉</Heading>
-        <Paragraph style={{ textAlign: 'center', margin: '0 0 10px 0' }}>
+      <ContentSection>
+        <Eyebrow>Bienvenue</Eyebrow>
+        <Heading>Bienvenue sur Wishlist</Heading>
+        <Paragraph style={{ textAlign: 'center' }}>
           Nous sommes ravis de vous accueillir dans notre communauté !
         </Paragraph>
         <Paragraph style={{ margin: 0 }}>
@@ -22,42 +30,29 @@ export default function WelcomeUserEmail({ mainUrl }: WelcomeUserEmailProps) {
         </Paragraph>
       </ContentSection>
 
-      <ContentSection style={{ padding: '20px 30px' }}>
-        <Text style={{ ...styles.sectionTitle, fontSize: '20px', lineHeight: '26px' }}>
-          Que pouvez-vous faire avec Wishlist ?
-        </Text>
-        <Text style={{ ...styles.listItem, paddingLeft: '10px' }}>
-          <span style={styles.accent}>✓</span> <b>Créer des événements</b> : Anniversaires, Noël, mariages, etc.
-        </Text>
-        <Text style={{ ...styles.listItem, paddingLeft: '10px' }}>
-          <span style={styles.accent}>✓</span> <b>Partager vos listes de souhaits</b> : Vos proches sauront quoi vous
-          offrir
-        </Text>
-        <Text style={{ ...styles.listItem, paddingLeft: '10px' }}>
-          <span style={styles.accent}>✓</span> <b>Organiser un Secret Santa</b> : Tirage au sort automatique avec budget
-        </Text>
-        <Text style={{ ...styles.listItem, paddingLeft: '10px', margin: 0 }}>
-          <span style={styles.accent}>✓</span> <b>Inviter vos amis</b> : Partagez facilement vos événements
-        </Text>
+      <ContentSection compact>
+        <SectionTitle>Que pouvez-vous faire avec Wishlist ?</SectionTitle>
+        <FeatureItem>
+          <b>Créer des événements</b> : Anniversaires, Noël, mariages, etc.
+        </FeatureItem>
+        <FeatureItem>
+          <b>Partager vos listes de souhaits</b> : Vos proches sauront quoi vous offrir
+        </FeatureItem>
+        <FeatureItem>
+          <b>Organiser un Secret Santa</b> : Tirage au sort automatique avec budget
+        </FeatureItem>
+        <FeatureItem>
+          <b>Inviter vos amis</b> : Partagez facilement vos événements
+        </FeatureItem>
       </ContentSection>
 
-      <Section style={{ ...styles.callout(styles.palette.neutral.background), padding: '25px 30px' }}>
-        <Text style={{ ...styles.sectionTitle }}>Pour bien démarrer :</Text>
-        <Text style={styles.listItem}>
-          <b>1.</b> Créez votre premier événement
-        </Text>
-        <Text style={styles.listItem}>
-          <b>2.</b> Ajoutez vos souhaits à votre liste
-        </Text>
-        <Text style={{ ...styles.listItem, margin: 0 }}>
-          <b>3.</b> Invitez vos proches à rejoindre l'événement
-        </Text>
-      </Section>
+      <Callout title="Pour bien démarrer" variant="tip">
+        <Step n={1}>Créez votre premier événement</Step>
+        <Step n={2}>Ajoutez vos souhaits à votre liste</Step>
+        <Step n={3}>Invitez vos proches à rejoindre l'événement</Step>
+      </Callout>
 
-      <Section style={styles.buttonSection}>
-        <PrimaryButton href={mainUrl}>Découvrir Wishlist</PrimaryButton>
-        <ButtonFallback href={mainUrl} />
-      </Section>
+      <CtaBlock href={mainUrl}>Découvrir Wishlist</CtaBlock>
     </EmailLayout>
   );
 }


### PR DESCRIPTION
## Summary
- Restyle the 11 react-email templates with a navy-and-cream “gift stationery” look (serif titles, gold accents, single card with navy ribbon) aligned with the Wishlist landing.
- Unify layout via new primitives (`Eyebrow`, `HighlightCard`, `FeatureItem`, `Callout`, `CtaBlock`) without changing template props or the API mapper.
- Make the emails responsive: fluid 600px container, viewport meta, and mobile media queries so the react-email preview no longer overflows.

## Test plan
- [ ] `bun nx run mail:typecheck`
- [ ] `bun test src/core/mail/mail.mapper.spec.ts` from `apps/api`
- [ ] `bun mail:preview` — check all 11 templates on desktop and mobile widths
- [ ] Spot-check a couple of real sends (welcome, reset password, Secret Santa draw) in MailDev / Gmail


Made with [Cursor](https://cursor.com)