### PR TITLE
feat(front): prompt for size when adding a clothing wish

### DIFF
--- a/apps/front/src/components/item/ClothingSizeHint.tsx
+++ b/apps/front/src/components/item/ClothingSizeHint.tsx
@@ -1,7 +1,7 @@
 import CheckroomIcon from '@mui/icons-material/Checkroom';
 import { Alert, AlertTitle, alertClasses, styled, Typography } from '@mui/material';
 
-import { shouldShowClothingSizeHint } from '../../utils/clothing.utils';
+import { getClothingSizeHintKind } from '../../utils/clothing.utils';
 
 const ClothingSizeAlert = styled(Alert)(({ theme }) => ({
   border: `2px solid ${theme.palette.warning.main}`,
@@ -11,13 +11,29 @@ const ClothingSizeAlert = styled(Alert)(({ theme }) => ({
   },
 }));
 
+const HINT_COPY = {
+  shoe: {
+    title: 'Pensez à indiquer la pointure',
+    measurement: 'la pointure',
+    example: 'Pointure 42',
+  },
+  garment: {
+    title: 'Pensez à indiquer la taille',
+    measurement: 'la taille',
+    example: 'Taille M',
+  },
+} as const;
+
 interface ClothingSizeHintProps {
   title: string;
   description: string;
 }
 
 export function ClothingSizeHint({ title, description }: ClothingSizeHintProps) {
-  if (!shouldShowClothingSizeHint(title, description)) return null;
+  const kind = getClothingSizeHintKind(title, description);
+  if (!kind) return null;
+
+  const copy = HINT_COPY[kind];
 
   return (
     <ClothingSizeAlert
@@ -25,10 +41,10 @@ export function ClothingSizeHint({ title, description }: ClothingSizeHintProps) 
       icon={<CheckroomIcon fontSize="inherit" />}
       className="animated zoomIn faster"
     >
-      <AlertTitle>Pensez à indiquer la taille</AlertTitle>
+      <AlertTitle>{copy.title}</AlertTitle>
       <Typography variant="body2">
-        Ce souhait a très peu de chances d'être pris si la taille n'est pas renseignée dans le champ{' '}
-        <strong>Détails</strong>. Ajoutez par exemple « Taille M » ou « Pointure 42 ».
+        Ce souhait a très peu de chances d'être pris si {copy.measurement} n'est pas renseignée dans le champ{' '}
+        <strong>Détails</strong>. Ajoutez par exemple « {copy.example} ».
       </Typography>
     </ClothingSizeAlert>
   );

--- a/apps/front/src/components/item/ClothingSizeHint.tsx
+++ b/apps/front/src/components/item/ClothingSizeHint.tsx
@@ -1,0 +1,35 @@
+import CheckroomIcon from '@mui/icons-material/Checkroom';
+import { Alert, AlertTitle, alertClasses, styled, Typography } from '@mui/material';
+
+import { shouldShowClothingSizeHint } from '../../utils/clothing.utils';
+
+const ClothingSizeAlert = styled(Alert)(({ theme }) => ({
+  border: `2px solid ${theme.palette.warning.main}`,
+  [`& .${alertClasses.icon}`]: {
+    fontSize: '2rem',
+    alignItems: 'center',
+  },
+}));
+
+interface ClothingSizeHintProps {
+  title: string;
+  description: string;
+}
+
+export function ClothingSizeHint({ title, description }: ClothingSizeHintProps) {
+  if (!shouldShowClothingSizeHint(title, description)) return null;
+
+  return (
+    <ClothingSizeAlert
+      severity="warning"
+      icon={<CheckroomIcon fontSize="inherit" />}
+      className="animated zoomIn faster"
+    >
+      <AlertTitle>Pensez à indiquer la taille</AlertTitle>
+      <Typography variant="body2">
+        Ce souhait a très peu de chances d'être pris si la taille n'est pas renseignée dans le champ{' '}
+        <strong>Détails</strong>. Ajoutez par exemple « Taille M » ou « Pointure 42 ».
+      </Typography>
+    </ClothingSizeAlert>
+  );
+}

--- a/apps/front/src/components/item/ItemFormDialog.tsx
+++ b/apps/front/src/components/item/ItemFormDialog.tsx
@@ -37,7 +37,7 @@ import {
   useScanItemUrlMutation,
   useUpdateItemMutation,
 } from '../../gql';
-import { isClothingItemTitle, shouldShowClothingSizeHint } from '../../utils/clothing.utils';
+import { getClothingDetailsPlaceholder, getClothingKind, shouldShowClothingSizeHint } from '../../utils/clothing.utils';
 import { isValidUrl } from '../../utils/router.utils';
 import { CharsRemaining } from '../common/CharsRemaining';
 import { InputLabel } from '../common/InputLabel';
@@ -86,7 +86,7 @@ export const ItemFormDialog = ({ title, open, item, mode, handleClose, wishlistI
   const invalidUrl = url !== '' && !isValidUrl(url);
   const formIsValid =
     name.trim() !== '' && !invalidUrl && ((pictureUrl && validPictureUrl === true) || !pictureUrl) && !scanUrlLoading;
-  const clothingTitle = isClothingItemTitle(name);
+  const clothingKind = getClothingKind(name);
   const showClothingSizeHint = shouldShowClothingSizeHint(name, description);
 
   const resetForm = () => {
@@ -237,7 +237,7 @@ export const ItemFormDialog = ({ title, open, item, mode, handleClose, wishlistI
               value={description}
               color={showClothingSizeHint ? 'warning' : undefined}
               slotProps={{ htmlInput: { maxLength: 120 } }}
-              placeholder={clothingTitle ? 'Ex : Taille M, couleur, matière…' : 'Ajouter du détail à votre souhait'}
+              placeholder={getClothingDetailsPlaceholder(clothingKind)}
               helperText={<CharsRemaining max={120} value={description} />}
               onChange={e => setDescription(e.target.value)}
             />

--- a/apps/front/src/components/item/ItemFormDialog.tsx
+++ b/apps/front/src/components/item/ItemFormDialog.tsx
@@ -37,11 +37,13 @@ import {
   useScanItemUrlMutation,
   useUpdateItemMutation,
 } from '../../gql';
+import { isClothingItemTitle, shouldShowClothingSizeHint } from '../../utils/clothing.utils';
 import { isValidUrl } from '../../utils/router.utils';
 import { CharsRemaining } from '../common/CharsRemaining';
 import { InputLabel } from '../common/InputLabel';
 import { Rating } from '../common/Rating';
 import { Subtitle } from '../common/Subtitle';
+import { ClothingSizeHint } from './ClothingSizeHint';
 
 const Transition = forwardRef(function TransitionComponent(
   props: TransitionProps & { children: React.ReactElement },
@@ -84,6 +86,8 @@ export const ItemFormDialog = ({ title, open, item, mode, handleClose, wishlistI
   const invalidUrl = url !== '' && !isValidUrl(url);
   const formIsValid =
     name.trim() !== '' && !invalidUrl && ((pictureUrl && validPictureUrl === true) || !pictureUrl) && !scanUrlLoading;
+  const clothingTitle = isClothingItemTitle(name);
+  const showClothingSizeHint = shouldShowClothingSizeHint(name, description);
 
   const resetForm = () => {
     setName('');
@@ -220,8 +224,9 @@ export const ItemFormDialog = ({ title, open, item, mode, handleClose, wishlistI
               helperText={<CharsRemaining max={40} value={name} />}
               onChange={e => setName(e.target.value)}
             />
-            {/* TODO: suggest to "add size" if it's clothe */}
           </Box>
+
+          <ClothingSizeHint title={name} description={description} />
 
           <Box>
             <TextField
@@ -230,12 +235,12 @@ export const ItemFormDialog = ({ title, open, item, mode, handleClose, wishlistI
               disabled={loading}
               fullWidth
               value={description}
+              color={showClothingSizeHint ? 'warning' : undefined}
               slotProps={{ htmlInput: { maxLength: 120 } }}
-              placeholder="Ajouter du détail à votre souhait"
+              placeholder={clothingTitle ? 'Ex : Taille M, couleur, matière…' : 'Ajouter du détail à votre souhait'}
               helperText={<CharsRemaining max={120} value={description} />}
               onChange={e => setDescription(e.target.value)}
             />
-            {/* TODO: suggest to "add size" if it's clothe */}
           </Box>
 
           <Box>

--- a/apps/front/src/utils/clothing.utils.spec.ts
+++ b/apps/front/src/utils/clothing.utils.spec.ts
@@ -1,6 +1,45 @@
-import { descriptionMentionsSize, isClothingItemTitle, shouldShowClothingSizeHint } from './clothing.utils';
+import {
+  descriptionMentionsSize,
+  getClothingDetailsPlaceholder,
+  getClothingKind,
+  getClothingSizeHintKind,
+  isClothingItemTitle,
+  shouldShowClothingSizeHint,
+} from './clothing.utils';
 
 describe('clothing.utils', () => {
+  describe('getClothingKind', () => {
+    it.each(['Chaussures de running', 'Baskets Air Max', 'Sneakers blanches', 'Bottes de pluie', 'Sandales été'])(
+      'should detect shoes: "%s"',
+      title => {
+        expect(getClothingKind(title)).toBe('shoe');
+      },
+    );
+
+    it.each([
+      'Pull Nike',
+      'T-shirt blanc',
+      'Jean slim',
+      'Pantalon cargo',
+      'Robe d été',
+      'Veste en cuir',
+      'Sweat à capuche',
+      'Chaussettes invisibles',
+      'Soutien-gorge',
+      'Coupe-vent',
+      'Vêtement de sport',
+    ])('should detect garments: "%s"', title => {
+      expect(getClothingKind(title)).toBe('garment');
+    });
+
+    it.each(['Livre Harry Potter', 'Jeanne', 'Shortcut clavier', '', null, undefined])(
+      'should return null for unrelated or empty titles: "%s"',
+      title => {
+        expect(getClothingKind(title)).toBeNull();
+      },
+    );
+  });
+
   describe('isClothingItemTitle', () => {
     it.each([
       'Pull Nike',
@@ -83,6 +122,35 @@ describe('clothing.utils', () => {
 
     it('should not show the hint for a non-clothing title', () => {
       expect(shouldShowClothingSizeHint('Livre Harry Potter', '')).toBe(false);
+    });
+  });
+
+  describe('getClothingSizeHintKind', () => {
+    it('should return garment for a clothing title without a size', () => {
+      expect(getClothingSizeHintKind('Pull Nike', '')).toBe('garment');
+    });
+
+    it('should return shoe for a footwear title without a size', () => {
+      expect(getClothingSizeHintKind('Baskets Air Max', '')).toBe('shoe');
+    });
+
+    it('should hide the hint once a size is mentioned', () => {
+      expect(getClothingSizeHintKind('Baskets Air Max', 'Pointure 42')).toBeNull();
+      expect(getClothingSizeHintKind('Pull Nike', 'Taille M')).toBeNull();
+    });
+  });
+
+  describe('getClothingDetailsPlaceholder', () => {
+    it('should suggest a clothing size for garments', () => {
+      expect(getClothingDetailsPlaceholder('garment')).toBe('Ex : Taille M, couleur, matière…');
+    });
+
+    it('should suggest a shoe size for footwear', () => {
+      expect(getClothingDetailsPlaceholder('shoe')).toBe('Ex : Pointure 42, couleur…');
+    });
+
+    it('should keep the default placeholder otherwise', () => {
+      expect(getClothingDetailsPlaceholder(null)).toBe('Ajouter du détail à votre souhait');
     });
   });
 });

--- a/apps/front/src/utils/clothing.utils.spec.ts
+++ b/apps/front/src/utils/clothing.utils.spec.ts
@@ -1,0 +1,88 @@
+import { descriptionMentionsSize, isClothingItemTitle, shouldShowClothingSizeHint } from './clothing.utils';
+
+describe('clothing.utils', () => {
+  describe('isClothingItemTitle', () => {
+    it.each([
+      'Pull Nike',
+      'T-shirt blanc',
+      'Tshirt Adidas',
+      'Tee-shirt oversize',
+      'Chaussures de running',
+      'Baskets Air Max',
+      'Jean slim',
+      'Pantalon cargo',
+      'Robe d été',
+      'Veste en cuir',
+      'Doudoune The North Face',
+      'Sweat à capuche',
+      'Hoodie noir',
+      'Short de bain',
+      'Maillot de foot',
+      'Pyjama enfant',
+      'Chaussettes invisibles',
+      'Gants de ski',
+      'Casquette NY',
+      'Sneakers blanches',
+      'Soutien-gorge',
+      'Coupe-vent',
+      'K-way jaune',
+      'Vêtement de sport',
+    ])('should detect clothing titles: "%s"', title => {
+      expect(isClothingItemTitle(title)).toBe(true);
+    });
+
+    it.each(['PULL', 'Chaussure', 'vêtements', 'T-SHIRT', 'Jean'])(
+      'should be accent-insensitive and case-insensitive: "%s"',
+      title => {
+        expect(isClothingItemTitle(title)).toBe(true);
+      },
+    );
+
+    it.each([
+      'Livre Harry Potter',
+      'Console PS5',
+      'Coffret thé',
+      'Bougie parfumée',
+      'Abonnement Spotify',
+      'Lego Star Wars',
+      'Normal day in Paris',
+      'Jeanne',
+      'Address book',
+      'Bluetooth speaker',
+      'Shortcut clavier',
+    ])('should not match unrelated titles: "%s"', title => {
+      expect(isClothingItemTitle(title)).toBe(false);
+    });
+
+    it.each(['', '   ', null, undefined])('should handle empty or invalid input: "%s"', title => {
+      expect(isClothingItemTitle(title)).toBe(false);
+    });
+  });
+
+  describe('descriptionMentionsSize', () => {
+    it.each(['Taille M', 'taille : 42', 'Pointure 38', 'Size L', 'XS', 'XXL', 'T.M', 'T-L', '2XL'])(
+      'should detect a size in "%s"',
+      description => {
+        expect(descriptionMentionsSize(description)).toBe(true);
+      },
+    );
+
+    it.each(['Couleur bleu', 'Coton bio', 'Avec capuche', ''])('should not detect a size in "%s"', description => {
+      expect(descriptionMentionsSize(description)).toBe(false);
+    });
+  });
+
+  describe('shouldShowClothingSizeHint', () => {
+    it('should show the hint for a clothing title without a size', () => {
+      expect(shouldShowClothingSizeHint('Pull Nike', '')).toBe(true);
+    });
+
+    it('should hide the hint once a size is mentioned', () => {
+      expect(shouldShowClothingSizeHint('Pull Nike', 'Taille M')).toBe(false);
+    });
+
+    it('should not show the hint for a non-clothing title', () => {
+      expect(shouldShowClothingSizeHint('Livre Harry Potter', '')).toBe(false);
+    });
+  });
+});

--- a/apps/front/src/utils/clothing.utils.ts
+++ b/apps/front/src/utils/clothing.utils.ts
@@ -15,15 +15,62 @@ function tokenize(value: string): string[] {
   return normalized.split(/\s+/);
 }
 
+function matchesKeywords(words: string[], keywords: Set<string>, compounds: Set<string> = new Set()): boolean {
+  if (words.some(word => keywords.has(word))) return true;
+
+  for (let i = 0; i < words.length - 1; i++) {
+    const compound = `${words[i]}${words[i + 1]}`;
+    if (compounds.has(compound) || keywords.has(compound)) return true;
+  }
+
+  return false;
+}
+
 /**
- * Garment types that typically need a size (FR + common EN).
- * Short generic words like "top" or "haut" are omitted to avoid false positives.
+ * Footwear that needs a shoe size / pointure (FR + common EN).
  */
-const CLOTHING_WORDS = new Set([
+const SHOE_WORDS = new Set([
   'ballerine',
   'ballerines',
   'basket',
   'baskets',
+  'boot',
+  'boots',
+  'botte',
+  'bottes',
+  'bottine',
+  'bottines',
+  'chausson',
+  'chaussons',
+  'chaussure',
+  'chaussures',
+  'claquette',
+  'claquettes',
+  'derby',
+  'derbys',
+  'escarpin',
+  'escarpins',
+  'mocassin',
+  'mocassins',
+  'pantoufle',
+  'pantoufles',
+  'richelieu',
+  'richelieus',
+  'sabot',
+  'sabots',
+  'sandale',
+  'sandales',
+  'sneaker',
+  'sneakers',
+  'tong',
+  'tongs',
+]);
+
+/**
+ * Garment types that typically need a clothing size / taille (FR + common EN).
+ * Short generic words like "top" or "haut" are omitted to avoid false positives.
+ */
+const GARMENT_WORDS = new Set([
   'bermuda',
   'bermudas',
   'blazer',
@@ -34,12 +81,6 @@ const CLOTHING_WORDS = new Set([
   'blousons',
   'bonnet',
   'bonnets',
-  'boot',
-  'boots',
-  'botte',
-  'bottes',
-  'bottine',
-  'bottines',
   'boxer',
   'boxers',
   'brassiere',
@@ -56,16 +97,10 @@ const CLOTHING_WORDS = new Set([
   'chapeaux',
   'chaussette',
   'chaussettes',
-  'chausson',
-  'chaussons',
-  'chaussure',
-  'chaussures',
   'chemise',
   'chemises',
   'chemisier',
   'chemisiers',
-  'claquette',
-  'claquettes',
   'coat',
   'coats',
   'collant',
@@ -78,14 +113,10 @@ const CLOTHING_WORDS = new Set([
   'culottes',
   'debardeur',
   'debardeurs',
-  'derby',
-  'derbys',
   'doudoune',
   'doudounes',
   'dress',
   'dresses',
-  'escarpin',
-  'escarpins',
   'gant',
   'gants',
   'gilet',
@@ -116,12 +147,8 @@ const CLOTHING_WORDS = new Set([
   'maillots',
   'manteau',
   'manteaux',
-  'mocassin',
-  'mocassins',
   'nuisette',
   'nuisettes',
-  'pantoufle',
-  'pantoufles',
   'pantalon',
   'pantalons',
   'pants',
@@ -137,16 +164,10 @@ const CLOTHING_WORDS = new Set([
   'pulls',
   'pyjama',
   'pyjamas',
-  'richelieu',
-  'richelieus',
   'robe',
   'robes',
-  'sabot',
-  'sabots',
   'salopette',
   'salopettes',
-  'sandale',
-  'sandales',
   'shirt',
   'shirts',
   'short',
@@ -157,8 +178,6 @@ const CLOTHING_WORDS = new Set([
   'slips',
   'smoking',
   'smokings',
-  'sneaker',
-  'sneakers',
   'socks',
   'survet',
   'survetement',
@@ -171,8 +190,6 @@ const CLOTHING_WORDS = new Set([
   'sweatshirts',
   'teeshirt',
   'teeshirts',
-  'tong',
-  'tongs',
   'trench',
   'trenchs',
   'trousers',
@@ -186,24 +203,26 @@ const CLOTHING_WORDS = new Set([
   'vetements',
 ]);
 
-const CLOTHING_COMPOUNDS = new Set(['soutiengorge', 'coupevent', 'croptop']);
+const GARMENT_COMPOUNDS = new Set(['soutiengorge', 'coupevent', 'croptop']);
 
 const SIZE_KEYWORDS = new Set(['taille', 'pointure', 'size', 'sizes']);
 
 const SIZE_TOKENS = new Set(['xxxs', 'xxs', 'xs', 'xl', 'xxl', 'xxxl', 'xxxxl', '2xl', '3xl', '4xl', '5xl']);
 
-export function isClothingItemTitle(title: string | null | undefined): boolean {
-  if (!title?.trim()) return false;
+export type ClothingKind = 'shoe' | 'garment';
+
+export function getClothingKind(title: string | null | undefined): ClothingKind | null {
+  if (!title?.trim()) return null;
 
   const words = tokenize(title);
-  if (words.some(word => CLOTHING_WORDS.has(word))) return true;
+  if (matchesKeywords(words, SHOE_WORDS)) return 'shoe';
+  if (matchesKeywords(words, GARMENT_WORDS, GARMENT_COMPOUNDS)) return 'garment';
 
-  for (let i = 0; i < words.length - 1; i++) {
-    const compound = `${words[i]}${words[i + 1]}`;
-    if (CLOTHING_COMPOUNDS.has(compound) || CLOTHING_WORDS.has(compound)) return true;
-  }
+  return null;
+}
 
-  return false;
+export function isClothingItemTitle(title: string | null | undefined): boolean {
+  return getClothingKind(title) !== null;
 }
 
 export function descriptionMentionsSize(description: string | null | undefined): boolean {
@@ -219,5 +238,20 @@ export function shouldShowClothingSizeHint(
   title: string | null | undefined,
   description: string | null | undefined,
 ): boolean {
-  return isClothingItemTitle(title) && !descriptionMentionsSize(description);
+  return getClothingSizeHintKind(title, description) !== null;
+}
+
+export function getClothingSizeHintKind(
+  title: string | null | undefined,
+  description: string | null | undefined,
+): ClothingKind | null {
+  const kind = getClothingKind(title);
+  if (!kind || descriptionMentionsSize(description)) return null;
+  return kind;
+}
+
+export function getClothingDetailsPlaceholder(kind: ClothingKind | null): string {
+  if (kind === 'shoe') return 'Ex : Pointure 42, couleur…';
+  if (kind === 'garment') return 'Ex : Taille M, couleur, matière…';
+  return 'Ajouter du détail à votre souhait';
 }

--- a/apps/front/src/utils/clothing.utils.ts
+++ b/apps/front/src/utils/clothing.utils.ts
@@ -1,0 +1,223 @@
+function normalizeText(value: string): string {
+  return value
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/\p{Diacritic}/gu, '');
+}
+
+function tokenize(value: string): string[] {
+  const normalized = normalizeText(value)
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim();
+
+  if (!normalized) return [];
+
+  return normalized.split(/\s+/);
+}
+
+/**
+ * Garment types that typically need a size (FR + common EN).
+ * Short generic words like "top" or "haut" are omitted to avoid false positives.
+ */
+const CLOTHING_WORDS = new Set([
+  'ballerine',
+  'ballerines',
+  'basket',
+  'baskets',
+  'bermuda',
+  'bermudas',
+  'blazer',
+  'blazers',
+  'blouse',
+  'blouses',
+  'blouson',
+  'blousons',
+  'bonnet',
+  'bonnets',
+  'boot',
+  'boots',
+  'botte',
+  'bottes',
+  'bottine',
+  'bottines',
+  'boxer',
+  'boxers',
+  'brassiere',
+  'brassieres',
+  'calecon',
+  'calecons',
+  'cardigan',
+  'cardigans',
+  'casquette',
+  'casquettes',
+  'ceinture',
+  'ceintures',
+  'chapeau',
+  'chapeaux',
+  'chaussette',
+  'chaussettes',
+  'chausson',
+  'chaussons',
+  'chaussure',
+  'chaussures',
+  'chemise',
+  'chemises',
+  'chemisier',
+  'chemisiers',
+  'claquette',
+  'claquettes',
+  'coat',
+  'coats',
+  'collant',
+  'collants',
+  'combinaison',
+  'combinaisons',
+  'costume',
+  'costumes',
+  'culotte',
+  'culottes',
+  'debardeur',
+  'debardeurs',
+  'derby',
+  'derbys',
+  'doudoune',
+  'doudounes',
+  'dress',
+  'dresses',
+  'escarpin',
+  'escarpins',
+  'gant',
+  'gants',
+  'gilet',
+  'gilets',
+  'hoodie',
+  'hoodies',
+  'imper',
+  'impermeable',
+  'impermeables',
+  'jacket',
+  'jackets',
+  'jean',
+  'jeans',
+  'jogging',
+  'joggings',
+  'jumper',
+  'jumpers',
+  'jupe',
+  'jupes',
+  'kimono',
+  'kimonos',
+  'kway',
+  'kways',
+  'legging',
+  'leggings',
+  'lingerie',
+  'maillot',
+  'maillots',
+  'manteau',
+  'manteaux',
+  'mocassin',
+  'mocassins',
+  'nuisette',
+  'nuisettes',
+  'pantoufle',
+  'pantoufles',
+  'pantalon',
+  'pantalons',
+  'pants',
+  'parka',
+  'parkas',
+  'peignoir',
+  'peignoirs',
+  'polo',
+  'polos',
+  'pull',
+  'pullover',
+  'pullovers',
+  'pulls',
+  'pyjama',
+  'pyjamas',
+  'richelieu',
+  'richelieus',
+  'robe',
+  'robes',
+  'sabot',
+  'sabots',
+  'salopette',
+  'salopettes',
+  'sandale',
+  'sandales',
+  'shirt',
+  'shirts',
+  'short',
+  'shorts',
+  'skirt',
+  'skirts',
+  'slip',
+  'slips',
+  'smoking',
+  'smokings',
+  'sneaker',
+  'sneakers',
+  'socks',
+  'survet',
+  'survetement',
+  'survetements',
+  'sweat',
+  'sweater',
+  'sweaters',
+  'sweats',
+  'sweatshirt',
+  'sweatshirts',
+  'teeshirt',
+  'teeshirts',
+  'tong',
+  'tongs',
+  'trench',
+  'trenchs',
+  'trousers',
+  'tshirt',
+  'tshirts',
+  'tunique',
+  'tuniques',
+  'veste',
+  'vestes',
+  'vetement',
+  'vetements',
+]);
+
+const CLOTHING_COMPOUNDS = new Set(['soutiengorge', 'coupevent', 'croptop']);
+
+const SIZE_KEYWORDS = new Set(['taille', 'pointure', 'size', 'sizes']);
+
+const SIZE_TOKENS = new Set(['xxxs', 'xxs', 'xs', 'xl', 'xxl', 'xxxl', 'xxxxl', '2xl', '3xl', '4xl', '5xl']);
+
+export function isClothingItemTitle(title: string | null | undefined): boolean {
+  if (!title?.trim()) return false;
+
+  const words = tokenize(title);
+  if (words.some(word => CLOTHING_WORDS.has(word))) return true;
+
+  for (let i = 0; i < words.length - 1; i++) {
+    const compound = `${words[i]}${words[i + 1]}`;
+    if (CLOTHING_COMPOUNDS.has(compound) || CLOTHING_WORDS.has(compound)) return true;
+  }
+
+  return false;
+}
+
+export function descriptionMentionsSize(description: string | null | undefined): boolean {
+  if (!description?.trim()) return false;
+
+  const words = tokenize(description);
+  if (words.some(word => SIZE_KEYWORDS.has(word) || SIZE_TOKENS.has(word))) return true;
+
+  return /\bt(?:\s+[.-]?\s*)?(?:xxs|xs|s|m|l|xl|xxl|\d{2,3})\b/.test(words.join(' '));
+}
+
+export function shouldShowClothingSizeHint(
+  title: string | null | undefined,
+  description: string | null | undefined,
+): boolean {
+  return isClothingItemTitle(title) && !descriptionMentionsSize(description);
+}


### PR DESCRIPTION
## Summary
- Detect clothing items from the wish title (shoes, sweater, t-shirt, etc.) when adding or suggesting a wish
- Show a visible warning that asks to put the size in the Details field, and reminds that the wish is unlikely to be taken without it
- Hide the warning once a size is mentioned in the description (`Taille M`, `Pointure 42`, `XS`, …)

## Test plan
- [ ] Open a wishlist and add a wish titled e.g. `Pull Nike` — the size warning should appear above Details
- [ ] Confirm the same happens when suggesting a wish on someone else's list
- [ ] Type `Taille M` in Details — the warning should disappear
- [ ] Use a non-clothing title like `Livre Harry Potter` — no warning
- [ ] Edit an existing clothing wish without a size — the warning should still appear


Made with [Cursor](https://cursor.com)